### PR TITLE
Fix dashboard patch count showing 0

### DIFF
--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -1798,7 +1798,7 @@
     }
 
     function renderAgentStats(evo, sess) {
-        var patchCount = (evo.patches || []).filter(function(p) { return p.content && p.content.trim(); }).length;
+        var patchCount = (evo.patches || []).filter(function(p) { var text = p.content || p.instruction || ''; return text.trim(); }).length;
         var avgCost = sess.stats.total_tasks > 0 ? sess.stats.total_cost_usd / sess.stats.total_tasks : 0;
         var lastEvo = '';
         if (state.agentData && state.agentData.changelog && state.agentData.changelog.entries && state.agentData.changelog.entries.length > 0) {


### PR DESCRIPTION
## Summary
- Dashboard PATCHES stat box always showed 0 despite patches existing
- `renderAgentStats` filtered on `p.content`, but the API returns `p.instruction`
- The `renderAgentPatches` render function already checked both fields — the stat counter just missed it

## Test plan
- [x] Verified API returns 5 patches with `instruction` field
- [x] Verified dashboard now shows correct count after rebuild
- [ ] CI build/lint/test

🤖 Generated with [Claude Code](https://claude.com/claude-code)