### PR TITLE
Fix daemon crash on fresh install (missing log directory)

### DIFF
--- a/internal/daemon/service_darwin.go
+++ b/internal/daemon/service_darwin.go
@@ -121,6 +121,10 @@ func (m *launchdManager) Install(execPath, configPath string) error {
 	if err := os.MkdirAll(launchAgentsDir, 0755); err != nil {
 		return fmt.Errorf("creating LaunchAgents directory: %w", err)
 	}
+	logDir := filepath.Dir(LogPath())
+	if err := os.MkdirAll(logDir, 0700); err != nil {
+		return fmt.Errorf("creating log directory: %w", err)
+	}
 
 	plistPath := filepath.Join(launchAgentsDir, serviceLabel+".plist")
 	if err := os.WriteFile(plistPath, []byte(plistContent.String()), 0644); err != nil {

--- a/internal/daemon/service_linux.go
+++ b/internal/daemon/service_linux.go
@@ -111,10 +111,14 @@ func (m *systemdManager) Install(execPath, configPath string) error {
 		return fmt.Errorf("generating unit file: %w", err)
 	}
 
-	// Ensure directory exists
+	// Ensure directories exist
 	unitDir := filepath.Dir(unitPath)
 	if err := os.MkdirAll(unitDir, 0755); err != nil {
 		return fmt.Errorf("creating systemd user directory: %w", err)
+	}
+	logDir := filepath.Dir(LogPath())
+	if err := os.MkdirAll(logDir, 0700); err != nil {
+		return fmt.Errorf("creating log directory: %w", err)
 	}
 
 	if err := os.WriteFile(unitPath, []byte(unitContent.String()), 0644); err != nil {


### PR DESCRIPTION
## Summary
- `Install()` in both `service_linux.go` and `service_darwin.go` wrote a service config pointing at `~/.mnemonic/mnemonic.log` but never created the `~/.mnemonic/` directory
- On a fresh Linux machine, systemd immediately exits with code 209 (`STDOUT`) because the `StandardOutput=append:` target path doesn't exist
- Fixed by adding `os.MkdirAll` for the log directory during install, matching the pattern already used in `daemon.Start()`

## Test plan
- [x] Tested full lifecycle on Linux (Ubuntu 24.04, systemd 255): `install` → `start` → `status` → `stop` → `uninstall`
- [x] Service starts and stays running after fix
- [x] `make test` passes (all 10 packages, zero failures)
- [x] `go vet` clean
- [ ] Verify macOS launchd path still works (same pattern, not tested on this machine)

🤖 Generated with [Claude Code](https://claude.com/claude-code)