### PR TITLE
Refactor SDK: fix 13 issues from code review

### DIFF
--- a/sdk/agent/config.py
+++ b/sdk/agent/config.py
@@ -4,6 +4,12 @@ import os
 from dataclasses import dataclass, field
 from pathlib import Path
 
+# ── Defaults (single source of truth for CLI parsers and Config) ─────
+DEFAULT_MODEL = "claude-sonnet-4-6"
+DEFAULT_SUBAGENT_MODEL = "sonnet"
+DEFAULT_PERMISSION_MODE = "acceptEdits"
+DEFAULT_EVOLVE_INTERVAL = 5
+
 
 @dataclass
 class Config:
@@ -23,14 +29,17 @@ class Config:
     )
     project_cwd: str = field(default_factory=os.getcwd)
     model: str = field(
-        default_factory=lambda: os.environ.get("MNEMONIC_AGENT_MODEL", "claude-sonnet-4-6")
+        default_factory=lambda: os.environ.get("MNEMONIC_AGENT_MODEL", DEFAULT_MODEL)
     )
-    permission_mode: str = "acceptEdits"
-    evolve_interval: int = 5
+    permission_mode: str = DEFAULT_PERMISSION_MODE
+    evolve_interval: int = DEFAULT_EVOLVE_INTERVAL
     max_turns: int | None = None
     verbose: bool = False
     no_reflect: bool = False
-    subagent_model: str = "sonnet"
+    subagent_model: str = DEFAULT_SUBAGENT_MODEL
+    evolution_dir_override: str | None = field(
+        default_factory=lambda: os.environ.get("MNEMONIC_EVOLUTION_DIR")
+    )
 
     @property
     def project_root(self) -> str:
@@ -43,4 +52,6 @@ class Config:
 
     @property
     def evolution_dir(self) -> str:
+        if self.evolution_dir_override:
+            return self.evolution_dir_override
         return str(Path(self.sdk_dir) / "evolution")

--- a/sdk/agent/conversation_store.py
+++ b/sdk/agent/conversation_store.py
@@ -7,6 +7,7 @@ from __future__ import annotations
 
 import json
 import logging
+import threading
 import uuid
 from datetime import datetime, timezone
 from pathlib import Path
@@ -27,6 +28,7 @@ class ConversationStore:
         self._dir.mkdir(parents=True, exist_ok=True)
         self._index_path = self._dir / "_index.json"
         self._prefs_path = self._dir / "_preferences.json"
+        self._index_lock = threading.Lock()
 
     # ── CRUD ──────────────────────────────────────────────────────────
 
@@ -101,11 +103,12 @@ class ConversationStore:
         path = self._dir / f"{conv_id}.json"
         if path.exists():
             path.unlink()
-        index = self._load_index()
-        index["conversations"] = [
-            c for c in index.get("conversations", []) if c["id"] != conv_id
-        ]
-        self._save_index(index)
+        with self._index_lock:
+            index = self._load_index()
+            index["conversations"] = [
+                c for c in index.get("conversations", []) if c["id"] != conv_id
+            ]
+            self._save_index(index)
         return True
 
     # ── Continuation ─────────────────────────────────────────────────
@@ -233,27 +236,28 @@ class ConversationStore:
             logger.warning("Failed to save conversation index: %s", e)
 
     def _update_index(self, conv: dict[str, Any]) -> None:
-        index = self._load_index()
-        entry: dict[str, Any] = {
-            "id": conv["id"],
-            "title": conv.get("title", "Untitled"),
-            "created_at": conv.get("created_at", ""),
-            "updated_at": conv.get("updated_at", ""),
-            "message_count": conv.get("message_count", 0),
-            "total_cost_usd": conv.get("total_cost_usd", 0.0),
-            "preview": "",
-        }
-        for m in conv.get("messages", []):
-            if m.get("role") == "user":
-                entry["preview"] = m["content"][:100]
-                break
-        # Upsert
-        found = False
-        for i, c in enumerate(index.get("conversations", [])):
-            if c["id"] == conv["id"]:
-                index["conversations"][i] = entry
-                found = True
-                break
-        if not found:
-            index.setdefault("conversations", []).append(entry)
-        self._save_index(index)
+        with self._index_lock:
+            index = self._load_index()
+            entry: dict[str, Any] = {
+                "id": conv["id"],
+                "title": conv.get("title", "Untitled"),
+                "created_at": conv.get("created_at", ""),
+                "updated_at": conv.get("updated_at", ""),
+                "message_count": conv.get("message_count", 0),
+                "total_cost_usd": conv.get("total_cost_usd", 0.0),
+                "preview": "",
+            }
+            for m in conv.get("messages", []):
+                if m.get("role") == "user":
+                    entry["preview"] = m["content"][:100]
+                    break
+            # Upsert
+            found = False
+            for i, c in enumerate(index.get("conversations", [])):
+                if c["id"] == conv["id"]:
+                    index["conversations"][i] = entry
+                    found = True
+                    break
+            if not found:
+                index.setdefault("conversations", []).append(entry)
+            self._save_index(index)

--- a/sdk/agent/evolution/examples/changelog.md
+++ b/sdk/agent/evolution/examples/changelog.md
@@ -2,6 +2,13 @@
 
 All self-modifications are logged here with date, what changed, and rationale.
 
+## 2026-02-27 (critical review)
+
+### Post-review evolution updates
+- **p12 confidence 0.7→0.8**: Validated again — Explore subagent missed duplicate `ALL_MNEMONIC_TOOLS` definitions across `options.py` and `subagents.py`; targeted Grep found it instantly.
+- **code_review strategy**: Added 2 tips — grep for duplicate symbol definitions across modules; distinguish "what has tests" from "what matters and lacks tests" (49 passing tests masked zero orchestration coverage).
+- **Stored 3 memories**: duplicate ALL_MNEMONIC_TOOLS bug (insight), PRE_TASK_PROMPT format string vulnerability (error), subagent-vs-grep review finding (learning).
+
 ## 2026-02-27
 
 ### Merged evolution directories and added p11-p13, prompt_audit, code_review, pp6

--- a/sdk/agent/evolution/examples/principles.yaml
+++ b/sdk/agent/evolution/examples/principles.yaml
@@ -77,7 +77,7 @@ principles:
   - id: p12
     text: "Verify subagent line-number and code-location claims with targeted Read calls before treating them as confirmed — subagents can plausibly hallucinate specific line numbers while getting the conceptual finding right"
     source: "Explore subagent gave detailed file:line bug reports; most concepts were correct but some line numbers needed verification against actual reads"
-    confidence: 0.7
+    confidence: 0.8
     created: "2026-02-25"
 
   - id: p13

--- a/sdk/agent/evolution/examples/strategies.yaml
+++ b/sdk/agent/evolution/examples/strategies.yaml
@@ -194,4 +194,6 @@ strategies:
       - "Shared mutable state (Config objects, module-level dicts) is the #1 source of subtle multi-client bugs"
       - "Near-duplicate functions across modules are high-signal — they indicate a missing abstraction"
       - "Test coverage gaps are the easiest wins to recommend — concrete, unambiguous, low-risk"
-    learned_from: "SDK code review 2026-02-27: read all 8 .py files, found 13 issues, prioritized into severity/effort table"
+      - "Grep for key symbol names across all modules to find duplicate definitions — subagents consistently miss cross-module duplication"
+      - "High test count with high pass rate can mask the real issue: what ISN'T tested. Distinguish 'what has tests' from 'what matters and lacks tests'"
+    learned_from: "SDK code reviews 2026-02-27: duplicate ALL_MNEMONIC_TOOLS across options.py and subagents.py found via Grep, missed by Explore subagent. 49/49 tests passing masked that orchestration layer (run_session, _run_task, build_options, web endpoint) had zero coverage."

--- a/sdk/agent/hooks.py
+++ b/sdk/agent/hooks.py
@@ -2,6 +2,14 @@ from __future__ import annotations
 
 from typing import Any
 
+_nudged_files: set[str] = set()
+_MAX_WRITE_NUDGES = 5
+
+
+def reset_nudge_state() -> None:
+    """Clear nudge tracking state. Call between tests for isolation."""
+    _nudged_files.clear()
+
 
 async def post_tool_use_hook(
     input_data: dict[str, Any],
@@ -13,14 +21,20 @@ async def post_tool_use_hook(
     Returns systemMessage strings that get injected into the conversation,
     guiding Claude toward recording the right things. Never calls tools
     directly — preserves Claude's agency and avoids infinite loops.
+
+    Rate-limited: Write/Edit nudges fire at most _MAX_WRITE_NUDGES times
+    per session and deduplicate by file path.
     """
     tool_name = input_data.get("tool_name", "")
     tool_input = input_data.get("tool_input", {})
     tool_response = input_data.get("tool_response", {})
 
-    # After file writes/edits — nudge decision capture
+    # After file writes/edits — nudge decision capture (rate-limited)
     if tool_name in ("Write", "Edit"):
         file_path = tool_input.get("file_path", "unknown")
+        if file_path in _nudged_files or len(_nudged_files) >= _MAX_WRITE_NUDGES:
+            return {}
+        _nudged_files.add(file_path)
         return {
             "systemMessage": (
                 f"You just modified {file_path}. "

--- a/sdk/agent/main.py
+++ b/sdk/agent/main.py
@@ -6,7 +6,13 @@ import logging
 import os
 import sys
 
-from agent.config import Config
+from agent.config import (
+    DEFAULT_EVOLVE_INTERVAL,
+    DEFAULT_MODEL,
+    DEFAULT_PERMISSION_MODE,
+    DEFAULT_SUBAGENT_MODEL,
+    Config,
+)
 from agent.session import run_session
 
 
@@ -27,8 +33,8 @@ def cli() -> None:
     )
     parser.add_argument(
         "--model",
-        default=os.environ.get("MNEMONIC_AGENT_MODEL", "claude-sonnet-4-6"),
-        help="Claude model to use (default: claude-sonnet-4-6)",
+        default=os.environ.get("MNEMONIC_AGENT_MODEL", DEFAULT_MODEL),
+        help=f"Claude model to use (default: {DEFAULT_MODEL})",
     )
     parser.add_argument(
         "--mnemonic-binary",
@@ -43,14 +49,14 @@ def cli() -> None:
     parser.add_argument(
         "--permission-mode",
         choices=["default", "acceptEdits", "bypassPermissions"],
-        default="acceptEdits",
-        help="Tool permission mode (default: acceptEdits)",
+        default=DEFAULT_PERMISSION_MODE,
+        help=f"Tool permission mode (default: {DEFAULT_PERMISSION_MODE})",
     )
     parser.add_argument(
         "--evolve-interval",
         type=int,
-        default=5,
-        help="Tasks between evolution cycles (default: 5)",
+        default=DEFAULT_EVOLVE_INTERVAL,
+        help=f"Tasks between evolution cycles (default: {DEFAULT_EVOLVE_INTERVAL})",
     )
     parser.add_argument(
         "--max-turns",
@@ -70,8 +76,13 @@ def cli() -> None:
     )
     parser.add_argument(
         "--subagent-model",
-        default="sonnet",
-        help="Model for subagents: code-reviewer, test-runner, memory-archivist (default: sonnet)",
+        default=DEFAULT_SUBAGENT_MODEL,
+        help=f"Model for subagents: code-reviewer, test-runner, memory-archivist (default: {DEFAULT_SUBAGENT_MODEL})",
+    )
+    parser.add_argument(
+        "--evolution-dir",
+        default=None,
+        help="Path to evolution directory (default: sdk/evolution or $MNEMONIC_EVOLUTION_DIR)",
     )
 
     args = parser.parse_args()
@@ -97,6 +108,8 @@ def cli() -> None:
         cfg.mnemonic_binary = args.mnemonic_binary
     if args.mnemonic_config:
         cfg.mnemonic_config = args.mnemonic_config
+    if args.evolution_dir:
+        cfg.evolution_dir_override = args.evolution_dir
 
     asyncio.run(run_session(cfg, initial_prompt=args.task))
 

--- a/sdk/agent/options.py
+++ b/sdk/agent/options.py
@@ -6,31 +6,7 @@ from agent.config import Config
 from agent.hooks import post_tool_use_hook
 from agent.prompts import assemble_system_prompt
 from agent.subagents import make_subagents
-
-BUILTIN_TOOLS = [
-    "Read",
-    "Edit",
-    "Write",
-    "Bash",
-    "Glob",
-    "Grep",
-    "Task",
-]
-
-ALL_MNEMONIC_TOOLS = [
-    "mcp__mnemonic__remember",
-    "mcp__mnemonic__recall",
-    "mcp__mnemonic__forget",
-    "mcp__mnemonic__status",
-    "mcp__mnemonic__recall_project",
-    "mcp__mnemonic__recall_timeline",
-    "mcp__mnemonic__session_summary",
-    "mcp__mnemonic__get_patterns",
-    "mcp__mnemonic__get_insights",
-    "mcp__mnemonic__feedback",
-    "mcp__mnemonic__audit_encodings",
-    "mcp__mnemonic__coach_local_llm",
-]
+from agent.tools import ALL_MNEMONIC_TOOLS, BUILTIN_TOOLS
 
 
 def build_options(cfg: Config) -> ClaudeAgentOptions:

--- a/sdk/agent/prompts.py
+++ b/sdk/agent/prompts.py
@@ -109,18 +109,32 @@ Only change things you have evidence for. Don't speculate.
 """
 
 
+_PRINCIPLES_MIN_CONFIDENCE = 0.6
+_PRINCIPLES_MAX = 15
+_STRATEGIES_INCLUDE_TIPS = False
+_PATCHES_MAX = 20
+_PROMPT_BUDGET = 20_000
+
+
 def assemble_system_prompt(evolution_dir: str) -> str:
     """Dynamically build the system prompt from base + evolution files."""
     parts = [BASE_PROMPT]
 
     evo = Path(evolution_dir)
 
-    # Inject learned principles
+    # Inject learned principles (filtered by confidence, capped)
     principles_file = evo / "principles.yaml"
     if principles_file.exists():
         try:
             data = yaml.safe_load(principles_file.read_text()) or {}
             principles = data.get("principles", [])
+            # Filter low-confidence, sort by confidence desc, cap
+            principles = [
+                p for p in principles
+                if p.get("confidence", 0.0) >= _PRINCIPLES_MIN_CONFIDENCE
+            ]
+            principles.sort(key=lambda p: p.get("confidence", 0.0), reverse=True)
+            principles = principles[:_PRINCIPLES_MAX]
             if principles:
                 lines = ["## Learned Principles", "Follow these rules you've discovered:\n"]
                 for p in principles:
@@ -130,7 +144,7 @@ def assemble_system_prompt(evolution_dir: str) -> str:
         except (yaml.YAMLError, OSError) as e:
             logger.warning("Failed to load principles.yaml: %s", e)
 
-    # Inject task strategies
+    # Inject task strategies (steps only — tips omitted to save budget)
     strategies_file = evo / "strategies.yaml"
     if strategies_file.exists():
         try:
@@ -142,19 +156,20 @@ def assemble_system_prompt(evolution_dir: str) -> str:
                     lines.append(f"### {task_type}")
                     for i, step in enumerate(strategy.get("steps", []), 1):
                         lines.append(f"  {i}. {step}")
-                    for tip in strategy.get("tips", []):
-                        lines.append(f"  - Tip: {tip}")
+                    if _STRATEGIES_INCLUDE_TIPS:
+                        for tip in strategy.get("tips", []):
+                            lines.append(f"  - Tip: {tip}")
                     lines.append("")
                 parts.append("\n".join(lines))
         except (yaml.YAMLError, OSError) as e:
             logger.warning("Failed to load strategies.yaml: %s", e)
 
-    # Inject prompt patches
+    # Inject prompt patches (capped)
     patches_file = evo / "prompt_patches.yaml"
     if patches_file.exists():
         try:
             data = yaml.safe_load(patches_file.read_text()) or {}
-            patches = data.get("patches", [])
+            patches = data.get("patches", [])[:_PATCHES_MAX]
             if patches:
                 lines = ["## Additional Instructions"]
                 for patch in patches:
@@ -194,4 +209,10 @@ You can review and improve its encoding quality.
 - Coaching instructions are appended verbatim to local LLM prompts — be precise and concise.
 - Each coach_local_llm call overwrites the previous file — keep instructions cumulative.""")
 
-    return "\n\n".join(parts)
+    prompt = "\n\n".join(parts)
+    if len(prompt) > _PROMPT_BUDGET:
+        logger.warning(
+            "System prompt exceeds budget: %d chars (limit %d)",
+            len(prompt), _PROMPT_BUDGET,
+        )
+    return prompt

--- a/sdk/agent/session.py
+++ b/sdk/agent/session.py
@@ -4,7 +4,7 @@ import json
 import logging
 import time
 import uuid
-from collections.abc import AsyncGenerator
+from collections.abc import AsyncGenerator, Callable
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -199,44 +199,59 @@ async def run_session(cfg: Config, initial_prompt: str | None = None) -> None:
                 await _run_evolution(client, cfg)
 
 
-async def _run_task(
+async def _orchestrate_task(
     client: ClaudeSDKClient,
     cfg: Config,
     task: str,
     session_id: str,
     task_count: int,
-) -> None:
-    """Execute a single task with pre-task recall and post-task reflection."""
+    main_stream_fn: Callable,
+    side_stream_fn: Callable | None = None,
+    on_phase: Callable | None = None,
+) -> TaskMetrics:
+    """Shared task orchestration: pre-task recall → main → post-task reflect → telemetry.
+
+    Args:
+        main_stream_fn: async (client) -> TaskMetrics — streams the main task output.
+        side_stream_fn: async (client) -> TaskMetrics — streams pre/post phases.
+            Defaults to main_stream_fn if not provided.
+        on_phase: optional async (phase_name: str) -> None — called before each phase
+            with "recalling", "working", or "reflecting".
+
+    Returns accumulated TaskMetrics for the full orchestration.
+    """
+    if side_stream_fn is None:
+        side_stream_fn = main_stream_fn
+
     task_start = time.monotonic()
     started_iso = datetime.now(timezone.utc).isoformat()
-    total_cost = 0.0
-    total_turns = 0
+    total = TaskMetrics()
 
     # === PRE-TASK: automatic context recall ===
     if not cfg.no_reflect:
-        if cfg.verbose:
-            logger.debug("\n[pre-task] Recalling context...")
-        await client.query(PRE_TASK_PROMPT.format(task=task))
-        m = await _stream_responses(client, verbose=cfg.verbose)
-        total_cost += m.cost_usd
-        total_turns += m.turns
+        if on_phase:
+            await on_phase("recalling")
+        await client.query(PRE_TASK_PROMPT.replace("{task}", task))
+        m = await side_stream_fn(client)
+        total.cost_usd += m.cost_usd
+        total.turns += m.turns
 
     # === MAIN TASK ===
-    if cfg.verbose:
-        logger.debug("\n[task] %s", task)
+    if on_phase:
+        await on_phase("working")
     await client.query(task)
-    m = await _stream_responses(client, verbose=cfg.verbose)
-    total_cost += m.cost_usd
-    total_turns += m.turns
+    m = await main_stream_fn(client)
+    total.cost_usd += m.cost_usd
+    total.turns += m.turns
 
     # === POST-TASK: automatic reflection ===
     if not cfg.no_reflect:
-        if cfg.verbose:
-            logger.debug("\n[post-task] Reflecting...")
+        if on_phase:
+            await on_phase("reflecting")
         await client.query(POST_TASK_PROMPT)
-        m = await _stream_responses(client, verbose=cfg.verbose)
-        total_cost += m.cost_usd
-        total_turns += m.turns
+        m = await side_stream_fn(client)
+        total.cost_usd += m.cost_usd
+        total.turns += m.turns
 
     # === Record telemetry ===
     evolved = (task_count + 1) % cfg.evolve_interval == 0
@@ -248,9 +263,33 @@ async def _run_task(
         description=task,
         started=started_iso,
         duration_ms=duration_ms,
-        cost_usd=total_cost,
-        turns=total_turns,
+        cost_usd=total.cost_usd,
+        turns=total.turns,
         evolved=evolved,
+    )
+    return total
+
+
+async def _run_task(
+    client: ClaudeSDKClient,
+    cfg: Config,
+    task: str,
+    session_id: str,
+    task_count: int,
+) -> None:
+    """CLI task execution — streams to stdout."""
+
+    async def _cli_stream(c: ClaudeSDKClient) -> TaskMetrics:
+        return await _stream_responses(c, verbose=cfg.verbose)
+
+    async def _on_phase(phase: str) -> None:
+        if cfg.verbose:
+            logger.debug("\n[%s]%s", phase, f" {task}" if phase == "working" else "")
+
+    await _orchestrate_task(
+        client, cfg, task, session_id, task_count,
+        main_stream_fn=_cli_stream,
+        on_phase=_on_phase,
     )
 
 

--- a/sdk/agent/subagents.py
+++ b/sdk/agent/subagents.py
@@ -2,24 +2,11 @@ from __future__ import annotations
 
 from claude_agent_sdk import AgentDefinition
 
-MNEMONIC_RECALL_TOOLS = [
-    "mcp__mnemonic__recall",
-    "mcp__mnemonic__recall_project",
-    "mcp__mnemonic__remember",
-    "mcp__mnemonic__get_patterns",
-    "mcp__mnemonic__get_insights",
-    "mcp__mnemonic__feedback",
-]
-
-ALL_MNEMONIC_TOOLS = MNEMONIC_RECALL_TOOLS + [
-    "mcp__mnemonic__forget",
-    "mcp__mnemonic__status",
-    "mcp__mnemonic__recall_timeline",
-    "mcp__mnemonic__session_summary",
-]
+from agent.config import DEFAULT_SUBAGENT_MODEL
+from agent.tools import ALL_MNEMONIC_TOOLS, MNEMONIC_RECALL_TOOLS
 
 
-def make_subagents(subagent_model: str = "sonnet") -> dict[str, AgentDefinition]:
+def make_subagents(subagent_model: str = DEFAULT_SUBAGENT_MODEL) -> dict[str, AgentDefinition]:
     """Build subagent definitions with the specified model."""
     return {
         "code-reviewer": AgentDefinition(

--- a/sdk/agent/tools.py
+++ b/sdk/agent/tools.py
@@ -1,0 +1,40 @@
+"""Canonical tool list definitions for the mnemonic-agent.
+
+Single source of truth — imported by options.py and subagents.py.
+No internal SDK imports to avoid circular dependencies.
+"""
+from __future__ import annotations
+
+BUILTIN_TOOLS = [
+    "Read",
+    "Edit",
+    "Write",
+    "Bash",
+    "Glob",
+    "Grep",
+    "Task",
+]
+
+ALL_MNEMONIC_TOOLS = [
+    "mcp__mnemonic__remember",
+    "mcp__mnemonic__recall",
+    "mcp__mnemonic__forget",
+    "mcp__mnemonic__status",
+    "mcp__mnemonic__recall_project",
+    "mcp__mnemonic__recall_timeline",
+    "mcp__mnemonic__session_summary",
+    "mcp__mnemonic__get_patterns",
+    "mcp__mnemonic__get_insights",
+    "mcp__mnemonic__feedback",
+    "mcp__mnemonic__audit_encodings",
+    "mcp__mnemonic__coach_local_llm",
+]
+
+MNEMONIC_RECALL_TOOLS = [
+    "mcp__mnemonic__recall",
+    "mcp__mnemonic__recall_project",
+    "mcp__mnemonic__remember",
+    "mcp__mnemonic__get_patterns",
+    "mcp__mnemonic__get_insights",
+    "mcp__mnemonic__feedback",
+]

--- a/sdk/agent/web.py
+++ b/sdk/agent/web.py
@@ -9,10 +9,10 @@ switching (with client recreation), and context injection for continuation.
 from __future__ import annotations
 
 import argparse
+import asyncio
 import json
 import logging
 import os
-import time
 import uuid
 from dataclasses import replace
 from datetime import datetime, timezone
@@ -24,13 +24,14 @@ from starlette.websockets import WebSocket, WebSocketDisconnect
 
 from claude_agent_sdk import ClaudeSDKClient
 
-from agent.config import Config
+from agent.config import DEFAULT_EVOLVE_INTERVAL, DEFAULT_PERMISSION_MODE, Config
 from agent.conversation_store import ConversationStore
 from agent.options import build_options
-from agent.prompts import POST_TASK_PROMPT, PRE_TASK_PROMPT
-from agent.session import _record_task, stream_events
+from agent.session import TaskMetrics, _orchestrate_task, _run_evolution, stream_events
 
 logger = logging.getLogger(__name__)
+
+WS_IDLE_TIMEOUT = 300  # seconds
 
 
 # ── Helpers ──────────────────────────────────────────────────────────
@@ -105,58 +106,265 @@ async def _handle_task(
     conv_id: str | None = None,
 ) -> None:
     """Run pre-task recall -> main query -> post-task reflection, streaming to WS."""
-    task_start = time.monotonic()
-    started_iso = datetime.now(timezone.utc).isoformat()
-    total_cost = 0.0
-    total_turns = 0
 
-    # Pre-task recall
-    if not cfg.no_reflect:
-        await _send(ws, {"type": "status", "status": "recalling"})
-        await client.query(PRE_TASK_PROMPT.format(task=task))
-        cost, turns = await _stream_to_ws(client, ws)  # don't persist recall phase
-        total_cost += cost
-        total_turns += turns
+    async def _ws_main_stream(c: ClaudeSDKClient) -> TaskMetrics:
+        cost, turns = await _stream_to_ws(c, ws, store, conv_id)
+        return TaskMetrics(cost_usd=cost, turns=turns)
 
-    # Main task
-    await _send(ws, {"type": "status", "status": "working"})
-    await client.query(task)
-    cost, turns = await _stream_to_ws(client, ws, store, conv_id)
-    total_cost += cost
-    total_turns += turns
+    async def _ws_side_stream(c: ClaudeSDKClient) -> TaskMetrics:
+        cost, turns = await _stream_to_ws(c, ws)  # don't persist recall/reflect
+        return TaskMetrics(cost_usd=cost, turns=turns)
 
-    # Post-task reflection
-    if not cfg.no_reflect:
-        await _send(ws, {"type": "status", "status": "reflecting"})
-        await client.query(POST_TASK_PROMPT)
-        cost, turns = await _stream_to_ws(client, ws)  # don't persist reflection
-        total_cost += cost
-        total_turns += turns
+    async def _on_phase(phase: str) -> None:
+        await _send(ws, {"type": "status", "status": phase})
 
-    # Record telemetry
-    evolved = (task_count + 1) % cfg.evolve_interval == 0
-    duration_ms = int((time.monotonic() - task_start) * 1000)
-    _record_task(
-        evolution_dir=cfg.evolution_dir,
-        session_id=session_id,
-        model=cfg.model,
-        description=task,
-        started=started_iso,
-        duration_ms=duration_ms,
-        cost_usd=total_cost,
-        turns=total_turns,
-        evolved=evolved,
+    total = await _orchestrate_task(
+        client, cfg, task, session_id, task_count,
+        main_stream_fn=_ws_main_stream,
+        side_stream_fn=_ws_side_stream,
+        on_phase=_on_phase,
     )
 
     # Update conversation cost
     if store and conv_id:
-        store.update_cost(conv_id, total_cost)
+        store.update_cost(conv_id, total.cost_usd)
 
     await _send(ws, {
         "type": "done",
-        "cost_usd": round(total_cost, 6),
-        "turns": total_turns,
+        "cost_usd": round(total.cost_usd, 6),
+        "turns": total.turns,
     })
+
+
+# ── WebSocket session ────────────────────────────────────────────────
+
+class WebSocketSession:
+    """Manages a single WebSocket connection's lifecycle and state."""
+
+    def __init__(self, ws: WebSocket, cfg: Config, store: ConversationStore) -> None:
+        self._ws = ws
+        self._cfg = cfg
+        self._store = store
+        self._session_id = f"web-{uuid.uuid4().hex[:8]}"
+        self._task_count = 0
+        self._continuation_context: str | None = None
+        self._current_conv_id: str | None = None
+        self._session_model = store.get_preferred_model() or cfg.model
+
+    async def run(self) -> None:
+        """Outer lifecycle — handles client recreation on model switch."""
+        logger.info("WebSocket connected, starting agent session %s", self._session_id)
+        try:
+            while True:
+                reconnect = await self._run_client_lifecycle()
+                if not reconnect:
+                    break
+        except WebSocketDisconnect:
+            logger.info("WebSocket disconnected: session %s", self._session_id)
+        except Exception:
+            logger.exception("Fatal error in WebSocket handler: %s", self._session_id)
+            try:
+                await _send(self._ws, {
+                    "type": "error",
+                    "message": "Internal server error — session terminated.",
+                })
+                await self._ws.close()
+            except Exception:
+                pass
+
+    async def _run_client_lifecycle(self) -> bool:
+        """Create a ClaudeSDKClient and run the message loop.
+
+        Returns True if the client should be recreated (model switch).
+        """
+        session_cfg = replace(self._cfg, model=self._session_model)
+        options = build_options(session_cfg)
+        async with ClaudeSDKClient(options=options) as client:
+            await _send(self._ws, {"type": "status", "status": "ready"})
+            await _send(self._ws, {
+                "type": "conversation_started",
+                "id": self._current_conv_id,
+                "model": self._session_model,
+            })
+            return await self._run_message_loop(client, session_cfg)
+
+    async def _run_message_loop(
+        self, client: ClaudeSDKClient, session_cfg: Config,
+    ) -> bool:
+        """Receive and dispatch messages. Returns True to trigger reconnect."""
+        while True:
+            try:
+                raw = await asyncio.wait_for(
+                    self._ws.receive_text(), timeout=WS_IDLE_TIMEOUT,
+                )
+            except asyncio.TimeoutError:
+                await _send(self._ws, {
+                    "type": "error",
+                    "message": "Connection timed out due to inactivity.",
+                })
+                await self._ws.close()
+                return False
+            except WebSocketDisconnect:
+                return False
+
+            try:
+                msg = json.loads(raw)
+            except json.JSONDecodeError:
+                await _send(self._ws, {"type": "error", "message": "Invalid JSON"})
+                continue
+
+            reconnect = await self._handle_message(msg, client, session_cfg)
+            if reconnect:
+                return True
+
+        return False  # unreachable, but satisfies type checkers
+
+    async def _handle_message(
+        self,
+        msg: dict,
+        client: ClaudeSDKClient,
+        session_cfg: Config,
+    ) -> bool:
+        """Dispatch a single message. Returns True to trigger reconnect."""
+        msg_type = msg.get("type")
+
+        if msg_type == "list_conversations":
+            await self._handle_list_conversations()
+        elif msg_type == "load_conversation":
+            await self._handle_load_conversation(msg)
+        elif msg_type == "delete_conversation":
+            await self._handle_delete_conversation(msg)
+        elif msg_type == "new_conversation":
+            await self._handle_new_conversation()
+        elif msg_type == "set_model":
+            return await self._handle_set_model(msg)
+        elif msg_type == "message":
+            await self._handle_chat_message(msg, client, session_cfg)
+
+        return False
+
+    # ── Conversation management ──
+
+    async def _handle_list_conversations(self) -> None:
+        convs = self._store.list_conversations()
+        await _send(self._ws, {
+            "type": "conversations_list",
+            "conversations": convs,
+        })
+
+    async def _handle_load_conversation(self, msg: dict) -> None:
+        cid = msg.get("id", "")
+        loaded = self._store.get_conversation(cid)
+        if loaded:
+            self._current_conv_id = cid
+            self._continuation_context = self._store.build_continuation_summary(cid)
+            await _send(self._ws, {
+                "type": "conversation_loaded",
+                "conversation": loaded,
+            })
+        else:
+            await _send(self._ws, {
+                "type": "error",
+                "message": "Conversation not found",
+            })
+
+    async def _handle_delete_conversation(self, msg: dict) -> None:
+        cid = msg.get("id", "")
+        self._store.delete_conversation(cid)
+        if cid == self._current_conv_id:
+            self._current_conv_id = None
+            self._continuation_context = None
+            await _send(self._ws, {
+                "type": "conversation_started",
+                "id": None,
+                "model": self._session_model,
+            })
+        await _send(self._ws, {
+            "type": "conversation_deleted",
+            "id": cid,
+        })
+
+    async def _handle_new_conversation(self) -> None:
+        self._current_conv_id = None
+        self._continuation_context = None
+        await _send(self._ws, {
+            "type": "conversation_started",
+            "id": None,
+            "model": self._session_model,
+        })
+
+    # ── Model switching ──
+
+    async def _handle_set_model(self, msg: dict) -> bool:
+        """Returns True to trigger client reconnect."""
+        new_model = msg.get("model", "").strip()
+        if not new_model:
+            return False
+        self._session_model = new_model
+        self._store.set_preferred_model(new_model)
+        logger.info("Model changed to %s", new_model)
+        if self._current_conv_id:
+            self._continuation_context = self._store.build_continuation_summary(
+                self._current_conv_id
+            )
+        await _send(self._ws, {"type": "model_set", "model": new_model})
+        return True
+
+    # ── Chat ──
+
+    async def _handle_chat_message(
+        self, msg: dict, client: ClaudeSDKClient, session_cfg: Config,
+    ) -> None:
+        content = (msg.get("content") or "").strip()
+        if not content:
+            return
+
+        # Lazy conversation creation — create on first message
+        if self._current_conv_id is None:
+            conv = self._store.new_conversation(self._session_model)
+            self._current_conv_id = conv["id"]
+            await _send(self._ws, {
+                "type": "conversation_started",
+                "id": conv["id"],
+                "model": self._session_model,
+            })
+
+        # Persist user message
+        now = datetime.now(timezone.utc).isoformat()
+        self._store.append_message(self._current_conv_id, {
+            "role": "user",
+            "content": content,
+            "timestamp": now,
+        })
+
+        # On first message after loading a prior conversation,
+        # inject the continuation context summary.
+        effective_task = content
+        if self._continuation_context:
+            effective_task = (
+                self._continuation_context
+                + "\n\n## Current Message\n"
+                + content
+            )
+            self._continuation_context = None  # only inject once
+
+        try:
+            await _handle_task(
+                client, session_cfg, effective_task,
+                self._session_id, self._task_count, self._ws,
+                self._store, self._current_conv_id,
+            )
+            self._task_count += 1
+            # Periodic evolution cycle
+            if self._task_count % session_cfg.evolve_interval == 0:
+                await _send(self._ws, {"type": "status", "status": "evolving"})
+                await _run_evolution(client, session_cfg)
+        except Exception as exc:
+            logger.exception("Error handling task: %s", exc)
+            await _send(self._ws, {
+                "type": "error",
+                "message": "Task failed — check server logs for details.",
+            })
 
 
 # ── App factory ──────────────────────────────────────────────────────
@@ -167,172 +375,7 @@ def make_app(cfg: Config) -> Starlette:
 
     async def ws_endpoint(ws: WebSocket) -> None:
         await ws.accept()
-        session_id = f"web-{uuid.uuid4().hex[:8]}"
-        task_count = 0
-        continuation_context: str | None = None
-        current_conv_id: str | None = None
-        # Per-connection model — read saved preference, fall back to cfg default
-        session_model = store.get_preferred_model() or cfg.model
-
-        logger.info("WebSocket connected, starting agent session %s", session_id)
-
-        try:
-            while True:  # Client lifecycle loop — restarts when model changes
-                session_cfg = replace(cfg, model=session_model)
-                options = build_options(session_cfg)
-                async with ClaudeSDKClient(options=options) as client:
-                    await _send(ws, {"type": "status", "status": "ready"})
-                    await _send(ws, {
-                        "type": "conversation_started",
-                        "id": current_conv_id,
-                        "model": session_model,
-                    })
-
-                    reconnect = False
-                    while True:  # Message loop
-                        try:
-                            raw = await ws.receive_text()
-                        except WebSocketDisconnect:
-                            logger.info("WebSocket disconnected: session %s", session_id)
-                            return
-
-                        try:
-                            msg = json.loads(raw)
-                        except json.JSONDecodeError:
-                            await _send(ws, {"type": "error", "message": "Invalid JSON"})
-                            continue
-
-                        msg_type = msg.get("type")
-
-                        # ── Conversation management ──
-
-                        if msg_type == "list_conversations":
-                            convs = store.list_conversations()
-                            await _send(ws, {
-                                "type": "conversations_list",
-                                "conversations": convs,
-                            })
-
-                        elif msg_type == "load_conversation":
-                            cid = msg.get("id", "")
-                            loaded = store.get_conversation(cid)
-                            if loaded:
-                                current_conv_id = cid
-                                continuation_context = store.build_continuation_summary(cid)
-                                await _send(ws, {
-                                    "type": "conversation_loaded",
-                                    "conversation": loaded,
-                                })
-                            else:
-                                await _send(ws, {
-                                    "type": "error",
-                                    "message": "Conversation not found",
-                                })
-
-                        elif msg_type == "delete_conversation":
-                            cid = msg.get("id", "")
-                            store.delete_conversation(cid)
-                            if cid == current_conv_id:
-                                current_conv_id = None
-                                continuation_context = None
-                                await _send(ws, {
-                                    "type": "conversation_started",
-                                    "id": None,
-                                    "model": session_model,
-                                })
-                            await _send(ws, {
-                                "type": "conversation_deleted",
-                                "id": cid,
-                            })
-
-                        elif msg_type == "new_conversation":
-                            current_conv_id = None
-                            continuation_context = None
-                            await _send(ws, {
-                                "type": "conversation_started",
-                                "id": None,
-                                "model": session_model,
-                            })
-
-                        # ── Model switching ──
-
-                        elif msg_type == "set_model":
-                            new_model = msg.get("model", "").strip()
-                            if new_model:
-                                session_model = new_model
-                                store.set_preferred_model(new_model)
-                                logger.info("Model changed to %s", new_model)
-                                # Preserve conversation context across model switch
-                                if current_conv_id:
-                                    continuation_context = store.build_continuation_summary(
-                                        current_conv_id
-                                    )
-                                await _send(ws, {
-                                    "type": "model_set",
-                                    "model": new_model,
-                                })
-                                reconnect = True
-                                break  # Exit message loop to recreate client
-
-                        # ── Chat message ──
-
-                        elif msg_type == "message":
-                            content = (msg.get("content") or "").strip()
-                            if not content:
-                                continue
-
-                            # Lazy conversation creation — create on first message
-                            if current_conv_id is None:
-                                conv = store.new_conversation(session_model)
-                                current_conv_id = conv["id"]
-                                await _send(ws, {
-                                    "type": "conversation_started",
-                                    "id": conv["id"],
-                                    "model": session_model,
-                                })
-
-                            # Persist user message
-                            now = datetime.now(timezone.utc).isoformat()
-                            store.append_message(current_conv_id, {
-                                "role": "user",
-                                "content": content,
-                                "timestamp": now,
-                            })
-
-                            # On first message after loading a prior conversation,
-                            # inject the continuation context summary.
-                            effective_task = content
-                            if continuation_context:
-                                effective_task = (
-                                    continuation_context
-                                    + "\n\n## Current Message\n"
-                                    + content
-                                )
-                                continuation_context = None  # only inject once
-
-                            try:
-                                await _handle_task(
-                                    client, session_cfg, effective_task,
-                                    session_id, task_count, ws,
-                                    store, current_conv_id,
-                                )
-                                task_count += 1
-                            except Exception as exc:
-                                logger.exception("Error handling task: %s", exc)
-                                await _send(ws, {"type": "error", "message": str(exc)})
-
-                    if not reconnect:
-                        break  # Clean exit from client lifecycle loop
-
-        except WebSocketDisconnect:
-            logger.info("WebSocket disconnected before session init: %s", session_id)
-        except Exception as exc:
-            logger.exception("Fatal error in WebSocket handler: %s", exc)
-            try:
-                await _send(ws, {"type": "error", "message": f"Server error: {exc}"})
-                await ws.close()
-            except Exception:
-                pass
+        await WebSocketSession(ws, cfg, store).run()
 
     return Starlette(routes=[WebSocketRoute("/ws", ws_endpoint)])
 
@@ -354,10 +397,12 @@ def main() -> None:
     parser.add_argument("--mnemonic-binary", default=None)
     parser.add_argument("--mnemonic-config", default=None)
     parser.add_argument("--cwd", default=None)
-    parser.add_argument("--permission-mode", default="acceptEdits")
-    parser.add_argument("--evolve-interval", type=int, default=5)
+    parser.add_argument("--permission-mode", default=DEFAULT_PERMISSION_MODE)
+    parser.add_argument("--evolve-interval", type=int, default=DEFAULT_EVOLVE_INTERVAL)
     parser.add_argument("--no-reflect", action="store_true")
     parser.add_argument("--verbose", action="store_true")
+    parser.add_argument("--evolution-dir", default=None,
+                        help="Path to evolution directory (default: sdk/evolution or $MNEMONIC_EVOLUTION_DIR)")
     args = parser.parse_args()
 
     logging.basicConfig(
@@ -379,6 +424,8 @@ def main() -> None:
         cfg.mnemonic_config = args.mnemonic_config
     if args.cwd:
         cfg.project_cwd = args.cwd
+    if args.evolution_dir:
+        cfg.evolution_dir_override = args.evolution_dir
 
     app = make_app(cfg)
     logger.info("Starting agent WebSocket server on %s:%d", args.host, args.port)

--- a/sdk/tests/test_orchestration.py
+++ b/sdk/tests/test_orchestration.py
@@ -1,0 +1,368 @@
+"""Tests for the orchestration layer: build_options, make_subagents, Config, prompt budget."""
+
+import asyncio
+import os
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from agent.config import Config
+from agent.hooks import reset_nudge_state
+from agent.prompts import (
+    _PRINCIPLES_MAX,
+    _PRINCIPLES_MIN_CONFIDENCE,
+    _PROMPT_BUDGET,
+    assemble_system_prompt,
+)
+from agent.tools import ALL_MNEMONIC_TOOLS, BUILTIN_TOOLS, MNEMONIC_RECALL_TOOLS
+
+
+class TestToolLists(unittest.TestCase):
+    def test_all_mnemonic_tools_has_12_entries(self):
+        self.assertEqual(len(ALL_MNEMONIC_TOOLS), 12)
+
+    def test_builtin_tools_has_7_entries(self):
+        self.assertEqual(len(BUILTIN_TOOLS), 7)
+
+    def test_recall_tools_is_subset_of_all(self):
+        for tool in MNEMONIC_RECALL_TOOLS:
+            self.assertIn(tool, ALL_MNEMONIC_TOOLS)
+
+    def test_no_duplicates_in_all_mnemonic_tools(self):
+        self.assertEqual(len(ALL_MNEMONIC_TOOLS), len(set(ALL_MNEMONIC_TOOLS)))
+
+
+class TestConfig(unittest.TestCase):
+    def test_default_evolution_dir_uses_sdk_dir(self):
+        cfg = Config()
+        self.assertTrue(cfg.evolution_dir.endswith("evolution"))
+
+    def test_evolution_dir_override_from_field(self):
+        cfg = Config(evolution_dir_override="/custom/path")
+        self.assertEqual(cfg.evolution_dir, "/custom/path")
+
+    def test_evolution_dir_override_from_env(self):
+        with patch.dict(os.environ, {"MNEMONIC_EVOLUTION_DIR": "/env/path"}):
+            cfg = Config()
+            self.assertEqual(cfg.evolution_dir, "/env/path")
+
+    def test_project_root_from_config_path(self):
+        cfg = Config(mnemonic_config="/some/project/config.yaml")
+        self.assertEqual(cfg.project_root, "/some/project")
+
+    def test_default_model(self):
+        with patch.dict(os.environ, {}, clear=True):
+            # Remove env var if set
+            os.environ.pop("MNEMONIC_AGENT_MODEL", None)
+            os.environ.pop("MNEMONIC_EVOLUTION_DIR", None)
+            cfg = Config()
+            self.assertEqual(cfg.model, "claude-sonnet-4-6")
+
+
+class TestBuildOptions(unittest.TestCase):
+    @patch("agent.options.assemble_system_prompt", return_value="test prompt")
+    @patch("agent.options.make_subagents", return_value={})
+    def test_includes_all_tools(self, _mock_sub, _mock_prompt):
+        from agent.options import build_options
+
+        cfg = Config()
+        opts = build_options(cfg)
+        expected = BUILTIN_TOOLS + ALL_MNEMONIC_TOOLS
+        self.assertEqual(opts.allowed_tools, expected)
+
+    @patch("agent.options.assemble_system_prompt", return_value="test prompt")
+    @patch("agent.options.make_subagents", return_value={})
+    def test_permission_mode_passed(self, _mock_sub, _mock_prompt):
+        from agent.options import build_options
+
+        cfg = Config(permission_mode="bypassPermissions")
+        opts = build_options(cfg)
+        self.assertEqual(opts.permission_mode, "bypassPermissions")
+
+    @patch("agent.options.assemble_system_prompt", return_value="test prompt")
+    @patch("agent.options.make_subagents", return_value={})
+    def test_max_turns_omitted_when_none(self, _mock_sub, _mock_prompt):
+        from agent.options import build_options
+
+        cfg = Config(max_turns=None)
+        opts = build_options(cfg)
+        self.assertFalse(hasattr(opts, "max_turns") and opts.max_turns is not None)
+
+    @patch("agent.options.assemble_system_prompt", return_value="test prompt")
+    @patch("agent.options.make_subagents", return_value={})
+    def test_max_turns_set_when_provided(self, _mock_sub, _mock_prompt):
+        from agent.options import build_options
+
+        cfg = Config(max_turns=10)
+        opts = build_options(cfg)
+        self.assertEqual(opts.max_turns, 10)
+
+
+class TestMakeSubagents(unittest.TestCase):
+    def test_returns_three_agents(self):
+        from agent.subagents import make_subagents
+
+        agents = make_subagents()
+        self.assertEqual(len(agents), 3)
+        self.assertIn("code-reviewer", agents)
+        self.assertIn("test-runner", agents)
+        self.assertIn("memory-archivist", agents)
+
+    def test_model_propagated(self):
+        from agent.subagents import make_subagents
+
+        agents = make_subagents(subagent_model="opus")
+        for name, defn in agents.items():
+            self.assertEqual(defn.model, "opus", f"{name} should use opus")
+
+    def test_code_reviewer_has_read_and_recall_tools(self):
+        from agent.subagents import make_subagents
+
+        agents = make_subagents()
+        tools = agents["code-reviewer"].tools
+        self.assertIn("Read", tools)
+        self.assertIn("mcp__mnemonic__recall", tools)
+
+    def test_memory_archivist_has_all_mnemonic_tools(self):
+        from agent.subagents import make_subagents
+
+        agents = make_subagents()
+        for tool in ALL_MNEMONIC_TOOLS:
+            self.assertIn(tool, agents["memory-archivist"].tools)
+
+
+class TestPromptBudget(unittest.TestCase):
+    def test_principles_filtered_by_confidence(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "principles.yaml").write_text(
+                "principles:\n"
+                '  - id: p1\n    text: "High conf"\n    source: "test"\n    confidence: 0.8\n'
+                '  - id: p2\n    text: "Low conf"\n    source: "test"\n    confidence: 0.3\n'
+                '  - id: p3\n    text: "Exact threshold"\n    source: "test"\n    confidence: 0.6\n'
+            )
+            (Path(tmpdir) / "strategies.yaml").write_text("strategies: {}\n")
+            (Path(tmpdir) / "prompt_patches.yaml").write_text("patches: []\n")
+
+            prompt = assemble_system_prompt(tmpdir)
+            self.assertIn("High conf", prompt)
+            self.assertNotIn("Low conf", prompt)
+            self.assertIn("Exact threshold", prompt)
+
+    def test_principles_sorted_by_confidence_desc(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "principles.yaml").write_text(
+                "principles:\n"
+                '  - id: p1\n    text: "Medium"\n    source: "test"\n    confidence: 0.7\n'
+                '  - id: p2\n    text: "Highest"\n    source: "test"\n    confidence: 0.9\n'
+                '  - id: p3\n    text: "High"\n    source: "test"\n    confidence: 0.8\n'
+            )
+            (Path(tmpdir) / "strategies.yaml").write_text("strategies: {}\n")
+            (Path(tmpdir) / "prompt_patches.yaml").write_text("patches: []\n")
+
+            prompt = assemble_system_prompt(tmpdir)
+            # Highest should appear before Medium
+            idx_highest = prompt.index("Highest")
+            idx_medium = prompt.index("Medium")
+            self.assertLess(idx_highest, idx_medium)
+
+    def test_principles_capped_at_max(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lines = ["principles:"]
+            for i in range(_PRINCIPLES_MAX + 5):
+                lines.append(
+                    f'  - id: p{i}\n    text: "Principle {i}"\n'
+                    f'    source: "test"\n    confidence: 0.8\n'
+                )
+            (Path(tmpdir) / "principles.yaml").write_text("\n".join(lines))
+            (Path(tmpdir) / "strategies.yaml").write_text("strategies: {}\n")
+            (Path(tmpdir) / "prompt_patches.yaml").write_text("patches: []\n")
+
+            prompt = assemble_system_prompt(tmpdir)
+            # Should have exactly _PRINCIPLES_MAX entries
+            count = prompt.count("[0.8]")
+            self.assertEqual(count, _PRINCIPLES_MAX)
+
+    def test_strategies_omit_tips(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "principles.yaml").write_text("principles: []\n")
+            (Path(tmpdir) / "strategies.yaml").write_text(
+                "strategies:\n  bug_fix:\n    steps:\n"
+                '      - "Reproduce first"\n'
+                "    tips:\n"
+                '      - "Check logs early"\n'
+            )
+            (Path(tmpdir) / "prompt_patches.yaml").write_text("patches: []\n")
+
+            prompt = assemble_system_prompt(tmpdir)
+            self.assertIn("Reproduce first", prompt)
+            self.assertNotIn("Check logs early", prompt)
+            self.assertIn("bug_fix", prompt)
+
+    def test_patches_capped(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            (Path(tmpdir) / "principles.yaml").write_text("principles: []\n")
+            (Path(tmpdir) / "strategies.yaml").write_text("strategies: {}\n")
+            lines = ["patches:"]
+            for i in range(25):
+                lines.append(f'  - id: pp{i}\n    instruction: "Patch {i}"\n    reason: "test"\n')
+            (Path(tmpdir) / "prompt_patches.yaml").write_text("\n".join(lines))
+
+            prompt = assemble_system_prompt(tmpdir)
+            # Count occurrences — only first 20 should appear
+            count = sum(1 for i in range(25) if f"Patch {i}" in prompt)
+            self.assertEqual(count, 20)
+
+
+class TestHookRateLimit(unittest.TestCase):
+    def setUp(self):
+        reset_nudge_state()
+
+    def tearDown(self):
+        reset_nudge_state()
+
+    def _run(self, coro):
+        return asyncio.run(coro)
+
+    def test_same_file_nudges_once(self):
+        from agent.hooks import post_tool_use_hook
+
+        r1 = self._run(post_tool_use_hook(
+            {"tool_name": "Write", "tool_input": {"file_path": "/tmp/same.py"}, "tool_response": {}},
+            "tu_1", None,
+        ))
+        r2 = self._run(post_tool_use_hook(
+            {"tool_name": "Write", "tool_input": {"file_path": "/tmp/same.py"}, "tool_response": {}},
+            "tu_2", None,
+        ))
+        self.assertIn("systemMessage", r1)
+        self.assertEqual(r2, {})
+
+    def test_different_files_each_nudge(self):
+        from agent.hooks import post_tool_use_hook
+
+        for i in range(3):
+            result = self._run(post_tool_use_hook(
+                {"tool_name": "Edit", "tool_input": {"file_path": f"/tmp/file{i}.py"}, "tool_response": {}},
+                f"tu_{i}", None,
+            ))
+            self.assertIn("systemMessage", result)
+
+    def test_cap_at_max_nudges(self):
+        from agent.hooks import _MAX_WRITE_NUDGES, post_tool_use_hook
+
+        for i in range(_MAX_WRITE_NUDGES + 3):
+            result = self._run(post_tool_use_hook(
+                {"tool_name": "Write", "tool_input": {"file_path": f"/tmp/cap{i}.py"}, "tool_response": {}},
+                f"tu_{i}", None,
+            ))
+            if i < _MAX_WRITE_NUDGES:
+                self.assertIn("systemMessage", result, f"Nudge {i} should fire")
+            else:
+                self.assertEqual(result, {}, f"Nudge {i} should be suppressed")
+
+
+class TestStreamEvents(unittest.TestCase):
+    def test_text_and_done_events(self):
+        from claude_agent_sdk import AssistantMessage, ResultMessage, TextBlock
+
+        from agent.session import stream_events
+
+        async def fake_messages():
+            yield AssistantMessage(
+                content=[TextBlock(text="hello")],
+                model="test-model",
+            )
+            yield ResultMessage(
+                subtype="success",
+                duration_ms=100,
+                duration_api_ms=80,
+                is_error=False,
+                num_turns=1,
+                session_id="test-session",
+                total_cost_usd=0.01,
+            )
+
+        mock_client = MagicMock()
+        mock_client.receive_messages = fake_messages
+
+        events = []
+
+        async def collect():
+            async for ev in stream_events(mock_client):
+                events.append(ev)
+
+        asyncio.run(collect())
+        types = [e[0] for e in events]
+        self.assertIn("text", types)
+        self.assertIn("done", types)
+        text_events = [e for e in events if e[0] == "text"]
+        self.assertEqual(text_events[0][1], "hello")
+        done_events = [e for e in events if e[0] == "done"]
+        cost, turns = done_events[0][1]
+        self.assertAlmostEqual(cost, 0.01)
+        self.assertEqual(turns, 1)
+
+    def test_thinking_event(self):
+        from claude_agent_sdk import AssistantMessage, ResultMessage, ThinkingBlock
+
+        from agent.session import stream_events
+
+        async def fake_messages():
+            yield AssistantMessage(
+                content=[ThinkingBlock(thinking="deep thought", signature="sig")],
+                model="test-model",
+            )
+            yield ResultMessage(
+                subtype="success", duration_ms=0, duration_api_ms=0,
+                is_error=False, num_turns=0, session_id="s",
+            )
+
+        mock_client = MagicMock()
+        mock_client.receive_messages = fake_messages
+
+        events = []
+
+        async def collect():
+            async for ev in stream_events(mock_client):
+                events.append(ev)
+
+        asyncio.run(collect())
+        thinking_events = [e for e in events if e[0] == "thinking"]
+        self.assertEqual(len(thinking_events), 1)
+        # Thinking is truncated to 300 chars
+        self.assertEqual(thinking_events[0][1], "deep thought")
+
+    def test_tool_use_event(self):
+        from claude_agent_sdk import AssistantMessage, ResultMessage, ToolUseBlock
+
+        from agent.session import stream_events
+
+        async def fake_messages():
+            yield AssistantMessage(
+                content=[ToolUseBlock(id="tu_1", name="Read", input={"file_path": "/tmp/x"})],
+                model="test-model",
+            )
+            yield ResultMessage(
+                subtype="success", duration_ms=0, duration_api_ms=0,
+                is_error=False, num_turns=0, session_id="s",
+            )
+
+        mock_client = MagicMock()
+        mock_client.receive_messages = fake_messages
+
+        events = []
+
+        async def collect():
+            async for ev in stream_events(mock_client):
+                events.append(ev)
+
+        asyncio.run(collect())
+        tool_events = [e for e in events if e[0] == "tool_use"]
+        self.assertEqual(len(tool_events), 1)
+        name, inp = tool_events[0][1]
+        self.assertEqual(name, "Read")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Addresses all 13 findings from the agent SDK code review, plus centralizes hardcoded defaults that were duplicated across CLI entry points.

### Phase 1 — Quick Wins
- **Single source of truth for tool lists** — new `sdk/agent/tools.py` with `BUILTIN_TOOLS`, `ALL_MNEMONIC_TOOLS`, `MNEMONIC_RECALL_TOOLS`. Eliminates duplicate definitions in `options.py` and `subagents.py`
- **Format string hardening** — `PRE_TASK_PROMPT.format(task=task)` → `.replace("{task}", task)` to prevent crashes on tasks containing `{` or `}`
- **Hook rate limiting** — Write/Edit nudges fire at most 5 times per session, deduplicated by file path

### Phase 2 — Config
- **Configurable evolution_dir** — new `evolution_dir_override` field on `Config`, `MNEMONIC_EVOLUTION_DIR` env var, `--evolution-dir` CLI arg on both entry points

### Phase 3 — Orchestration Dedup
- **Shared `_orchestrate_task()`** — callback-based orchestration in `session.py` used by both CLI (`_run_task`) and WebSocket (`_handle_task`), eliminating duplicated pre/post/telemetry logic
- **Evolution wired into web** — web users now get self-improvement cycles (calls `_run_evolution` every N tasks)

### Phase 4 — WebSocket Refactor
- **`WebSocketSession` class** — extracted from 167-line nested closure into a class with one method per message type
- **Error sanitization** — generic messages sent to clients instead of raw `str(exc)` with internal paths
- **Idle timeout** — 300s via `asyncio.wait_for`, closes stale connections
- **Index lock** — `threading.Lock` on `ConversationStore._update_index` and `delete_conversation`

### Phase 5 — Prompt Budget
- Principles filtered by confidence >= 0.6, sorted desc, capped at 15
- Strategy tips omitted from assembled prompt (steps kept)
- Patches capped at 20; warning logged if prompt exceeds 20K chars

### Phase 6 — Tests & Defaults
- **28 new tests** in `test_orchestration.py` covering tool lists, Config, build_options, make_subagents, prompt budget, hook rate limiting, and stream_events
- **Centralized defaults** — `DEFAULT_MODEL`, `DEFAULT_SUBAGENT_MODEL`, `DEFAULT_PERMISSION_MODE`, `DEFAULT_EVOLVE_INTERVAL` exported from `config.py`, referenced by all CLI parsers

## Test plan

- [x] All 77 tests pass (49 original + 28 new)
- [ ] Smoke test CLI: `python -m agent.main "what time is it"` — verify no crash on brace content
- [ ] Smoke test web: `python -m agent.web --verbose` — verify WS connects, idle timeout works, no leaked paths in errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)