### PR TITLE
Add Linux desktop app exclusions to watcher config

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -94,6 +94,18 @@ perception:
       - "evolution/conversations/"
       - "evolution/sessions.json"
 
+      # --- Linux desktop/app internal state ---
+      - ".config/Code/"
+      - ".config/google-chrome/"
+      - ".config/chromium/"
+      - ".config/BraveSoftware/"
+      - ".local/share/gnome-shell/"
+      - ".local/share/Trash/"
+      - "/dconf/"
+      - "/gconf/"
+      - "/pulse/"
+      - "/pipewire/"
+
     # Maximum file content size to process (in bytes)
     max_content_bytes: 102400
 


### PR DESCRIPTION
## Summary

- VS Code (`.config/Code/`) was generating ~950 heuristic rejections per session from WebStorage, CacheStorage, QuotaManager, and log rotation
- GNOME shell was firing temp output stream events every few minutes
- All were caught by the heuristic filter but still wasted watcher → heuristic processing

Adds watcher-level exclusions so these events are never even seen:
- `.config/Code/` — VS Code internal state
- `.config/google-chrome/`, `.config/chromium/`, `.config/BraveSoftware/` — browser internals
- `.local/share/gnome-shell/` — GNOME temp streams
- `.local/share/Trash/` — trash operations
- `/dconf/`, `/gconf/` — GNOME settings backends
- `/pulse/`, `/pipewire/` — audio system state

## Test plan

- [x] Config change only — no code changes
- [ ] Restart daemon, verify VS Code/gnome-shell events no longer appear in log
- [ ] Verify legitimate filesystem events (project files) still get through

## Related

- Part of the noise suppression work from #22 and the system audit
- Tier 1 of a 3-tier approach to intelligent exclusions: (1) ship smart defaults, (2) auto-detect at startup (#25), (3) adaptive learning from heuristic rejections (#26)

🤖 Generated with [Claude Code](https://claude.com/claude-code)