### PR TITLE
Attention-based filesystem watching + git watcher

### DIFF
--- a/cmd/mnemonic/main.go
+++ b/cmd/mnemonic/main.go
@@ -40,6 +40,7 @@ import (
 
 	clipwatcher "github.com/appsprout/mnemonic/internal/watcher/clipboard"
 	fswatcher "github.com/appsprout/mnemonic/internal/watcher/filesystem"
+	gitwatcher "github.com/appsprout/mnemonic/internal/watcher/git"
 	termwatcher "github.com/appsprout/mnemonic/internal/watcher/terminal"
 
 	"github.com/google/uuid"
@@ -921,9 +922,14 @@ func serveCommand(configPath string) {
 			}
 
 			fsw, err := fswatcher.NewFilesystemWatcher(fswatcher.Config{
-				WatchDirs:       cfg.Perception.Filesystem.WatchDirs,
-				ExcludePatterns: allExclusions,
-				MaxContentBytes: cfg.Perception.Filesystem.MaxContentBytes,
+				WatchDirs:          cfg.Perception.Filesystem.WatchDirs,
+				ExcludePatterns:    allExclusions,
+				MaxContentBytes:    cfg.Perception.Filesystem.MaxContentBytes,
+				MaxWatches:         cfg.Perception.Filesystem.MaxWatches,
+				ShallowDepth:       cfg.Perception.Filesystem.ShallowDepth,
+				PollIntervalSec:    cfg.Perception.Filesystem.PollIntervalSec,
+				PromotionThreshold: cfg.Perception.Filesystem.PromotionThreshold,
+				DemotionTimeoutMin: cfg.Perception.Filesystem.DemotionTimeoutMin,
 			}, log)
 			if err != nil {
 				log.Error("failed to create filesystem watcher", "error", err)
@@ -957,6 +963,20 @@ func serveCommand(configPath string) {
 			} else {
 				watchers = append(watchers, cw)
 				log.Info("clipboard watcher configured")
+			}
+		}
+
+		if cfg.Perception.Git.Enabled {
+			gw, err := gitwatcher.NewGitWatcher(gitwatcher.Config{
+				WatchDirs:       cfg.Perception.Filesystem.WatchDirs,
+				PollIntervalSec: cfg.Perception.Git.PollIntervalSec,
+				MaxRepoDepth:    cfg.Perception.Git.MaxRepoDepth,
+			}, log)
+			if err != nil {
+				log.Warn("git watcher not available", "error", err)
+			} else {
+				watchers = append(watchers, gw)
+				log.Info("git watcher configured")
 			}
 		}
 

--- a/config.yaml
+++ b/config.yaml
@@ -109,6 +109,31 @@ perception:
     # Maximum file content size to process (in bytes)
     max_content_bytes: 102400
 
+    # --- Attention-based watching (Linux only, ignored on macOS) ---
+    # Hard cap on inotify watches to prevent starving VS Code and other apps.
+    # Linux default inotify limit is 65536; we leave headroom for other apps.
+    max_watches: 20000
+
+    # How deep to add inotify watches at startup (shallow = fast, safe).
+    # Deeper directories are polled in the background instead.
+    shallow_depth: 3
+
+    # How often (seconds) to poll cold (non-inotify) directories for changes.
+    poll_interval_sec: 45
+
+    # How many changes in a poll window before promoting a cold dir to inotify.
+    promotion_threshold: 3
+
+    # Minutes of inactivity before an inotify watch is demoted back to polling.
+    demotion_timeout_min: 30
+
+  # Git perception (monitors git repos for working tree changes)
+  # Provides richer context than raw filesystem events and uses zero inotify watches.
+  git:
+    enabled: true
+    poll_interval_sec: 45
+    max_repo_depth: 3
+
   # Terminal perception (captures shell commands and output)
   terminal:
     enabled: true

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -63,6 +63,7 @@ type PerceptionConfig struct {
 	LLMGatingEnabled      bool                       `yaml:"llm_gating_enabled"`
 	LearnedExclusionsPath string                     `yaml:"learned_exclusions_path"`
 	Filesystem            FilesystemPerceptionConfig `yaml:"filesystem"`
+	Git                   GitPerceptionConfig        `yaml:"git"`
 	Terminal              TerminalPerceptionConfig   `yaml:"terminal"`
 	Clipboard             ClipboardPerceptionConfig  `yaml:"clipboard"`
 	Heuristics            HeuristicsConfig           `yaml:"heuristics"`
@@ -70,10 +71,22 @@ type PerceptionConfig struct {
 
 // FilesystemPerceptionConfig holds filesystem perception settings.
 type FilesystemPerceptionConfig struct {
-	Enabled         bool     `yaml:"enabled"`
-	WatchDirs       []string `yaml:"watch_dirs"`
-	ExcludePatterns []string `yaml:"exclude_patterns"`
-	MaxContentBytes int      `yaml:"max_content_bytes"`
+	Enabled            bool     `yaml:"enabled"`
+	WatchDirs          []string `yaml:"watch_dirs"`
+	ExcludePatterns    []string `yaml:"exclude_patterns"`
+	MaxContentBytes    int      `yaml:"max_content_bytes"`
+	MaxWatches         int      `yaml:"max_watches"`          // hard cap on inotify watches (Linux only, 0 = unlimited)
+	ShallowDepth       int      `yaml:"shallow_depth"`        // inotify watch depth at startup (default: 3)
+	PollIntervalSec    int      `yaml:"poll_interval_sec"`    // how often to scan cold directories (default: 45)
+	PromotionThreshold int      `yaml:"promotion_threshold"`  // changes in poll window to promote to hot (default: 3)
+	DemotionTimeoutMin int      `yaml:"demotion_timeout_min"` // minutes of inactivity before demotion (default: 30)
+}
+
+// GitPerceptionConfig holds git repository watching settings.
+type GitPerceptionConfig struct {
+	Enabled         bool `yaml:"enabled"`
+	PollIntervalSec int  `yaml:"poll_interval_sec"` // how often to check each repo (default: 45)
+	MaxRepoDepth    int  `yaml:"max_repo_depth"`    // how deep to scan for .git/ dirs (default: 3)
 }
 
 // TerminalPerceptionConfig holds terminal perception settings.
@@ -295,7 +308,17 @@ func Default() *Config {
 					"node_modules/",
 					".DS_Store",
 				},
-				MaxContentBytes: 102400,
+				MaxContentBytes:    102400,
+				MaxWatches:         20000,
+				ShallowDepth:       3,
+				PollIntervalSec:    45,
+				PromotionThreshold: 3,
+				DemotionTimeoutMin: 30,
+			},
+			Git: GitPerceptionConfig{
+				Enabled:         true,
+				PollIntervalSec: 45,
+				MaxRepoDepth:    3,
 			},
 			Terminal: TerminalPerceptionConfig{
 				Enabled:         true,

--- a/internal/watcher/filesystem/common.go
+++ b/internal/watcher/filesystem/common.go
@@ -10,9 +10,14 @@ import (
 
 // Config holds configuration for the filesystem watcher.
 type Config struct {
-	WatchDirs       []string
-	ExcludePatterns []string
-	MaxContentBytes int
+	WatchDirs          []string
+	ExcludePatterns    []string
+	MaxContentBytes    int
+	MaxWatches         int // hard cap on inotify watches (Linux only, 0 = unlimited)
+	ShallowDepth       int // inotify watch depth at startup (default: 3)
+	PollIntervalSec    int // how often to scan cold directories (default: 45)
+	PromotionThreshold int // changes in poll window to promote to hot (default: 3)
+	DemotionTimeoutMin int // minutes of inactivity before demotion (default: 30)
 }
 
 // MatchesExcludePattern checks if a path matches any exclude pattern.

--- a/internal/watcher/filesystem/watcher_other.go
+++ b/internal/watcher/filesystem/watcher_other.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -17,18 +18,32 @@ import (
 	"github.com/google/uuid"
 )
 
-// FilesystemWatcher implements the watcher.Watcher interface using fsnotify (kqueue/inotify).
-// Used on non-macOS platforms. On macOS, the FSEvents-based watcher is used instead.
+// FilesystemWatcher implements the watcher.Watcher interface using fsnotify (inotify).
+// Uses attention-based watching: shallow inotify for real-time perception of active areas,
+// background polling for deeper/cold directories. A hard watch budget prevents inotify
+// exhaustion that would starve VS Code and other apps.
 type FilesystemWatcher struct {
-	cfg      Config
-	log      *slog.Logger
-	fsw      *fsnotify.Watcher
-	events   chan watcher.Event
-	done     chan struct{}
-	mu       sync.RWMutex
+	cfg    Config
+	log    *slog.Logger
+	fsw    *fsnotify.Watcher
+	events chan watcher.Event
+	done   chan struct{}
+	mu     sync.RWMutex
+
 	running  bool
 	debounce map[string]*time.Timer
 	dbMutex  sync.Mutex
+
+	// Watch budget tracking
+	watchCount int
+	maxWatches int
+
+	// Hot/cold tier tracking
+	hotDirs      map[string]time.Time // dir → last activity time (inotify-watched)
+	coldDirs     []string             // dirs being polled (deeper than shallow depth)
+	coldMtimes   map[string]time.Time // dir → last known mtime (for change detection)
+	coldActivity map[string]int       // dir → change count in current poll window
+	tierMu       sync.Mutex           // protects hot/cold state
 }
 
 // NewFilesystemWatcher creates a new filesystem watcher using fsnotify.
@@ -42,13 +57,22 @@ func NewFilesystemWatcher(cfg Config, log *slog.Logger) (*FilesystemWatcher, err
 		return nil, fmt.Errorf("logger must not be nil")
 	}
 
+	maxWatches := cfg.MaxWatches
+	if maxWatches == 0 {
+		maxWatches = 20000
+	}
+
 	return &FilesystemWatcher{
-		cfg:      cfg,
-		log:      log,
-		fsw:      fsw,
-		events:   make(chan watcher.Event, 100),
-		done:     make(chan struct{}),
-		debounce: make(map[string]*time.Timer),
+		cfg:          cfg,
+		log:          log,
+		fsw:          fsw,
+		events:       make(chan watcher.Event, 100),
+		done:         make(chan struct{}),
+		debounce:     make(map[string]*time.Timer),
+		maxWatches:   maxWatches,
+		hotDirs:      make(map[string]time.Time),
+		coldMtimes:   make(map[string]time.Time),
+		coldActivity: make(map[string]int),
 	}, nil
 }
 
@@ -65,15 +89,53 @@ func (fw *FilesystemWatcher) Start(ctx context.Context) error {
 	fw.running = true
 	fw.mu.Unlock()
 
-	for _, dir := range fw.cfg.WatchDirs {
-		if err := fw.addDirRecursive(dir); err != nil {
-			fw.log.Warn("failed to add directory", "dir", dir, "err", err)
-		}
+	shallowDepth := fw.cfg.ShallowDepth
+	if shallowDepth == 0 {
+		shallowDepth = 3
 	}
 
+	// Phase 1: Add shallow inotify watches (depth-limited)
+	for _, dir := range fw.cfg.WatchDirs {
+		fw.addDirShallow(dir, shallowDepth)
+	}
+
+	fw.log.Info("filesystem watcher: shallow watches added",
+		"watch_count", fw.watchCount,
+		"budget", fw.maxWatches,
+		"shallow_depth", shallowDepth,
+	)
+
+	// Phase 2: Discover cold directories (deeper than shallow depth)
+	for _, dir := range fw.cfg.WatchDirs {
+		fw.discoverColdDirs(dir, shallowDepth)
+	}
+
+	fw.log.Info("filesystem watcher: cold directories discovered",
+		"cold_count", len(fw.coldDirs),
+	)
+
+	// Start event handler
 	go fw.handleEvents(ctx)
 
-	fw.log.Info("filesystem watcher started (fsnotify)", "dirs", fw.cfg.WatchDirs)
+	// Start background polling for cold directories
+	pollInterval := time.Duration(fw.cfg.PollIntervalSec) * time.Second
+	if pollInterval == 0 {
+		pollInterval = 45 * time.Second
+	}
+	go fw.pollColdDirs(ctx, pollInterval)
+
+	// Start demotion checker
+	demotionTimeout := time.Duration(fw.cfg.DemotionTimeoutMin) * time.Minute
+	if demotionTimeout == 0 {
+		demotionTimeout = 30 * time.Minute
+	}
+	go fw.demotionLoop(ctx, demotionTimeout)
+
+	fw.log.Info("filesystem watcher started (attention-based)",
+		"dirs", fw.cfg.WatchDirs,
+		"hot_watches", fw.watchCount,
+		"cold_dirs", len(fw.coldDirs),
+	)
 	return nil
 }
 
@@ -124,27 +186,270 @@ func (fw *FilesystemWatcher) Health(ctx context.Context) error {
 	return nil
 }
 
-func (fw *FilesystemWatcher) addDirRecursive(dir string) error {
-	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+// addDirShallow adds inotify watches up to maxDepth levels deep.
+func (fw *FilesystemWatcher) addDirShallow(root string, maxDepth int) {
+	rootDepth := strings.Count(filepath.Clean(root), string(filepath.Separator))
+
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
 		if err != nil {
-			return err
+			return nil // skip inaccessible dirs
 		}
 		if !d.IsDir() {
 			return nil
 		}
+
 		fw.mu.RLock()
 		excluded := MatchesExcludePattern(path, fw.cfg.ExcludePatterns)
 		fw.mu.RUnlock()
 		if excluded {
 			return filepath.SkipDir
 		}
+
+		// Check depth
+		pathDepth := strings.Count(filepath.Clean(path), string(filepath.Separator))
+		if pathDepth-rootDepth >= maxDepth {
+			return filepath.SkipDir
+		}
+
+		// Check budget
+		if fw.watchCount >= fw.maxWatches {
+			fw.log.Warn("inotify watch budget exhausted",
+				"budget", fw.maxWatches,
+				"path", path,
+			)
+			return filepath.SkipDir
+		}
+
 		if err := fw.fsw.Add(path); err != nil {
-			fw.log.Debug("failed to add directory to watcher", "path", path, "err", err)
+			fw.log.Debug("failed to add inotify watch", "path", path, "err", err)
 			return nil
 		}
-		fw.log.Debug("added directory to watcher", "path", path)
+
+		fw.watchCount++
+		fw.tierMu.Lock()
+		fw.hotDirs[path] = time.Now()
+		fw.tierMu.Unlock()
+
 		return nil
 	})
+}
+
+// discoverColdDirs finds directories deeper than shallowDepth for background polling.
+func (fw *FilesystemWatcher) discoverColdDirs(root string, shallowDepth int) {
+	rootDepth := strings.Count(filepath.Clean(root), string(filepath.Separator))
+
+	_ = filepath.WalkDir(root, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return nil
+		}
+		if !d.IsDir() {
+			return nil
+		}
+
+		fw.mu.RLock()
+		excluded := MatchesExcludePattern(path, fw.cfg.ExcludePatterns)
+		fw.mu.RUnlock()
+		if excluded {
+			return filepath.SkipDir
+		}
+
+		pathDepth := strings.Count(filepath.Clean(path), string(filepath.Separator))
+		depth := pathDepth - rootDepth
+
+		// Skip directories already watched by inotify (shallow tier)
+		if depth < shallowDepth {
+			return nil
+		}
+
+		// Only add directories at exactly shallowDepth as cold polling roots.
+		// We don't need to recurse infinitely — poll these and they'll tell us
+		// about activity in their subtrees via mtime changes.
+		if depth == shallowDepth {
+			fw.tierMu.Lock()
+			fw.coldDirs = append(fw.coldDirs, path)
+			// Record initial mtime
+			if info, err := os.Stat(path); err == nil {
+				fw.coldMtimes[path] = info.ModTime()
+			}
+			fw.tierMu.Unlock()
+			return filepath.SkipDir // don't recurse deeper
+		}
+
+		return nil
+	})
+}
+
+// pollColdDirs periodically checks cold directories for mtime changes.
+func (fw *FilesystemWatcher) pollColdDirs(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	promotionThreshold := fw.cfg.PromotionThreshold
+	if promotionThreshold == 0 {
+		promotionThreshold = 3
+	}
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-fw.done:
+			return
+		case <-ticker.C:
+			fw.tierMu.Lock()
+			var toPromote []string
+
+			for _, dir := range fw.coldDirs {
+				info, err := os.Stat(dir)
+				if err != nil {
+					continue
+				}
+
+				lastMtime, known := fw.coldMtimes[dir]
+				currentMtime := info.ModTime()
+
+				if known && currentMtime.After(lastMtime) {
+					// Activity detected
+					fw.coldActivity[dir]++
+					fw.coldMtimes[dir] = currentMtime
+
+					// Emit a polling-detected event for the changed directory
+					fw.tierMu.Unlock()
+					fw.emitPollEvent(dir)
+					fw.tierMu.Lock()
+
+					if fw.coldActivity[dir] >= promotionThreshold {
+						toPromote = append(toPromote, dir)
+					}
+				} else if !known {
+					fw.coldMtimes[dir] = currentMtime
+				}
+			}
+			fw.tierMu.Unlock()
+
+			// Promote active cold dirs to hot (inotify)
+			for _, dir := range toPromote {
+				fw.promoteToHot(dir)
+			}
+		}
+	}
+}
+
+// promoteToHot moves a directory from cold polling to hot inotify watching.
+func (fw *FilesystemWatcher) promoteToHot(dir string) {
+	// Check budget
+	if fw.watchCount >= fw.maxWatches {
+		fw.log.Debug("cannot promote to hot: budget exhausted", "dir", dir)
+		return
+	}
+
+	if err := fw.fsw.Add(dir); err != nil {
+		fw.log.Debug("failed to promote directory to hot", "dir", dir, "err", err)
+		return
+	}
+
+	fw.watchCount++
+
+	fw.tierMu.Lock()
+	defer fw.tierMu.Unlock()
+
+	fw.hotDirs[dir] = time.Now()
+	delete(fw.coldActivity, dir)
+
+	// Remove from cold list
+	for i, d := range fw.coldDirs {
+		if d == dir {
+			fw.coldDirs = append(fw.coldDirs[:i], fw.coldDirs[i+1:]...)
+			break
+		}
+	}
+
+	fw.log.Info("promoted directory to hot (inotify)",
+		"dir", dir,
+		"watch_count", fw.watchCount,
+	)
+}
+
+// demotionLoop periodically checks for inactive hot directories and demotes them.
+func (fw *FilesystemWatcher) demotionLoop(ctx context.Context, timeout time.Duration) {
+	ticker := time.NewTicker(5 * time.Minute)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-fw.done:
+			return
+		case <-ticker.C:
+			fw.demoteColdDirs(timeout)
+		}
+	}
+}
+
+// demoteColdDirs removes inotify watches from directories that have been inactive.
+// Skips root watch dirs — those always stay hot.
+func (fw *FilesystemWatcher) demoteColdDirs(timeout time.Duration) {
+	now := time.Now()
+	rootDirs := make(map[string]bool)
+	for _, d := range fw.cfg.WatchDirs {
+		rootDirs[filepath.Clean(d)] = true
+	}
+
+	fw.tierMu.Lock()
+	var toDemote []string
+	for dir, lastActive := range fw.hotDirs {
+		// Never demote root watch dirs
+		if rootDirs[filepath.Clean(dir)] {
+			continue
+		}
+		if now.Sub(lastActive) > timeout {
+			toDemote = append(toDemote, dir)
+		}
+	}
+	fw.tierMu.Unlock()
+
+	for _, dir := range toDemote {
+		if err := fw.fsw.Remove(dir); err != nil {
+			fw.log.Debug("failed to remove inotify watch for demotion", "dir", dir, "err", err)
+			continue
+		}
+
+		fw.watchCount--
+
+		fw.tierMu.Lock()
+		delete(fw.hotDirs, dir)
+		fw.coldDirs = append(fw.coldDirs, dir)
+		if info, err := os.Stat(dir); err == nil {
+			fw.coldMtimes[dir] = info.ModTime()
+		}
+		fw.tierMu.Unlock()
+
+		fw.log.Info("demoted directory to cold (polling)",
+			"dir", dir,
+			"watch_count", fw.watchCount,
+		)
+	}
+}
+
+// emitPollEvent creates a filesystem event for a directory change detected by polling.
+func (fw *FilesystemWatcher) emitPollEvent(dir string) {
+	wevent := watcher.Event{
+		ID:        uuid.New().String(),
+		Source:    "filesystem",
+		Type:      "dir_activity",
+		Path:      dir,
+		Timestamp: time.Now(),
+		Metadata: map[string]interface{}{
+			"detection": "polling",
+		},
+	}
+
+	select {
+	case fw.events <- wevent:
+		fw.log.Debug("sent polling-detected event", "dir", dir)
+	case <-fw.done:
+	}
 }
 
 func (fw *FilesystemWatcher) handleEvents(ctx context.Context) {
@@ -164,10 +469,25 @@ func (fw *FilesystemWatcher) handleEvents(ctx context.Context) {
 			if excluded {
 				continue
 			}
+
+			// Update hot dir activity timestamp
+			dir := filepath.Dir(event.Name)
+			fw.tierMu.Lock()
+			if _, isHot := fw.hotDirs[dir]; isHot {
+				fw.hotDirs[dir] = time.Now()
+			}
+			fw.tierMu.Unlock()
+
 			if event.Has(fsnotify.Create) {
 				if info, err := os.Stat(event.Name); err == nil && info.IsDir() {
-					if err := fw.addDirRecursive(event.Name); err != nil {
-						fw.log.Debug("failed to add new directory to watcher", "path", event.Name, "err", err)
+					// New directory created — add shallow watch if under budget
+					if fw.watchCount < fw.maxWatches {
+						if err := fw.fsw.Add(event.Name); err == nil {
+							fw.watchCount++
+							fw.tierMu.Lock()
+							fw.hotDirs[event.Name] = time.Now()
+							fw.tierMu.Unlock()
+						}
 					}
 				}
 			}

--- a/internal/watcher/git/watcher.go
+++ b/internal/watcher/git/watcher.go
@@ -1,0 +1,285 @@
+package git
+
+import (
+	"context"
+	"crypto/sha256"
+	"fmt"
+	"io/fs"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/appsprout/mnemonic/internal/watcher"
+	"github.com/google/uuid"
+)
+
+// Config holds configuration for the git watcher.
+type Config struct {
+	WatchDirs       []string // top-level dirs to scan for repos
+	PollIntervalSec int      // how often to poll each repo (default: 45)
+	MaxRepoDepth    int      // how deep to scan for .git/ dirs (default: 3)
+}
+
+// GitWatcher monitors git repositories for changes by polling git status/diff.
+// It emits events when working tree changes are detected, providing richer
+// context than raw filesystem events (actual diffs vs "file X was modified").
+// Consumes zero inotify watches.
+type GitWatcher struct {
+	cfg    Config
+	log    *slog.Logger
+	events chan watcher.Event
+	done   chan struct{}
+	mu     sync.RWMutex
+
+	running bool
+	repos   []string          // discovered repo root paths
+	state   map[string]string // repo path → hash of last-seen status
+}
+
+// NewGitWatcher creates a new git repository watcher.
+func NewGitWatcher(cfg Config, log *slog.Logger) (*GitWatcher, error) {
+	if log == nil {
+		return nil, fmt.Errorf("logger must not be nil")
+	}
+
+	// Check that git is available
+	if _, err := exec.LookPath("git"); err != nil {
+		return nil, fmt.Errorf("git not found in PATH: %w", err)
+	}
+
+	return &GitWatcher{
+		cfg:    cfg,
+		log:    log,
+		events: make(chan watcher.Event, 100),
+		done:   make(chan struct{}),
+		state:  make(map[string]string),
+	}, nil
+}
+
+func (gw *GitWatcher) Name() string {
+	return "git"
+}
+
+func (gw *GitWatcher) Start(ctx context.Context) error {
+	gw.mu.Lock()
+	if gw.running {
+		gw.mu.Unlock()
+		return fmt.Errorf("git watcher is already running")
+	}
+	gw.running = true
+	gw.mu.Unlock()
+
+	maxDepth := gw.cfg.MaxRepoDepth
+	if maxDepth == 0 {
+		maxDepth = 3
+	}
+
+	// Discover git repositories
+	gw.repos = discoverRepos(gw.cfg.WatchDirs, maxDepth)
+	gw.log.Info("git watcher: discovered repositories",
+		"count", len(gw.repos),
+		"repos", gw.repos,
+	)
+
+	// Initialize state for each repo
+	for _, repo := range gw.repos {
+		status := gw.getRepoState(repo)
+		gw.state[repo] = hashState(status)
+	}
+
+	// Start polling loop
+	pollInterval := time.Duration(gw.cfg.PollIntervalSec) * time.Second
+	if pollInterval == 0 {
+		pollInterval = 45 * time.Second
+	}
+	go gw.pollLoop(ctx, pollInterval)
+
+	gw.log.Info("git watcher started", "poll_interval", pollInterval, "repos", len(gw.repos))
+	return nil
+}
+
+func (gw *GitWatcher) Stop() error {
+	gw.mu.Lock()
+	if !gw.running {
+		gw.mu.Unlock()
+		return fmt.Errorf("git watcher is not running")
+	}
+	gw.running = false
+	gw.mu.Unlock()
+
+	close(gw.done)
+	close(gw.events)
+	gw.log.Info("git watcher stopped")
+	return nil
+}
+
+func (gw *GitWatcher) Events() <-chan watcher.Event {
+	return gw.events
+}
+
+func (gw *GitWatcher) Health(ctx context.Context) error {
+	gw.mu.RLock()
+	defer gw.mu.RUnlock()
+	if !gw.running {
+		return fmt.Errorf("git watcher is not running")
+	}
+	return nil
+}
+
+// discoverRepos scans directories for git repositories up to maxDepth.
+func discoverRepos(dirs []string, maxDepth int) []string {
+	var repos []string
+	seen := make(map[string]bool)
+
+	for _, dir := range dirs {
+		rootDepth := strings.Count(filepath.Clean(dir), string(filepath.Separator))
+
+		_ = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+			if err != nil {
+				return nil
+			}
+			if !d.IsDir() {
+				return nil
+			}
+
+			// Check depth limit
+			pathDepth := strings.Count(filepath.Clean(path), string(filepath.Separator))
+			if pathDepth-rootDepth > maxDepth {
+				return filepath.SkipDir
+			}
+
+			// Skip common non-repo directories
+			name := d.Name()
+			if name == "node_modules" || name == ".git" || name == "__pycache__" || name == "vendor" {
+				return filepath.SkipDir
+			}
+
+			// Check if this directory is a git repo
+			gitDir := filepath.Join(path, ".git")
+			if info, err := statFile(gitDir); err == nil && info.IsDir() {
+				cleanPath := filepath.Clean(path)
+				if !seen[cleanPath] {
+					seen[cleanPath] = true
+					repos = append(repos, cleanPath)
+				}
+				return filepath.SkipDir // don't recurse into repos (submodules are separate)
+			}
+
+			return nil
+		})
+	}
+
+	return repos
+}
+
+// statFile wraps os.Stat for testability.
+var statFile = func(path string) (fs.FileInfo, error) {
+	return os.Stat(path)
+}
+
+// pollLoop periodically checks each repo for changes.
+func (gw *GitWatcher) pollLoop(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-gw.done:
+			return
+		case <-ticker.C:
+			gw.checkAllRepos()
+		}
+	}
+}
+
+// checkAllRepos checks each discovered repo for working tree changes.
+func (gw *GitWatcher) checkAllRepos() {
+	for _, repo := range gw.repos {
+		state := gw.getRepoState(repo)
+		newHash := hashState(state)
+
+		oldHash, known := gw.state[repo]
+		if known && newHash == oldHash {
+			continue // no changes
+		}
+		gw.state[repo] = newHash
+
+		if !known {
+			continue // first time seeing this repo, don't emit
+		}
+
+		if state == "" {
+			continue // empty state means no changes
+		}
+
+		// Build a meaningful event
+		diff := gw.getRepoDiff(repo)
+		content := state
+		if diff != "" {
+			content = state + "\n---\n" + diff
+		}
+
+		// Truncate to avoid huge diffs
+		if len(content) > 5000 {
+			content = content[:5000] + "\n... [truncated]"
+		}
+
+		wevent := watcher.Event{
+			ID:        uuid.New().String(),
+			Source:    "git",
+			Type:      "repo_changed",
+			Path:      repo,
+			Content:   content,
+			Timestamp: time.Now(),
+			Metadata: map[string]interface{}{
+				"repo": repo,
+			},
+		}
+
+		select {
+		case gw.events <- wevent:
+			gw.log.Debug("git watcher: detected changes", "repo", repo)
+		case <-gw.done:
+			return
+		}
+	}
+}
+
+// getRepoState returns the combined git status output for a repo.
+func (gw *GitWatcher) getRepoState(repo string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "-C", repo, "status", "--porcelain")
+	out, err := cmd.Output()
+	if err != nil {
+		gw.log.Debug("git status failed", "repo", repo, "err", err)
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// getRepoDiff returns a brief diff summary for a repo.
+func (gw *GitWatcher) getRepoDiff(repo string) string {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "git", "-C", repo, "diff", "--stat")
+	out, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// hashState produces a short hash of the state string for change detection.
+func hashState(state string) string {
+	h := sha256.Sum256([]byte(state))
+	return fmt.Sprintf("%x", h[:8])
+}

--- a/internal/watcher/git/watcher_test.go
+++ b/internal/watcher/git/watcher_test.go
@@ -1,0 +1,173 @@
+package git
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func testLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelWarn}))
+}
+
+func TestDiscoverRepos(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a fake git repo
+	repoDir := filepath.Join(tmpDir, "myproject")
+	if err := os.MkdirAll(filepath.Join(repoDir, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a non-repo directory
+	if err := os.MkdirAll(filepath.Join(tmpDir, "documents", "notes"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a nested repo (depth 2)
+	nestedRepo := filepath.Join(tmpDir, "work", "subproject")
+	if err := os.MkdirAll(filepath.Join(nestedRepo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	repos := discoverRepos([]string{tmpDir}, 3)
+
+	if len(repos) != 2 {
+		t.Fatalf("expected 2 repos, got %d: %v", len(repos), repos)
+	}
+
+	found := make(map[string]bool)
+	for _, r := range repos {
+		found[r] = true
+	}
+	if !found[filepath.Clean(repoDir)] {
+		t.Errorf("expected to find repo %s", repoDir)
+	}
+	if !found[filepath.Clean(nestedRepo)] {
+		t.Errorf("expected to find repo %s", nestedRepo)
+	}
+}
+
+func TestDiscoverRepos_DepthLimit(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a repo at depth 5 — should not be found with maxDepth=2
+	deepRepo := filepath.Join(tmpDir, "a", "b", "c", "d", "e")
+	if err := os.MkdirAll(filepath.Join(deepRepo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	repos := discoverRepos([]string{tmpDir}, 2)
+	if len(repos) != 0 {
+		t.Errorf("expected 0 repos with depth limit 2, got %d: %v", len(repos), repos)
+	}
+}
+
+func TestDiscoverRepos_SkipsNodeModules(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a repo inside node_modules — should be skipped
+	nmRepo := filepath.Join(tmpDir, "node_modules", "some-pkg")
+	if err := os.MkdirAll(filepath.Join(nmRepo, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	repos := discoverRepos([]string{tmpDir}, 5)
+	if len(repos) != 0 {
+		t.Errorf("expected 0 repos (node_modules skipped), got %d: %v", len(repos), repos)
+	}
+}
+
+func TestHashState(t *testing.T) {
+	h1 := hashState("some state")
+	h2 := hashState("some state")
+	h3 := hashState("different state")
+
+	if h1 != h2 {
+		t.Error("same input should produce same hash")
+	}
+	if h1 == h3 {
+		t.Error("different input should produce different hash")
+	}
+}
+
+func TestGitWatcher_RealRepo(t *testing.T) {
+	// Skip if git is not available
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not found, skipping integration test")
+	}
+
+	tmpDir := t.TempDir()
+
+	// Create a real git repo
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = tmpDir
+		cmd.Env = append(os.Environ(),
+			"GIT_AUTHOR_NAME=Test",
+			"GIT_AUTHOR_EMAIL=test@test.com",
+			"GIT_COMMITTER_NAME=Test",
+			"GIT_COMMITTER_EMAIL=test@test.com",
+		)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("command %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	run("git", "init")
+	run("git", "commit", "--allow-empty", "-m", "initial")
+
+	gw, err := NewGitWatcher(Config{
+		WatchDirs:       []string{tmpDir},
+		PollIntervalSec: 1,
+		MaxRepoDepth:    1,
+	}, testLogger())
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	if err := gw.Start(ctx); err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = gw.Stop() }()
+
+	if len(gw.repos) != 1 {
+		t.Fatalf("expected 1 repo, got %d", len(gw.repos))
+	}
+
+	// Create a new file in the repo (this changes git status)
+	if err := os.WriteFile(filepath.Join(tmpDir, "newfile.txt"), []byte("hello"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Wait for the polling to detect the change
+	var received bool
+	timeout := time.After(5 * time.Second)
+	for !received {
+		select {
+		case evt, ok := <-gw.Events():
+			if !ok {
+				t.Fatal("events channel closed unexpectedly")
+			}
+			if evt.Source == "git" && evt.Type == "repo_changed" {
+				received = true
+				if evt.Path != filepath.Clean(tmpDir) {
+					t.Errorf("expected path %s, got %s", tmpDir, evt.Path)
+				}
+				if evt.Content == "" {
+					t.Error("expected non-empty content")
+				}
+			}
+		case <-timeout:
+			t.Fatal("timed out waiting for git change event")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the inotify exhaustion bug that was breaking VS Code's file explorer. The old watcher recursively added 128,927 inotify watches (one per directory under ~/Documents and ~/Projects), exceeding the Linux limit of 65,536 and starving every other app.

- **Attention-based filesystem watcher** — Replaces unbounded recursive inotify with a budgeted hot/cold tier system inspired by how human attention works: real-time perception on active areas, background scanning everywhere else
- **Git watcher** — New perception source that polls git repos for working tree changes, providing richer context (actual diffs) with zero inotify watches

## How it works

### Filesystem watcher (Linux)

| Tier | Method | Latency | Budget |
|------|--------|---------|--------|
| Hot | inotify (shallow, depth 3) | Real-time | Max 20,000 watches |
| Cold | mtime polling (every 45s) | 30-60s | Unlimited |

- At startup, add inotify watches only to depth 3 (~50-200 dirs, not 128k)
- Discover deeper directories as cold polling targets
- When polling detects repeated activity in a cold dir, promote it to hot (inotify)
- When a hot dir goes inactive for 30min, demote it back to cold (release the watch)
- Hard budget of 20,000 watches — leaves ~45k for VS Code, editors, etc.
- macOS: no changes needed (FSEvents already watches entire trees efficiently)

### Git watcher

- Scans watch dirs for `.git/` directories at startup (depth-limited)
- Polls each repo every 45s with `git status --porcelain` and `git diff --stat`
- Emits events only when working tree state changes
- Provides richer content than raw filesystem events (actual diffs vs "file X modified")
- Consumes zero inotify watches

## New files

- `internal/watcher/git/watcher.go` — Git watcher implementation
- `internal/watcher/git/watcher_test.go` — 5 tests (discovery, depth limit, node_modules skip, hashing, real repo integration)

## Modified files

- `internal/watcher/filesystem/watcher_other.go` — Rewritten with hot/cold tiers and watch budget
- `internal/watcher/filesystem/common.go` — Added budget/tier config fields to Config struct
- `internal/config/config.go` — New config types: `GitPerceptionConfig`, filesystem budget fields
- `config.yaml` — New config sections with documented defaults
- `cmd/mnemonic/main.go` — Wire git watcher + pass budget config to filesystem watcher

## Config additions

```yaml
perception:
  filesystem:
    max_watches: 20000
    shallow_depth: 3
    poll_interval_sec: 45
    promotion_threshold: 3
    demotion_timeout_min: 30
  git:
    enabled: true
    poll_interval_sec: 45
    max_repo_depth: 3
```

## Test plan

- [x] `make build` succeeds
- [x] `make test` passes (all existing + 5 new git watcher tests)
- [x] `make check` passes (`go fmt` + `go vet`)
- [ ] Manual: Run daemon, verify VS Code file explorer works simultaneously
- [ ] Manual: Verify shallow watch count in startup logs
- [ ] Manual: Verify git watcher discovers repos and detects changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)