### PR TITLE
Fix episode stats and .git exclusion pattern

### DIFF
--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1412,6 +1412,13 @@ func (s *SQLiteStore) GetStatistics(ctx context.Context) (store.StoreStatistics,
 		return stats, fmt.Errorf("failed to count memories: %w", err)
 	}
 
+	// Count episodes
+	episodeQuery := `SELECT COUNT(*) FROM episodes`
+	err = s.db.QueryRowContext(ctx, episodeQuery).Scan(&stats.TotalEpisodes)
+	if err != nil {
+		return stats, fmt.Errorf("failed to count episodes: %w", err)
+	}
+
 	// Count associations
 	assocQuery := `SELECT COUNT(*) FROM associations`
 	err = s.db.QueryRowContext(ctx, assocQuery).Scan(&stats.TotalAssociations)

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -75,6 +75,7 @@ type StoreStatistics struct {
 	FadingMemories        int       `json:"fading_memories"`
 	ArchivedMemories      int       `json:"archived_memories"`
 	MergedMemories        int       `json:"merged_memories"`
+	TotalEpisodes         int       `json:"total_episodes"`
 	TotalAssociations     int       `json:"total_associations"`
 	AvgAssociationsPerMem float32   `json:"avg_associations_per_memory"`
 	StorageSizeBytes      int64     `json:"storage_size_bytes"`

--- a/internal/watcher/filesystem/common.go
+++ b/internal/watcher/filesystem/common.go
@@ -21,9 +21,12 @@ type Config struct {
 }
 
 // MatchesExcludePattern checks if a path matches any exclude pattern.
+// Also checks with a trailing slash so that patterns like ".git/" match
+// both the .git directory itself and files inside it.
 func MatchesExcludePattern(path string, patterns []string) bool {
+	pathWithSlash := path + "/"
 	for _, pattern := range patterns {
-		if strings.Contains(path, pattern) {
+		if strings.Contains(path, pattern) || strings.Contains(pathWithSlash, pattern) {
 			return true
 		}
 	}

--- a/migrations/003_episode_columns.sql
+++ b/migrations/003_episode_columns.sql
@@ -1,0 +1,7 @@
+-- Migration 003: Add missing episode columns
+-- The episodes table was created without concepts, files_modified, and
+-- event_timeline columns that the application code expects.
+
+ALTER TABLE episodes ADD COLUMN concepts TEXT;
+ALTER TABLE episodes ADD COLUMN files_modified TEXT;
+ALTER TABLE episodes ADD COLUMN event_timeline TEXT;


### PR DESCRIPTION
## Summary
- **Episode count in dashboard**: Added `TotalEpisodes` field to `StoreStatistics` and query it in `GetStatistics()`. The dashboard was reading `stats.total_episodes` but the field didn't exist in the JSON response — always showed 0.
- **`.git` exclusion pattern**: Fixed `MatchesExcludePattern` to also check the path with a trailing slash appended. Previously, patterns like `.git/` wouldn't match a path ending in `.git` (no slash), causing `.git` directories to get promoted to the hot inotify tier.
- **Migration 003 reference**: Added `migrations/003_episode_columns.sql` as documentation (the actual migration already runs inline in `schema.go`).

## Test plan
- [x] `make build` passes
- [x] `make test` passes (0 failures)
- [x] `make check` passes (fmt + vet)
- [ ] After merge: nuke DB, restart mnemonic, verify dashboard shows episode count
- [ ] Verify `.git` dirs no longer appear in hot tier promotion logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)