### PR TITLE
Fix audit findings: sentinel errors, N+1 queries, connection pooling

### DIFF
--- a/cmd/mnemonic/main.go
+++ b/cmd/mnemonic/main.go
@@ -1030,7 +1030,7 @@ func serveCommand(configPath string) {
 			MaxMemoriesPerCycle: cfg.Consolidation.MaxMemoriesPerCycle,
 			MaxMergesPerCycle:   cfg.Consolidation.MaxMergesPerCycle,
 			MinClusterSize:      cfg.Consolidation.MinClusterSize,
-			AssocPruneThreshold: 0.05,
+			AssocPruneThreshold: consolidation.DefaultConfig().AssocPruneThreshold,
 		}, log)
 
 		if err := consolidator.Start(rootCtx, bus); err != nil {
@@ -1446,7 +1446,7 @@ func consolidateCommand(configPath string) {
 		MaxMemoriesPerCycle: cfg.Consolidation.MaxMemoriesPerCycle,
 		MaxMergesPerCycle:   cfg.Consolidation.MaxMergesPerCycle,
 		MinClusterSize:      cfg.Consolidation.MinClusterSize,
-		AssocPruneThreshold: 0.05,
+		AssocPruneThreshold: consolidation.DefaultConfig().AssocPruneThreshold,
 	}, log)
 
 	fmt.Println("Running consolidation cycle...")
@@ -1885,7 +1885,7 @@ func mcpCommand(configPath string) {
 		DualHitBonus:        float32(cfg.Retrieval.DualHitBonus),
 	}, log)
 
-	server := mcp.NewMCPServer(db, retriever, bus, log, cfg.Coaching.CoachingFile, cfg.Perception.Filesystem.ExcludePatterns, cfg.Perception.Filesystem.MaxContentBytes)
+	server := mcp.NewMCPServer(db, retriever, bus, log, Version, cfg.Coaching.CoachingFile, cfg.Perception.Filesystem.ExcludePatterns, cfg.Perception.Filesystem.MaxContentBytes)
 
 	// Handle signal for graceful shutdown
 	sigChan := make(chan os.Signal, 1)

--- a/internal/agent/abstraction/agent.go
+++ b/internal/agent/abstraction/agent.go
@@ -42,14 +42,11 @@ type CycleReport struct {
 }
 
 func NewAbstractionAgent(s store.Store, llmProv llm.Provider, cfg AbstractionConfig, log *slog.Logger) *AbstractionAgent {
-	ctx, cancel := context.WithCancel(context.Background())
 	return &AbstractionAgent{
 		store:       s,
 		llmProvider: llmProv,
 		config:      cfg,
 		log:         log,
-		ctx:         ctx,
-		cancel:      cancel,
 		triggerCh:   make(chan struct{}, 1),
 	}
 }
@@ -59,6 +56,7 @@ func (aa *AbstractionAgent) Name() string {
 }
 
 func (aa *AbstractionAgent) Start(ctx context.Context, bus events.Bus) error {
+	aa.ctx, aa.cancel = context.WithCancel(ctx)
 	aa.bus = bus
 
 	// On-demand triggers (via triggerCh) are now managed by the reactor engine,

--- a/internal/agent/consolidation/agent.go
+++ b/internal/agent/consolidation/agent.go
@@ -62,14 +62,11 @@ type ConsolidationAgent struct {
 
 // NewConsolidationAgent creates a new consolidation agent.
 func NewConsolidationAgent(s store.Store, llmProv llm.Provider, cfg ConsolidationConfig, log *slog.Logger) *ConsolidationAgent {
-	ctx, cancel := context.WithCancel(context.Background())
 	return &ConsolidationAgent{
 		store:       s,
 		llmProvider: llmProv,
 		config:      cfg,
 		log:         log,
-		ctx:         ctx,
-		cancel:      cancel,
 		triggerCh:   make(chan struct{}, 1),
 	}
 }
@@ -81,6 +78,7 @@ func (ca *ConsolidationAgent) Name() string {
 
 // Start begins the consolidation timer loop and subscribes to on-demand triggers.
 func (ca *ConsolidationAgent) Start(ctx context.Context, bus events.Bus) error {
+	ca.ctx, ca.cancel = context.WithCancel(ctx)
 	ca.bus = bus
 
 	// On-demand triggers (via triggerCh) are now managed by the reactor engine,
@@ -268,12 +266,12 @@ func (ca *ConsolidationAgent) runCycle(ctx context.Context) (*CycleReport, error
 // Memories accessed recently get less decay (recency protection).
 func (ca *ConsolidationAgent) decaySalience(ctx context.Context) (decayed, processed int, err error) {
 	// Fetch all active and fading memories
-	activeMemories, err := ca.store.ListMemories(ctx, "active", ca.config.MaxMemoriesPerCycle, 0)
+	activeMemories, err := ca.store.ListMemories(ctx, store.MemoryStateActive, ca.config.MaxMemoriesPerCycle, 0)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to list active memories: %w", err)
 	}
 
-	fadingMemories, err := ca.store.ListMemories(ctx, "fading", ca.config.MaxMemoriesPerCycle, 0)
+	fadingMemories, err := ca.store.ListMemories(ctx, store.MemoryStateFading, ca.config.MaxMemoriesPerCycle, 0)
 	if err != nil {
 		return 0, 0, fmt.Errorf("failed to list fading memories: %w", err)
 	}
@@ -352,7 +350,7 @@ func (ca *ConsolidationAgent) decaySalience(ctx context.Context) (decayed, proce
 // transitionStates moves memories between states based on salience thresholds.
 func (ca *ConsolidationAgent) transitionStates(ctx context.Context) (toFading, toArchived int, err error) {
 	// Check active memories that should become fading
-	activeMemories, err := ca.store.ListMemories(ctx, "active", ca.config.MaxMemoriesPerCycle, 0)
+	activeMemories, err := ca.store.ListMemories(ctx, store.MemoryStateActive, ca.config.MaxMemoriesPerCycle, 0)
 	if err != nil {
 		return 0, 0, err
 	}
@@ -360,13 +358,13 @@ func (ca *ConsolidationAgent) transitionStates(ctx context.Context) (toFading, t
 	for _, mem := range activeMemories {
 		if float64(mem.Salience) < ca.config.ArchiveThreshold {
 			// Skip fading, go straight to archived
-			if err := ca.store.UpdateState(ctx, mem.ID, "archived"); err != nil {
+			if err := ca.store.UpdateState(ctx, mem.ID, store.MemoryStateArchived); err != nil {
 				ca.log.Warn("failed to archive memory", "memory_id", mem.ID, "error", err)
 				continue
 			}
 			toArchived++
 		} else if float64(mem.Salience) < ca.config.FadeThreshold {
-			if err := ca.store.UpdateState(ctx, mem.ID, "fading"); err != nil {
+			if err := ca.store.UpdateState(ctx, mem.ID, store.MemoryStateFading); err != nil {
 				ca.log.Warn("failed to transition memory to fading", "memory_id", mem.ID, "error", err)
 				continue
 			}
@@ -375,14 +373,14 @@ func (ca *ConsolidationAgent) transitionStates(ctx context.Context) (toFading, t
 	}
 
 	// Check fading memories that should become archived
-	fadingMemories, err := ca.store.ListMemories(ctx, "fading", ca.config.MaxMemoriesPerCycle, 0)
+	fadingMemories, err := ca.store.ListMemories(ctx, store.MemoryStateFading, ca.config.MaxMemoriesPerCycle, 0)
 	if err != nil {
 		return toFading, toArchived, err
 	}
 
 	for _, mem := range fadingMemories {
 		if float64(mem.Salience) < ca.config.ArchiveThreshold {
-			if err := ca.store.UpdateState(ctx, mem.ID, "archived"); err != nil {
+			if err := ca.store.UpdateState(ctx, mem.ID, store.MemoryStateArchived); err != nil {
 				ca.log.Warn("failed to archive fading memory", "memory_id", mem.ID, "error", err)
 				continue
 			}
@@ -409,7 +407,7 @@ func (ca *ConsolidationAgent) pruneAssociations(ctx context.Context) (int, error
 // Uses embedding similarity to find clusters, then asks the LLM to create a unified summary.
 func (ca *ConsolidationAgent) mergeClusters(ctx context.Context) (int, error) {
 	// Get all active memories with embeddings
-	memories, err := ca.store.ListMemories(ctx, "active", ca.config.MaxMemoriesPerCycle, 0)
+	memories, err := ca.store.ListMemories(ctx, store.MemoryStateActive, ca.config.MaxMemoriesPerCycle, 0)
 	if err != nil {
 		return 0, err
 	}
@@ -604,7 +602,7 @@ Respond with ONLY a JSON object:
 		Salience:     maxSalience, // inherit highest salience
 		AccessCount:  0,
 		LastAccessed: time.Time{},
-		State:        "active",
+		State:        store.MemoryStateActive,
 		CreatedAt:    now,
 		UpdatedAt:    now,
 	}, nil
@@ -620,7 +618,7 @@ const maxPatternExtractionsPerCycle = 10
 // Groups memories by project, clusters by concept overlap (lower threshold than merge),
 // and asks the LLM if a recurring pattern exists in qualifying clusters.
 func (ca *ConsolidationAgent) extractPatterns(ctx context.Context) (int, error) {
-	memories, err := ca.store.ListMemories(ctx, "active", ca.config.MaxMemoriesPerCycle, 0)
+	memories, err := ca.store.ListMemories(ctx, store.MemoryStateActive, ca.config.MaxMemoriesPerCycle, 0)
 	if err != nil {
 		return 0, fmt.Errorf("failed to list memories for pattern extraction: %w", err)
 	}
@@ -1055,7 +1053,7 @@ If these memories are just coincidentally similar but don't reveal a real patter
 		Embedding:    embedding,
 		AccessCount:  0,
 		LastAccessed: time.Now(),
-		State:        "active",
+		State:        store.MemoryStateActive,
 		CreatedAt:    time.Now(),
 		UpdatedAt:    time.Now(),
 	}

--- a/internal/agent/consolidation/agent_test.go
+++ b/internal/agent/consolidation/agent_test.go
@@ -409,11 +409,11 @@ func TestNewConsolidationAgent(t *testing.T) {
 	if agent.config.ArchiveThreshold != cfg.ArchiveThreshold {
 		t.Errorf("expected ArchiveThreshold %f, got %f", cfg.ArchiveThreshold, agent.config.ArchiveThreshold)
 	}
-	if agent.ctx == nil {
-		t.Error("expected non-nil context")
+	if agent.ctx != nil {
+		t.Error("expected nil context before Start()")
 	}
-	if agent.cancel == nil {
-		t.Error("expected non-nil cancel func")
+	if agent.cancel != nil {
+		t.Error("expected nil cancel func before Start()")
 	}
 }
 

--- a/internal/agent/dreaming/agent.go
+++ b/internal/agent/dreaming/agent.go
@@ -48,14 +48,11 @@ type DreamReport struct {
 }
 
 func NewDreamingAgent(s store.Store, llmProv llm.Provider, cfg DreamingConfig, log *slog.Logger) *DreamingAgent {
-	ctx, cancel := context.WithCancel(context.Background())
 	return &DreamingAgent{
 		store:       s,
 		llmProvider: llmProv,
 		config:      cfg,
 		log:         log,
-		ctx:         ctx,
-		cancel:      cancel,
 		triggerCh:   make(chan struct{}, 1),
 	}
 }
@@ -65,6 +62,7 @@ func (da *DreamingAgent) Name() string {
 }
 
 func (da *DreamingAgent) Start(ctx context.Context, bus events.Bus) error {
+	da.ctx, da.cancel = context.WithCancel(ctx)
 	da.bus = bus
 	da.wg.Add(1)
 	go da.loop()

--- a/internal/agent/dreaming/agent_test.go
+++ b/internal/agent/dreaming/agent_test.go
@@ -52,8 +52,8 @@ func TestNewDreamingAgent(t *testing.T) {
 		t.Fatal("logger not set")
 	}
 
-	if agent.ctx == nil {
-		t.Fatal("context not created")
+	if agent.ctx != nil {
+		t.Fatal("expected nil context before Start()")
 	}
 }
 

--- a/internal/agent/encoding/agent.go
+++ b/internal/agent/encoding/agent.go
@@ -156,11 +156,13 @@ func NewEncodingAgent(s store.Store, llmProv llm.Provider, log *slog.Logger) *En
 
 // NewEncodingAgentWithConfig creates a new encoding agent with custom configuration.
 func NewEncodingAgentWithConfig(s store.Store, llmProv llm.Provider, log *slog.Logger, cfg EncodingConfig) *EncodingAgent {
-	ctx, cancel := context.WithCancel(context.Background())
 	semSize := cfg.MaxConcurrentEncodings
 	if semSize <= 0 {
 		semSize = 1
 	}
+	// Default context allows direct method calls in tests; Start() replaces it
+	// with a context chained from the parent.
+	ctx, cancel := context.WithCancel(context.Background())
 	ea := &EncodingAgent{
 		store:              s,
 		llmProvider:        llmProv,
@@ -197,6 +199,7 @@ func (ea *EncodingAgent) Name() string {
 // Start begins the encoding agent's work.
 // It subscribes to RawMemoryCreated events and starts a polling fallback loop.
 func (ea *EncodingAgent) Start(ctx context.Context, bus events.Bus) error {
+	ea.ctx, ea.cancel = context.WithCancel(ctx)
 	ea.bus = bus
 
 	// Subscribe to RawMemoryCreated events

--- a/internal/agent/episoding/agent.go
+++ b/internal/agent/episoding/agent.go
@@ -53,14 +53,11 @@ type EpisodingAgent struct {
 
 // NewEpisodingAgent creates a new episoding agent.
 func NewEpisodingAgent(s store.Store, llmProvider llm.Provider, log *slog.Logger, cfg EpisodingConfig) *EpisodingAgent {
-	ctx, cancel := context.WithCancel(context.Background())
 	return &EpisodingAgent{
 		store:             s,
 		llmProvider:       llmProvider,
 		config:            cfg,
 		log:               log,
-		ctx:               ctx,
-		cancel:            cancel,
 		lastProcessedTime: time.Now().Add(-1 * time.Hour), // look back 1 hour on start
 		assignedRawIDs:    make(map[string]bool),
 	}
@@ -71,6 +68,7 @@ func (ea *EpisodingAgent) Name() string {
 }
 
 func (ea *EpisodingAgent) Start(ctx context.Context, bus events.Bus) error {
+	ea.ctx, ea.cancel = context.WithCancel(ctx)
 	ea.bus = bus
 
 	// Hydrate in-memory state from existing episodes so we don't re-process
@@ -202,7 +200,7 @@ func (ea *EpisodingAgent) processEpisodes(ctx context.Context) error {
 				EndTime:      raw.Timestamp,
 				RawMemoryIDs: []string{},
 				MemoryIDs:    []string{},
-				State:        "open",
+				State:        store.EpisodeStateOpen,
 				CreatedAt:    time.Now(),
 				UpdatedAt:    time.Now(),
 			}
@@ -400,7 +398,7 @@ Respond with ONLY a JSON object (no prose, no fences):
 		ep.Salience = parsed.Salience
 	}
 
-	ep.State = "closed"
+	ep.State = store.EpisodeStateClosed
 	ep.UpdatedAt = time.Now()
 
 	if err := ea.store.UpdateEpisode(ctx, *ep); err != nil {

--- a/internal/agent/metacognition/agent.go
+++ b/internal/agent/metacognition/agent.go
@@ -31,14 +31,11 @@ type MetacognitionAgent struct {
 }
 
 func NewMetacognitionAgent(s store.Store, llmProv llm.Provider, cfg MetacognitionConfig, log *slog.Logger) *MetacognitionAgent {
-	ctx, cancel := context.WithCancel(context.Background())
 	return &MetacognitionAgent{
 		store:       s,
 		llmProvider: llmProv,
 		config:      cfg,
 		log:         log,
-		ctx:         ctx,
-		cancel:      cancel,
 		triggerCh:   make(chan struct{}, 1),
 	}
 }
@@ -48,6 +45,7 @@ func (ma *MetacognitionAgent) Name() string {
 }
 
 func (ma *MetacognitionAgent) Start(ctx context.Context, bus events.Bus) error {
+	ma.ctx, ma.cancel = context.WithCancel(ctx)
 	ma.bus = bus
 	ma.wg.Add(1)
 	go ma.loop()

--- a/internal/agent/orchestrator/orchestrator.go
+++ b/internal/agent/orchestrator/orchestrator.go
@@ -63,15 +63,12 @@ type Orchestrator struct {
 }
 
 func NewOrchestrator(s store.Store, llmProv llm.Provider, cfg OrchestratorConfig, log *slog.Logger) *Orchestrator {
-	ctx, cancel := context.WithCancel(context.Background())
 	return &Orchestrator{
 		store:       s,
 		llmProvider: llmProv,
 		config:      cfg,
 		log:         log,
 		startTime:   time.Now(),
-		ctx:         ctx,
-		cancel:      cancel,
 		llmHealthy:  true,
 	}
 }
@@ -81,6 +78,7 @@ func (o *Orchestrator) Name() string {
 }
 
 func (o *Orchestrator) Start(ctx context.Context, bus events.Bus) error {
+	o.ctx, o.cancel = context.WithCancel(ctx)
 	o.bus = bus
 
 	// Run initial health checks

--- a/internal/agent/retrieval/agent.go
+++ b/internal/agent/retrieval/agent.go
@@ -175,7 +175,7 @@ func (ra *RetrievalAgent) Query(ctx context.Context, req QueryRequest) (QueryRes
 	ra.log.Debug("spread activation completed", "query_id", queryID, "activated_memories_count", len(activated), "traversals", len(traversedAssocs))
 
 	// Step 6: Rank results by combined score
-	ranked := ra.rankResults(activated, req.IncludeReasoning)
+	ranked := ra.rankResults(ctx, activated, req.IncludeReasoning)
 
 	// Step 7: Apply project and time filters (before truncation so matching results aren't discarded)
 	if req.Project != "" || !req.TimeFrom.IsZero() || !req.TimeTo.IsZero() {
@@ -413,9 +413,9 @@ func (ra *RetrievalAgent) spreadActivation(ctx context.Context, entryPoints map[
 }
 
 // rankResults sorts activated memories by a combined score and prepares results.
-func (ra *RetrievalAgent) rankResults(activated map[string]activationState, includeReasoning bool) []store.RetrievalResult {
+func (ra *RetrievalAgent) rankResults(ctx context.Context, activated map[string]activationState, includeReasoning bool) []store.RetrievalResult {
 	type scoredMemory struct {
-		id            string
+		mem           store.Memory
 		activation    float32
 		finalScore    float32
 		recencyBonus  float32
@@ -425,7 +425,7 @@ func (ra *RetrievalAgent) rankResults(activated map[string]activationState, incl
 	scored := make([]scoredMemory, 0, len(activated))
 
 	for memID, state := range activated {
-		mem, err := ra.store.GetMemory(context.Background(), memID)
+		mem, err := ra.store.GetMemory(ctx, memID)
 		if err != nil {
 			ra.log.Warn("failed to fetch memory for ranking", "memory_id", memID, "error", err)
 			continue
@@ -447,7 +447,7 @@ func (ra *RetrievalAgent) rankResults(activated map[string]activationState, incl
 		finalScore := state.activation * (1.0 + recencyBonus + activityBonus)
 
 		// Valence boost for significant memories
-		attrs, attrErr := ra.store.GetMemoryAttributes(context.Background(), memID)
+		attrs, attrErr := ra.store.GetMemoryAttributes(ctx, memID)
 		if attrErr == nil {
 			switch attrs.Significance {
 			case "critical":
@@ -458,7 +458,7 @@ func (ra *RetrievalAgent) rankResults(activated map[string]activationState, incl
 		}
 
 		scored = append(scored, scoredMemory{
-			id:            memID,
+			mem:           mem,
 			activation:    state.activation,
 			finalScore:    finalScore,
 			recencyBonus:  recencyBonus,
@@ -471,11 +471,9 @@ func (ra *RetrievalAgent) rankResults(activated map[string]activationState, incl
 		return scored[i].finalScore > scored[j].finalScore
 	})
 
-	// Build results
+	// Build results from already-fetched memories
 	results := make([]store.RetrievalResult, len(scored))
 	for i, sm := range scored {
-		mem, _ := ra.store.GetMemory(context.Background(), sm.id)
-
 		explanation := ""
 		if includeReasoning {
 			explanation = fmt.Sprintf(
@@ -485,7 +483,7 @@ func (ra *RetrievalAgent) rankResults(activated map[string]activationState, incl
 		}
 
 		results[i] = store.RetrievalResult{
-			Memory:      mem,
+			Memory:      sm.mem,
 			Score:       sm.finalScore,
 			Explanation: explanation,
 		}

--- a/internal/api/routes/episodes.go
+++ b/internal/api/routes/episodes.go
@@ -2,6 +2,7 @@ package routes
 
 import (
 	"context"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -73,7 +74,7 @@ func HandleGetEpisode(s store.Store, log *slog.Logger) http.HandlerFunc {
 		episode, err := s.GetEpisode(ctx, id)
 		if err != nil {
 			// Check if it's a not-found error
-			if err.Error() == "not found" || err.Error() == "sql: no rows in result set" {
+			if errors.Is(err, store.ErrNotFound) {
 				log.Debug("episode not found", "episode_id", id)
 				writeError(w, http.StatusNotFound, "episode not found", "NOT_FOUND")
 				return
@@ -120,7 +121,7 @@ func HandleMemoryContext(s store.Store, log *slog.Logger) http.HandlerFunc {
 		mem, err := s.GetMemory(ctx, id)
 		if err != nil {
 			// Check if it's a not-found error
-			if err.Error() == "not found" || err.Error() == "sql: no rows in result set" {
+			if errors.Is(err, store.ErrNotFound) {
 				log.Debug("memory not found", "memory_id", id)
 				writeError(w, http.StatusNotFound, "memory not found", "NOT_FOUND")
 				return

--- a/internal/api/routes/feedback.go
+++ b/internal/api/routes/feedback.go
@@ -158,8 +158,8 @@ func HandleFeedback(s store.Store, log *slog.Logger) http.HandlerFunc {
 }
 
 // SaveRetrievalFeedback saves traversal data for a query so feedback can adjust strengths later.
-func SaveRetrievalFeedback(s store.Store, log *slog.Logger, queryID string, queryText string, retrievedIDs []string, traversedAssocs []store.TraversedAssoc) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+func SaveRetrievalFeedback(ctx context.Context, s store.Store, log *slog.Logger, queryID string, queryText string, retrievedIDs []string, traversedAssocs []store.TraversedAssoc) {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
 
 	fb := store.RetrievalFeedback{

--- a/internal/api/routes/graph.go
+++ b/internal/api/routes/graph.go
@@ -75,7 +75,7 @@ func HandleGraph(s store.Store, log *slog.Logger) http.HandlerFunc {
 
 		if view == "episodes" {
 			// Fetch episodes as nodes
-			episodes, err := s.ListEpisodes(ctx, "closed", limit, 0)
+			episodes, err := s.ListEpisodes(ctx, store.EpisodeStateClosed, limit, 0)
 			if err != nil {
 				log.Error("failed to list episodes for graph", "error", err)
 				writeError(w, http.StatusInternalServerError, "failed to list episodes", "STORE_ERROR")

--- a/internal/api/routes/memories.go
+++ b/internal/api/routes/memories.go
@@ -3,6 +3,7 @@ package routes
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"log/slog"
 	"net/http"
 	"strconv"
@@ -29,7 +30,7 @@ func HandleGetRawMemory(s store.Store, log *slog.Logger) http.HandlerFunc {
 
 		raw, err := s.GetRaw(ctx, id)
 		if err != nil {
-			if err.Error() == "not found" || err.Error() == "sql: no rows in result set" {
+			if errors.Is(err, store.ErrNotFound) {
 				writeError(w, http.StatusNotFound, "raw memory not found", "NOT_FOUND")
 				return
 			}
@@ -263,7 +264,7 @@ func HandleGetMemory(s store.Store, log *slog.Logger) http.HandlerFunc {
 		memory, err := s.GetMemory(ctx, id)
 		if err != nil {
 			// Check if it's a not-found error
-			if err.Error() == "not found" || err.Error() == "sql: no rows in result set" {
+			if errors.Is(err, store.ErrNotFound) {
 				log.Debug("memory not found", "memory_id", id)
 				writeError(w, http.StatusNotFound, "memory not found", "NOT_FOUND")
 				return

--- a/internal/api/routes/query.go
+++ b/internal/api/routes/query.go
@@ -86,7 +86,7 @@ func HandleQuery(retriever *retrieval.RetrievalAgent, bus events.Bus, s store.St
 		for _, mem := range queryResp.Memories {
 			retrievedIDs = append(retrievedIDs, mem.Memory.ID)
 		}
-		SaveRetrievalFeedback(s, log, queryResp.QueryID, reqBody.Query, retrievedIDs, queryResp.TraversedAssocs)
+		SaveRetrievalFeedback(ctx, s, log, queryResp.QueryID, reqBody.Query, retrievedIDs, queryResp.TraversedAssocs)
 
 		// Publish query executed event
 		queryEvt := events.QueryExecuted{

--- a/internal/api/routes/routes_test.go
+++ b/internal/api/routes/routes_test.go
@@ -656,7 +656,7 @@ func TestHandleGetMemory(t *testing.T) {
 		ms := &mockStore{
 			getMemoryFn: func(_ context.Context, id string) (store.Memory, error) {
 				if id != "mem-abc-123" {
-					return store.Memory{}, fmt.Errorf("not found")
+					return store.Memory{}, store.ErrNotFound
 				}
 				return expected, nil
 			},
@@ -694,7 +694,7 @@ func TestHandleGetMemoryNotFound(t *testing.T) {
 	t.Run("missing ID returns 404", func(t *testing.T) {
 		ms := &mockStore{
 			getMemoryFn: func(_ context.Context, id string) (store.Memory, error) {
-				return store.Memory{}, fmt.Errorf("not found")
+				return store.Memory{}, store.ErrNotFound
 			},
 		}
 		handler := HandleGetMemory(ms, testLogger())

--- a/internal/api/routes/system.go
+++ b/internal/api/routes/system.go
@@ -28,7 +28,7 @@ func HandleHealth(s store.Store, llmProv llm.Provider, log *slog.Logger) http.Ha
 		log.Debug("health check requested")
 
 		// Check LLM health with 2s timeout
-		llmHealthCtx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+		llmHealthCtx, cancel := context.WithTimeout(r.Context(), 2*time.Second)
 		defer cancel()
 
 		llmAvailable := true

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -44,6 +44,7 @@ type MCPServer struct {
 	retriever       *retrieval.RetrievalAgent
 	bus             events.Bus
 	log             *slog.Logger
+	version         string // binary version, injected from main
 	sessionID       string // auto-generated per MCP server lifetime
 	project         string // auto-detected from working directory
 	coachingFile    string // path for coach_local_llm writes
@@ -52,7 +53,7 @@ type MCPServer struct {
 }
 
 // NewMCPServer creates a new MCP server with the given dependencies.
-func NewMCPServer(s store.Store, r *retrieval.RetrievalAgent, bus events.Bus, log *slog.Logger, coachingFile string, excludePatterns []string, maxContentBytes int) *MCPServer {
+func NewMCPServer(s store.Store, r *retrieval.RetrievalAgent, bus events.Bus, log *slog.Logger, version string, coachingFile string, excludePatterns []string, maxContentBytes int) *MCPServer {
 	// Auto-detect project from working directory
 	project := detectProject()
 
@@ -66,6 +67,7 @@ func NewMCPServer(s store.Store, r *retrieval.RetrievalAgent, bus events.Bus, lo
 		retriever:       r,
 		bus:             bus,
 		log:             log,
+		version:         version,
 		sessionID:       sessionID,
 		project:         project,
 		coachingFile:    coachingFile,
@@ -150,7 +152,7 @@ func (srv *MCPServer) handleInitialize(req *jsonRPCRequest) *jsonRPCResponse {
 		},
 		"serverInfo": map[string]interface{}{
 			"name":    "mnemonic",
-			"version": "1.0.0",
+			"version": srv.version,
 		},
 	}
 	return successResponse(req.ID, result)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -210,7 +210,7 @@ func (m *mockBus) Close() error                      { return nil }
 // TestHandleInitialize tests handleInitialize returns correct protocol version and server info.
 func TestHandleInitialize(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	srv := NewMCPServer(&mockStore{}, nil, &mockBus{}, logger, "", []string{}, 0)
+	srv := NewMCPServer(&mockStore{}, nil, &mockBus{}, logger, "test", "", []string{}, 0)
 
 	req := &jsonRPCRequest{
 		JSONRPC: "2.0",
@@ -260,8 +260,8 @@ func TestHandleInitialize(t *testing.T) {
 		if serverInfoMap["name"] != "mnemonic" {
 			t.Fatalf("expected server name 'mnemonic', got %v", serverInfoMap["name"])
 		}
-		if serverInfoMap["version"] != "1.0.0" {
-			t.Fatalf("expected server version '1.0.0', got %v", serverInfoMap["version"])
+		if serverInfoMap["version"] != "test" {
+			t.Fatalf("expected server version 'test', got %v", serverInfoMap["version"])
 		}
 	}
 }
@@ -269,7 +269,7 @@ func TestHandleInitialize(t *testing.T) {
 // TestHandleToolsList tests handleToolsList returns all 10 tools.
 func TestHandleToolsList(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	srv := NewMCPServer(&mockStore{}, nil, &mockBus{}, logger, "", []string{}, 0)
+	srv := NewMCPServer(&mockStore{}, nil, &mockBus{}, logger, "test", "", []string{}, 0)
 
 	req := &jsonRPCRequest{
 		JSONRPC: "2.0",
@@ -469,7 +469,7 @@ func TestSuccessResponse(t *testing.T) {
 // TestHandleRequestDispatch tests that handleRequest correctly dispatches to handlers.
 func TestHandleRequestDispatch(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	srv := NewMCPServer(&mockStore{}, nil, &mockBus{}, logger, "", []string{}, 0)
+	srv := NewMCPServer(&mockStore{}, nil, &mockBus{}, logger, "test", "", []string{}, 0)
 
 	tests := []struct {
 		method  string

--- a/internal/store/sqlite/abstractions.go
+++ b/internal/store/sqlite/abstractions.go
@@ -90,7 +90,7 @@ func (s *SQLiteStore) UpdateAbstraction(ctx context.Context, a store.Abstraction
 
 	rowsAffected, _ := result.RowsAffected()
 	if rowsAffected == 0 {
-		return fmt.Errorf("abstraction with id %s not found", a.ID)
+		return fmt.Errorf("abstraction with id %s: %w", a.ID, store.ErrNotFound)
 	}
 	return nil
 }
@@ -192,7 +192,7 @@ func scanAbstraction(row *sql.Row) (store.Abstraction, error) {
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return a, fmt.Errorf("abstraction not found")
+			return a, fmt.Errorf("abstraction: %w", store.ErrNotFound)
 		}
 		return a, fmt.Errorf("failed to scan abstraction: %w", err)
 	}

--- a/internal/store/sqlite/episodes.go
+++ b/internal/store/sqlite/episodes.go
@@ -160,7 +160,7 @@ func scanEpisode(row *sql.Row) (store.Episode, error) {
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return ep, fmt.Errorf("episode not found")
+			return ep, fmt.Errorf("episode: %w", store.ErrNotFound)
 		}
 		return ep, fmt.Errorf("failed to scan episode: %w", err)
 	}

--- a/internal/store/sqlite/patterns.go
+++ b/internal/store/sqlite/patterns.go
@@ -88,7 +88,7 @@ func (s *SQLiteStore) UpdatePattern(ctx context.Context, p store.Pattern) error 
 
 	rowsAffected, _ := result.RowsAffected()
 	if rowsAffected == 0 {
-		return fmt.Errorf("pattern with id %s not found", p.ID)
+		return fmt.Errorf("pattern with id %s: %w", p.ID, store.ErrNotFound)
 	}
 	return nil
 }
@@ -201,7 +201,7 @@ func scanPattern(row *sql.Row) (store.Pattern, error) {
 	)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return p, fmt.Errorf("pattern not found")
+			return p, fmt.Errorf("pattern: %w", store.ErrNotFound)
 		}
 		return p, fmt.Errorf("failed to scan pattern: %w", err)
 	}

--- a/internal/store/sqlite/resolutions.go
+++ b/internal/store/sqlite/resolutions.go
@@ -38,7 +38,7 @@ func (s *SQLiteStore) GetMemoryResolution(ctx context.Context, memoryID string) 
 	).Scan(&res.MemoryID, &gist, &narrative, &detailIDsStr, &createdStr)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return res, fmt.Errorf("memory resolution not found for %s", memoryID)
+			return res, fmt.Errorf("memory resolution for %s: %w", memoryID, store.ErrNotFound)
 		}
 		return res, fmt.Errorf("failed to get memory resolution: %w", err)
 	}
@@ -87,7 +87,7 @@ func (s *SQLiteStore) GetConceptSet(ctx context.Context, memoryID string) (store
 	).Scan(&cs.MemoryID, &topicsStr, &entitiesStr, &actionsStr, &causalityStr, &significance, &createdStr)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return cs, fmt.Errorf("concept set not found for %s", memoryID)
+			return cs, fmt.Errorf("concept set for %s: %w", memoryID, store.ErrNotFound)
 		}
 		return cs, fmt.Errorf("failed to get concept set: %w", err)
 	}
@@ -202,7 +202,7 @@ func (s *SQLiteStore) GetMemoryAttributes(ctx context.Context, memoryID string) 
 	).Scan(&attrs.MemoryID, &significance, &emotionalTone, &outcome, &causalityNotes, &createdStr)
 	if err != nil {
 		if err == sql.ErrNoRows {
-			return attrs, fmt.Errorf("memory attributes not found for %s", memoryID)
+			return attrs, fmt.Errorf("memory attributes for %s: %w", memoryID, store.ErrNotFound)
 		}
 		return attrs, fmt.Errorf("failed to get memory attributes: %w", err)
 	}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -28,6 +29,9 @@ func NewSQLiteStore(dbPath string) (*SQLiteStore, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to open database: %w", err)
 	}
+
+	// SQLite only supports one writer — limit Go's pool to avoid lock contention
+	db.SetMaxOpenConns(1)
 
 	// Test the connection
 	if err := db.Ping(); err != nil {
@@ -208,14 +212,6 @@ func scanRawMemory(row *sql.Row) (store.RawMemory, error) {
 		raw.Metadata = make(map[string]interface{})
 	}
 
-	// Parse timestamps
-	if raw.Timestamp.IsZero() {
-		raw.Timestamp, _ = time.Parse(time.RFC3339, raw.Timestamp.Format(time.RFC3339))
-	}
-	if raw.CreatedAt.IsZero() {
-		raw.CreatedAt, _ = time.Parse(time.RFC3339, raw.CreatedAt.Format(time.RFC3339))
-	}
-
 	return raw, nil
 }
 
@@ -360,17 +356,6 @@ func scanMemory(row *sql.Row) (store.Memory, error) {
 		if err == nil {
 			mem.LastAccessed = lastAccessed
 		}
-	}
-
-	// Parse timestamps
-	if !mem.Timestamp.IsZero() {
-		mem.Timestamp, _ = time.Parse(time.RFC3339, mem.Timestamp.Format(time.RFC3339))
-	}
-	if !mem.CreatedAt.IsZero() {
-		mem.CreatedAt, _ = time.Parse(time.RFC3339, mem.CreatedAt.Format(time.RFC3339))
-	}
-	if !mem.UpdatedAt.IsZero() {
-		mem.UpdatedAt, _ = time.Parse(time.RFC3339, mem.UpdatedAt.Format(time.RFC3339))
 	}
 
 	return mem, nil
@@ -615,7 +600,7 @@ func (s *SQLiteStore) MarkRawProcessed(ctx context.Context, id string) error {
 	}
 
 	if rowsAffected == 0 {
-		return fmt.Errorf("raw memory with id %s not found", id)
+		return fmt.Errorf("raw memory with id %s: %w", id, store.ErrNotFound)
 	}
 
 	return nil
@@ -677,7 +662,7 @@ func (s *SQLiteStore) WriteMemory(ctx context.Context, mem store.Memory) error {
 	}
 
 	// Update in-memory embedding index
-	if (mem.State == "active" || mem.State == "fading") && len(mem.Embedding) > 0 {
+	if (mem.State == store.MemoryStateActive || mem.State == store.MemoryStateFading) && len(mem.Embedding) > 0 {
 		s.embIndex.Add(mem.ID, mem.Embedding)
 	}
 
@@ -754,11 +739,11 @@ func (s *SQLiteStore) UpdateMemory(ctx context.Context, mem store.Memory) error 
 	}
 
 	if rowsAffected == 0 {
-		return fmt.Errorf("memory with id %s not found", mem.ID)
+		return fmt.Errorf("memory with id %s: %w", mem.ID, store.ErrNotFound)
 	}
 
 	// Update in-memory embedding index
-	if (mem.State == "active" || mem.State == "fading") && len(mem.Embedding) > 0 {
+	if (mem.State == store.MemoryStateActive || mem.State == store.MemoryStateFading) && len(mem.Embedding) > 0 {
 		s.embIndex.Add(mem.ID, mem.Embedding)
 	} else {
 		// State changed away from searchable, or embedding removed
@@ -784,7 +769,7 @@ func (s *SQLiteStore) UpdateSalience(ctx context.Context, id string, salience fl
 	}
 
 	if rowsAffected == 0 {
-		return fmt.Errorf("memory with id %s not found", id)
+		return fmt.Errorf("memory with id %s: %w", id, store.ErrNotFound)
 	}
 
 	return nil
@@ -805,11 +790,11 @@ func (s *SQLiteStore) UpdateState(ctx context.Context, id string, state string) 
 	}
 
 	if rowsAffected == 0 {
-		return fmt.Errorf("memory with id %s not found", id)
+		return fmt.Errorf("memory with id %s: %w", id, store.ErrNotFound)
 	}
 
 	// Remove from embedding index if state moved away from searchable
-	if state != "active" && state != "fading" {
+	if state != store.MemoryStateActive && state != store.MemoryStateFading {
 		s.embIndex.Remove(id)
 	}
 
@@ -831,7 +816,7 @@ func (s *SQLiteStore) IncrementAccess(ctx context.Context, id string) error {
 	}
 
 	if rowsAffected == 0 {
-		return fmt.Errorf("memory with id %s not found", id)
+		return fmt.Errorf("memory with id %s: %w", id, store.ErrNotFound)
 	}
 
 	return nil
@@ -954,19 +939,41 @@ func (s *SQLiteStore) SearchByEmbedding(ctx context.Context, embedding []float32
 		return []store.RetrievalResult{}, nil
 	}
 
-	// Fetch only the matched memories from DB by ID
-	results := make([]store.RetrievalResult, 0, len(matches))
-	for _, m := range matches {
-		mem, err := s.GetMemory(ctx, m.id)
-		if err != nil {
-			continue // Memory may have been deleted between index search and fetch
-		}
-		results = append(results, store.RetrievalResult{
-			Memory:      mem,
-			Score:       m.score,
-			Explanation: "Embedding similarity",
-		})
+	// Batch-fetch all matched memories in a single query
+	placeholders := make([]string, len(matches))
+	args := make([]interface{}, len(matches))
+	scoreByID := make(map[string]float32, len(matches))
+	orderByID := make(map[string]int, len(matches))
+	for i, m := range matches {
+		placeholders[i] = "?"
+		args[i] = m.id
+		scoreByID[m.id] = m.score
+		orderByID[m.id] = i
 	}
+
+	query := `SELECT ` + memoryColumns + ` FROM memories WHERE id IN (` + strings.Join(placeholders, ",") + `)`
+	rows, err := s.db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, fmt.Errorf("batch fetch memories: %w", err)
+	}
+
+	memories, err := scanMemoryRows(rows)
+	if err != nil {
+		return nil, fmt.Errorf("scan batch memories: %w", err)
+	}
+
+	// Build results preserving embedding-similarity order
+	results := make([]store.RetrievalResult, len(memories))
+	for i, mem := range memories {
+		results[i] = store.RetrievalResult{
+			Memory:      mem,
+			Score:       scoreByID[mem.ID],
+			Explanation: "Embedding similarity",
+		}
+	}
+	sort.Slice(results, func(i, j int) bool {
+		return orderByID[results[i].Memory.ID] < orderByID[results[j].Memory.ID]
+	})
 
 	return results, nil
 }
@@ -1105,7 +1112,7 @@ func (s *SQLiteStore) UpdateAssociationStrength(ctx context.Context, sourceID, t
 	}
 
 	if rowsAffected == 0 {
-		return fmt.Errorf("association from %s to %s not found", sourceID, targetID)
+		return fmt.Errorf("association from %s to %s: %w", sourceID, targetID, store.ErrNotFound)
 	}
 
 	return nil
@@ -1126,7 +1133,7 @@ func (s *SQLiteStore) UpdateAssociationType(ctx context.Context, sourceID, targe
 	}
 
 	if rowsAffected == 0 {
-		return fmt.Errorf("association from %s to %s not found", sourceID, targetID)
+		return fmt.Errorf("association from %s to %s: %w", sourceID, targetID, store.ErrNotFound)
 	}
 
 	return nil
@@ -1147,7 +1154,7 @@ func (s *SQLiteStore) ActivateAssociation(ctx context.Context, sourceID, targetI
 	}
 
 	if rowsAffected == 0 {
-		return fmt.Errorf("association from %s to %s not found", sourceID, targetID)
+		return fmt.Errorf("association from %s to %s: %w", sourceID, targetID, store.ErrNotFound)
 	}
 
 	return nil
@@ -1262,7 +1269,7 @@ func (s *SQLiteStore) BatchMergeMemories(ctx context.Context, sourceIDs []string
 	now := time.Now().Format(time.RFC3339)
 
 	for _, sourceID := range sourceIDs {
-		_, err := tx.ExecContext(ctx, updateStateQuery, "merged", now, sourceID)
+		_, err := tx.ExecContext(ctx, updateStateQuery, store.MemoryStateMerged, now, sourceID)
 		if err != nil {
 			return fmt.Errorf("failed to update state for source id %s: %w", sourceID, err)
 		}
@@ -1357,7 +1364,7 @@ func (s *SQLiteStore) BatchMergeMemories(ctx context.Context, sourceIDs []string
 	for _, sourceID := range sourceIDs {
 		s.embIndex.Remove(sourceID)
 	}
-	if (gist.State == "active" || gist.State == "fading") && len(gist.Embedding) > 0 {
+	if (gist.State == store.MemoryStateActive || gist.State == store.MemoryStateFading) && len(gist.Embedding) > 0 {
 		s.embIndex.Add(gist.ID, gist.Embedding)
 	}
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -2,7 +2,25 @@ package store
 
 import (
 	"context"
+	"errors"
 	"time"
+)
+
+// ErrNotFound is returned when a requested entity does not exist.
+var ErrNotFound = errors.New("not found")
+
+// Memory state constants.
+const (
+	MemoryStateActive   = "active"
+	MemoryStateFading   = "fading"
+	MemoryStateArchived = "archived"
+	MemoryStateMerged   = "merged"
+)
+
+// Episode state constants.
+const (
+	EpisodeStateOpen   = "open"
+	EpisodeStateClosed = "closed"
 )
 
 // RawMemory is a raw observation before encoding.


### PR DESCRIPTION
## Summary
- **Sentinel errors**: Replace string-matching "not found" errors with `store.ErrNotFound` sentinel, use `errors.Is()` throughout agents and API routes
- **Magic string cleanup**: Extract memory state strings (`"active"`, `"fading"`, etc.) into `store` constants used across all agents
- **N+1 query fix**: Batch-fetch embedding search results in a single `WHERE id IN (...)` query instead of individual `GetMemory()` calls per result
- **Connection pooling**: Set `SQLite MaxOpenConns(1)` to prevent write lock contention (SQLite only supports one writer)
- **Dead code removal**: Remove no-op timestamp re-parsing in scan functions
- **MCP version**: Add binary version field to MCP server for protocol compliance
- **Error wrapping**: Use `%w` consistently across the store layer for proper error chain inspection

## Test plan
- [x] `make build` succeeds
- [x] `make test` — all tests pass
- [ ] Manual: verify MCP tools still work via Claude Code
- [ ] Manual: confirm daemon starts and serves queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)