### PR TITLE
Fix noisy memory ingestion quality

### DIFF
--- a/cmd/mnemonic/main.go
+++ b/cmd/mnemonic/main.go
@@ -141,6 +141,8 @@ func main() {
 		dreamCycleCommand(*configPath)
 	case "purge":
 		purgeCommand(*configPath)
+	case "cleanup":
+		cleanupCommand(*configPath, args)
 	case "mcp":
 		mcpCommand(*configPath)
 	case "autopilot":
@@ -898,6 +900,7 @@ func serveCommand(configPath string) {
 			MaxConcurrentEncodings:  cfg.Encoding.MaxConcurrentEncodings,
 			EnableLLMClassification: cfg.Encoding.EnableLLMClassification,
 			CoachingFile:            cfg.Coaching.CoachingFile,
+			ExcludePatterns:         cfg.Perception.Filesystem.ExcludePatterns,
 		})
 		if err := encoder.Start(rootCtx, bus); err != nil {
 			log.Error("failed to start encoding agent", "error", err)
@@ -1345,6 +1348,7 @@ func rememberCommand(configPath, text string) {
 		MaxConcurrentEncodings:  cfg.Encoding.MaxConcurrentEncodings,
 		EnableLLMClassification: cfg.Encoding.EnableLLMClassification,
 		CoachingFile:            cfg.Coaching.CoachingFile,
+		ExcludePatterns:         cfg.Perception.Filesystem.ExcludePatterns,
 	})
 	if err := encoder.Start(encodeCtx, bus); err != nil {
 		fmt.Fprintf(os.Stderr, "Error starting encoder: %v\n", err)
@@ -1679,6 +1683,78 @@ func purgeCommand(configPath string) {
 }
 
 // ============================================================================
+// Cleanup Command (selective noise removal)
+// ============================================================================
+
+// cleanupCommand scans raw_memories for paths matching exclude patterns and
+// bulk-marks them as processed, then archives any encoded memories derived from them.
+func cleanupCommand(configPath string, args []string) {
+	cfg, db, _, _ := initRuntime(configPath)
+	defer db.Close()
+
+	ctx := context.Background()
+
+	patterns := cfg.Perception.Filesystem.ExcludePatterns
+	if len(patterns) == 0 {
+		fmt.Println("No exclude patterns configured in config.yaml — nothing to clean.")
+		return
+	}
+
+	// Check for --yes flag
+	autoConfirm := false
+	for _, a := range args {
+		if a == "--yes" || a == "-y" {
+			autoConfirm = true
+		}
+	}
+
+	// Count what would be cleaned
+	rawCount, err := db.CountRawUnprocessedByPathPatterns(ctx, patterns)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error counting raw memories: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("%sCleanup Summary%s\n", colorBold, colorReset)
+	fmt.Printf("  Exclude patterns:       %d (from config.yaml)\n", len(patterns))
+	fmt.Printf("  Unprocessed raw events:  %s%d%s matching exclude patterns\n", colorYellow, rawCount, colorReset)
+
+	if rawCount == 0 {
+		fmt.Println("\nNothing to clean up.")
+		return
+	}
+
+	if !autoConfirm {
+		fmt.Printf("\nThis will mark matching raw events as processed and archive derived memories.\n")
+		fmt.Printf("Type 'yes' to confirm: ")
+		var confirmation string
+		_, _ = fmt.Scanln(&confirmation)
+		if confirmation != "yes" {
+			fmt.Println("Aborted.")
+			return
+		}
+	}
+
+	// Mark raw events as processed
+	rawCleaned, err := db.BulkMarkRawProcessedByPathPatterns(ctx, patterns)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error cleaning raw memories: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Archive derived encoded memories
+	memArchived, err := db.ArchiveMemoriesByRawPathPatterns(ctx, patterns)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "Error archiving memories: %v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("\n%sCleanup complete%s\n", colorGreen, colorReset)
+	fmt.Printf("  Raw events marked processed:  %d\n", rawCleaned)
+	fmt.Printf("  Encoded memories archived:    %d\n", memArchived)
+}
+
+// ============================================================================
 // Insights Command (metacognition)
 // ============================================================================
 
@@ -1867,6 +1943,7 @@ func mcpCommand(configPath string) {
 		MaxConcurrentEncodings:  cfg.Encoding.MaxConcurrentEncodings,
 		EnableLLMClassification: cfg.Encoding.EnableLLMClassification,
 		CoachingFile:            cfg.Coaching.CoachingFile,
+		ExcludePatterns:         cfg.Perception.Filesystem.ExcludePatterns,
 	})
 	if err := encoder.Start(ctx, bus); err != nil {
 		log.Error("failed to start encoding agent for MCP", "error", err)
@@ -1932,6 +2009,7 @@ DATA MANAGEMENT:
   export          Export memories (--format json|sqlite, --output path)
   import FILE     Import from JSON export (--mode merge|replace)
   backup          Timestamped backup with retention (keeps last 5)
+  cleanup         Remove noise: mark excluded-path raw events as processed (--yes)
   purge           Stop daemon and delete all data (fresh start)
   insights        Show metacognition observations (memory health)
   meta-cycle      Run a single metacognition analysis cycle

--- a/internal/agent/consolidation/agent_test.go
+++ b/internal/agent/consolidation/agent_test.go
@@ -292,6 +292,15 @@ func (m *mockStore) ListProjects(ctx context.Context) ([]string, error) { return
 func (m *mockStore) RawMemoryExistsByPath(ctx context.Context, source string, project string, filePath string) (bool, error) {
 	return false, nil
 }
+func (m *mockStore) CountRawUnprocessedByPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	return 0, nil
+}
+func (m *mockStore) BulkMarkRawProcessedByPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	return 0, nil
+}
+func (m *mockStore) ArchiveMemoriesByRawPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	return 0, nil
+}
 func (m *mockStore) BatchWriteRaw(ctx context.Context, raws []store.RawMemory) error { return nil }
 
 // --- Lifecycle ---

--- a/internal/agent/dreaming/agent_test.go
+++ b/internal/agent/dreaming/agent_test.go
@@ -441,6 +441,15 @@ func (m *mockStore) ListProjects(ctx context.Context) ([]string, error) { return
 func (m *mockStore) RawMemoryExistsByPath(ctx context.Context, source string, project string, filePath string) (bool, error) {
 	return false, nil
 }
+func (m *mockStore) CountRawUnprocessedByPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	return 0, nil
+}
+func (m *mockStore) BulkMarkRawProcessedByPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	return 0, nil
+}
+func (m *mockStore) ArchiveMemoriesByRawPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	return 0, nil
+}
 
 func (m *mockStore) BatchWriteRaw(ctx context.Context, raws []store.RawMemory) error {
 	return nil

--- a/internal/agent/encoding/agent.go
+++ b/internal/agent/encoding/agent.go
@@ -16,6 +16,7 @@ import (
 	"github.com/appsprout/mnemonic/internal/events"
 	"github.com/appsprout/mnemonic/internal/llm"
 	"github.com/appsprout/mnemonic/internal/store"
+	"github.com/appsprout/mnemonic/internal/watcher/filesystem"
 )
 
 // maxRetries is the number of encoding attempts before a raw memory is skipped.
@@ -53,9 +54,10 @@ type EncodingConfig struct {
 	CompletionModel         string
 	CompletionMaxTokens     int
 	CompletionTemperature   float32
-	MaxConcurrentEncodings  int    // max concurrent LLM encoding calls (default 1 for local models)
-	EnableLLMClassification bool   // if true, use LLM to reclassify "similar" associations in background
-	CoachingFile            string // path to coaching.yaml; empty = no coaching
+	MaxConcurrentEncodings  int      // max concurrent LLM encoding calls (default 1 for local models)
+	EnableLLMClassification bool     // if true, use LLM to reclassify "similar" associations in background
+	CoachingFile            string   // path to coaching.yaml; empty = no coaching
+	ExcludePatterns         []string // paths matching these patterns are skipped (defense-in-depth)
 }
 
 // DefaultConfig returns sensible defaults for encoding configuration.
@@ -369,6 +371,19 @@ func (ea *EncodingAgent) pollAndProcessRawMemories(ctx context.Context) error {
 	consecutiveFailures := 0
 
 	for _, raw := range unprocessed {
+		// Defense-in-depth: skip raw memories whose path matches an exclude pattern.
+		// These should have been filtered at the watcher/perception layer, but if
+		// they leaked through (e.g., added before patterns existed), catch them here.
+		if path, ok := raw.Metadata["path"]; ok {
+			if pathStr, ok := path.(string); ok && pathStr != "" {
+				if filesystem.MatchesExcludePattern(pathStr, ea.config.ExcludePatterns) {
+					ea.log.Debug("skipping excluded path", "raw_id", raw.ID, "path", pathStr)
+					_ = ea.store.MarkRawProcessed(ctx, raw.ID)
+					continue
+				}
+			}
+		}
+
 		// Skip memories that have exceeded max retries
 		ea.processingMutex.Lock()
 		retries := ea.failureCounts[raw.ID]

--- a/internal/agent/encoding/agent_test.go
+++ b/internal/agent/encoding/agent_test.go
@@ -248,6 +248,15 @@ func (m *mockStore) ListProjects(ctx context.Context) ([]string, error) { return
 func (m *mockStore) RawMemoryExistsByPath(ctx context.Context, source string, project string, filePath string) (bool, error) {
 	return false, nil
 }
+func (m *mockStore) CountRawUnprocessedByPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	return 0, nil
+}
+func (m *mockStore) BulkMarkRawProcessedByPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	return 0, nil
+}
+func (m *mockStore) ArchiveMemoriesByRawPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	return 0, nil
+}
 func (m *mockStore) BatchWriteRaw(ctx context.Context, raws []store.RawMemory) error { return nil }
 
 func (m *mockStore) Close() error { return nil }
@@ -1592,6 +1601,78 @@ func TestPollAndProcessRawMemories(t *testing.T) {
 			t.Errorf("expected 'failed to list unprocessed' in error, got %q", err.Error())
 		}
 	})
+}
+
+func TestPollAndProcessRawMemories_SkipsExcludedPaths(t *testing.T) {
+	var mu sync.Mutex
+	markedProcessed := make(map[string]bool)
+	encodedIDs := make(map[string]bool)
+
+	ms := &mockStore{
+		listRawUnprocessedFn: func(_ context.Context, limit int) ([]store.RawMemory, error) {
+			return []store.RawMemory{
+				{
+					ID: "venv-1", Content: "pip config", Source: "filesystem", Type: "file_modified",
+					Metadata: map[string]interface{}{"path": "/home/user/Projects/foo/.venv/lib/python3.12/site-packages/pip/config.py"},
+				},
+				{
+					ID: "good-1", Content: "real code", Source: "user", Type: "explicit",
+					Metadata: map[string]interface{}{"path": "/home/user/Projects/foo/main.go"},
+				},
+			}, nil
+		},
+		getRawFn: func(_ context.Context, id string) (store.RawMemory, error) {
+			return store.RawMemory{ID: id, Content: "content", Source: "user", Type: "explicit"}, nil
+		},
+		writeMemoryFn: func(_ context.Context, mem store.Memory) error {
+			mu.Lock()
+			encodedIDs[mem.RawID] = true
+			mu.Unlock()
+			return nil
+		},
+		markRawProcessedFn: func(_ context.Context, id string) error {
+			mu.Lock()
+			markedProcessed[id] = true
+			mu.Unlock()
+			return nil
+		},
+	}
+
+	compressionJSON := `{"summary": "test", "content": "test", "concepts": ["test"], "salience": 0.5}`
+	llmProv := &mockLLMProvider{
+		completeFn: func(_ context.Context, req llm.CompletionRequest) (llm.CompletionResponse, error) {
+			return llm.CompletionResponse{Content: compressionJSON}, nil
+		},
+	}
+
+	bus := newMockBus()
+	agent := NewEncodingAgentWithConfig(ms, llmProv, testLogger(), EncodingConfig{
+		ExcludePatterns: []string{"venv/", ".venv/", "site-packages/", "node_modules/"},
+	})
+	agent.bus = bus
+
+	err := agent.pollAndProcessRawMemories(context.Background())
+	if err != nil {
+		t.Fatalf("pollAndProcessRawMemories failed: %v", err)
+	}
+
+	agent.wg.Wait()
+
+	mu.Lock()
+	defer mu.Unlock()
+
+	// venv-1 should be marked processed but NOT encoded
+	if !markedProcessed["venv-1"] {
+		t.Error("expected venv-1 to be marked processed (skipped)")
+	}
+	if encodedIDs["venv-1"] {
+		t.Error("expected venv-1 to NOT be encoded")
+	}
+
+	// good-1 should be encoded
+	if !encodedIDs["good-1"] {
+		t.Error("expected good-1 to be encoded")
+	}
 }
 
 // ---------------------------------------------------------------------------

--- a/internal/agent/perception/heuristic.go
+++ b/internal/agent/perception/heuristic.go
@@ -140,7 +140,17 @@ func (h *HeuristicFilter) Evaluate(event Event) HeuristicResult {
 	}
 
 	// 4. Source-specific heuristics and base score
-	score, sourceRationale := h.evaluateSource(event.Source, event.Type, event.Path, event.Content)
+	score, sourceRationale, hardReject := h.evaluateSource(event.Source, event.Type, event.Path, event.Content)
+
+	// Hard rejection: source-level filter says this event should never be remembered,
+	// regardless of keyword content. Do not allow keyword scoring to override.
+	if hardReject {
+		return HeuristicResult{
+			Pass:      false,
+			Score:     0.0,
+			Rationale: sourceRationale,
+		}
+	}
 
 	// 4b. Recall-aware salience boost for filesystem events
 	if event.Source == "filesystem" && event.Path != "" {
@@ -225,8 +235,9 @@ func (h *HeuristicFilter) checkAndRecordFrequency(contentHash string) bool {
 	return true
 }
 
-// evaluateSource returns a base score and rationale based on the event source.
-func (h *HeuristicFilter) evaluateSource(source, eventType, path, content string) (float32, string) {
+// evaluateSource returns a base score, rationale, and whether the event should
+// be hard-rejected (no keyword scoring can override it).
+func (h *HeuristicFilter) evaluateSource(source, eventType, path, content string) (float32, string, bool) {
 	switch source {
 	case "filesystem":
 		return h.evaluateFilesystem(path, content)
@@ -238,23 +249,22 @@ func (h *HeuristicFilter) evaluateSource(source, eventType, path, content string
 		return h.evaluateMCP(eventType, content)
 	default:
 		// Unknown source: neutral score
-		return 0.3, fmt.Sprintf("source=%s", source)
+		return 0.3, fmt.Sprintf("source=%s", source), false
 	}
 }
 
 // evaluateFilesystem scores filesystem events.
-func (h *HeuristicFilter) evaluateFilesystem(path, content string) (float32, string) {
-	// Skip if path contains ignored patterns
+func (h *HeuristicFilter) evaluateFilesystem(path, content string) (float32, string, bool) {
+	// Skip if path contains ignored patterns — hard reject, no keyword override
 	ignoredPatterns := []string{".git/", "node_modules/", "__pycache__/", ".DS_Store", "~", ".swp", ".tmp", ".xbel",
 		"venv/", ".venv/", "site-packages/", ".tox/", ".mypy_cache/", ".ruff_cache/", ".pytest_cache/"}
 	for _, pattern := range ignoredPatterns {
 		if strings.Contains(path, pattern) {
-			return 0.0, fmt.Sprintf("filesystem: ignored path pattern '%s'", pattern)
+			return 0.0, fmt.Sprintf("filesystem: ignored path pattern '%s'", pattern), true
 		}
 	}
 
-	// Suppress application-internal state directories — these produce high-volume
-	// noise that is never useful for memory (browser storage, desktop state, etc.)
+	// Suppress application-internal state directories — hard reject
 	appInternalDirs := []string{
 		"/google-chrome/", "/chromium/", "/BraveSoftware/",
 		"/LM Studio/", "/lm-studio/",
@@ -269,7 +279,7 @@ func (h *HeuristicFilter) evaluateFilesystem(path, content string) (float32, str
 	lowerPathCheck := strings.ToLower(path)
 	for _, dir := range appInternalDirs {
 		if strings.Contains(lowerPathCheck, strings.ToLower(dir)) {
-			return 0.0, fmt.Sprintf("filesystem: application-internal path '%s'", dir)
+			return 0.0, fmt.Sprintf("filesystem: application-internal path '%s'", dir), true
 		}
 	}
 
@@ -298,22 +308,22 @@ func (h *HeuristicFilter) evaluateFilesystem(path, content string) (float32, str
 		}
 	}
 
-	return score, rationale
+	return score, rationale, false
 }
 
 // evaluateTerminal scores terminal events.
-func (h *HeuristicFilter) evaluateTerminal(content string) (float32, string) {
+func (h *HeuristicFilter) evaluateTerminal(content string) (float32, string, bool) {
 	score := float32(0.3)
 	rationale := "terminal event"
 
 	command := strings.Fields(content)
 	if len(command) == 0 {
-		return score, rationale
+		return score, rationale, false
 	}
 
 	cmd := strings.ToLower(command[0])
 
-	// Skip trivial commands (only if they are just the command itself)
+	// Skip trivial commands (only if they are just the command itself) — hard reject
 	trivialCommands := map[string]bool{
 		"cd": true, "ls": true, "pwd": true, "clear": true,
 		"exit": true, "history": true, "which": true, "whoami": true,
@@ -321,7 +331,7 @@ func (h *HeuristicFilter) evaluateTerminal(content string) (float32, string) {
 	}
 
 	if trivialCommands[cmd] && len(command) == 1 {
-		return 0.0, fmt.Sprintf("terminal: trivial command '%s'", cmd)
+		return 0.0, fmt.Sprintf("terminal: trivial command '%s'", cmd), true
 	}
 
 	// Score boost for high-signal commands
@@ -338,20 +348,20 @@ func (h *HeuristicFilter) evaluateTerminal(content string) (float32, string) {
 		}
 	}
 
-	return score, rationale
+	return score, rationale, false
 }
 
 // evaluateClipboard scores clipboard events.
-func (h *HeuristicFilter) evaluateClipboard(content string) (float32, string) {
+func (h *HeuristicFilter) evaluateClipboard(content string) (float32, string, bool) {
 	score := float32(0.3)
 	rationale := "clipboard event"
 
 	trimmed := strings.TrimSpace(content)
 
-	// Skip if content looks like just a URL
+	// Skip if content looks like just a URL — hard reject
 	if (strings.HasPrefix(trimmed, "http://") || strings.HasPrefix(trimmed, "https://")) &&
 		!strings.ContainsAny(trimmed, " \t\n") {
-		return 0.0, "clipboard: URL-only content"
+		return 0.0, "clipboard: URL-only content", true
 	}
 
 	// Score boost for code snippets
@@ -368,7 +378,7 @@ func (h *HeuristicFilter) evaluateClipboard(content string) (float32, string) {
 		rationale += fmt.Sprintf("; code snippet detected (%d indicators)", foundCodeIndicators)
 	}
 
-	return score, rationale
+	return score, rationale, false
 }
 
 // scoreKeywords scans content for high-signal words and returns the score bonus and count.
@@ -417,7 +427,7 @@ func (h *HeuristicFilter) scoreKeywords(content string) (float32, int) {
 
 // evaluateMCP scores MCP-source events (from Claude Code tool calls).
 // MCP events are high-signal — they represent explicit user/AI interaction.
-func (h *HeuristicFilter) evaluateMCP(eventType, content string) (float32, string) {
+func (h *HeuristicFilter) evaluateMCP(eventType, content string) (float32, string, bool) {
 	score := float32(0.6) // High base score — MCP events are always intentional
 	rationale := "mcp event (high-signal)"
 
@@ -436,7 +446,7 @@ func (h *HeuristicFilter) evaluateMCP(eventType, content string) (float32, strin
 		rationale += "; learning type"
 	}
 
-	return score, rationale
+	return score, rationale, false
 }
 
 // IsBatchEdit checks if a filesystem event is part of a rapid batch of edits

--- a/internal/agent/perception/heuristic_test.go
+++ b/internal/agent/perception/heuristic_test.go
@@ -1,0 +1,125 @@
+package perception
+
+import (
+	"log/slog"
+	"os"
+	"testing"
+)
+
+func newTestFilter() *HeuristicFilter {
+	return NewHeuristicFilter(HeuristicConfig{
+		MinContentLength:   10,
+		MaxContentLength:   100000,
+		FrequencyThreshold: 5,
+		FrequencyWindowMin: 10,
+	}, slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError})))
+}
+
+func TestEvaluate_VenvPathHardReject(t *testing.T) {
+	hf := newTestFilter()
+
+	// Content loaded with high-signal keywords that would normally boost score above 0.2
+	keywordRichContent := `def test_config_error():
+    """Fix the deployment bug by updating the release config."""
+    install_package("important-lib")
+    raise ImportError("critical error in merge")
+`
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"venv path", "/home/user/Projects/foo/venv/lib/python3.12/site-packages/pip/config.py"},
+		{".venv path", "/home/user/Projects/foo/.venv/lib/python3.12/site-packages/pip/network/auth.py"},
+		{"site-packages path", "/usr/lib/python3/dist-packages/site-packages/keyring/core.py"},
+		{"node_modules path", "/home/user/Projects/app/node_modules/express/lib/router.js"},
+		{"__pycache__ path", "/home/user/Projects/foo/__pycache__/module.cpython-312.pyc"},
+		{"mypy_cache path", "/home/user/Projects/foo/.mypy_cache/3.12/module.meta.json"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			event := Event{
+				Source:  "filesystem",
+				Type:    "file_modified",
+				Path:    tc.path,
+				Content: keywordRichContent,
+			}
+
+			result := hf.Evaluate(event)
+			if result.Pass {
+				t.Errorf("expected hard reject for %s, got Pass=true (score=%.2f, rationale=%q)",
+					tc.path, result.Score, result.Rationale)
+			}
+			if result.Score != 0.0 {
+				t.Errorf("expected score 0.0 for %s, got %.2f", tc.path, result.Score)
+			}
+		})
+	}
+}
+
+func TestEvaluate_AppInternalPathHardReject(t *testing.T) {
+	hf := newTestFilter()
+
+	content := `{"error": "config merge failed", "fix": "update release"}`
+
+	event := Event{
+		Source:  "filesystem",
+		Type:    "file_modified",
+		Path:    "/home/user/.config/google-chrome/Default/Local Storage/leveldb/000123.log",
+		Content: content,
+	}
+
+	result := hf.Evaluate(event)
+	if result.Pass {
+		t.Errorf("expected hard reject for chrome internal path, got Pass=true (score=%.2f)", result.Score)
+	}
+}
+
+func TestEvaluate_TrivialCommandHardReject(t *testing.T) {
+	hf := newTestFilter()
+
+	// Bare "pwd" should be hard-rejected even if content somehow has keywords
+	event := Event{
+		Source:  "terminal",
+		Type:    "command_executed",
+		Content: "pwd",
+	}
+
+	result := hf.Evaluate(event)
+	if result.Pass {
+		t.Errorf("expected hard reject for trivial command, got Pass=true (score=%.2f)", result.Score)
+	}
+}
+
+func TestEvaluate_NormalSourceCodePasses(t *testing.T) {
+	hf := newTestFilter()
+
+	event := Event{
+		Source:  "filesystem",
+		Type:    "file_modified",
+		Path:    "/home/user/Projects/myapp/internal/server/handler.go",
+		Content: "func handleRequest(w http.ResponseWriter, r *http.Request) { /* error handling */ }",
+	}
+
+	result := hf.Evaluate(event)
+	if !result.Pass {
+		t.Errorf("expected normal source code to pass, got Pass=false (score=%.2f, rationale=%q)",
+			result.Score, result.Rationale)
+	}
+}
+
+func TestEvaluate_ClipboardURLHardReject(t *testing.T) {
+	hf := newTestFilter()
+
+	event := Event{
+		Source:  "clipboard",
+		Type:    "clipboard_change",
+		Content: "https://github.com/some/repo/issues/123",
+	}
+
+	result := hf.Evaluate(event)
+	if result.Pass {
+		t.Errorf("expected hard reject for URL-only clipboard, got Pass=true (score=%.2f)", result.Score)
+	}
+}

--- a/internal/agent/perception/rejection_tracker.go
+++ b/internal/agent/perception/rejection_tracker.go
@@ -113,6 +113,19 @@ func extractPrefix(path string) string {
 		}
 	}
 
+	// Fallback: detect common project-level noise directories anywhere in the path.
+	// E.g., "Projects/foo/.venv/lib/python3.12/..." → "./Projects/foo/.venv/"
+	noiseDirs := []string{
+		".venv/", "venv/", "node_modules/", "__pycache__/",
+		"site-packages/", ".tox/", ".mypy_cache/", ".ruff_cache/", ".pytest_cache/",
+	}
+	for _, noiseDir := range noiseDirs {
+		idx := strings.Index(rel, noiseDir)
+		if idx > 0 {
+			return "./" + rel[:idx+len(noiseDir)]
+		}
+	}
+
 	return ""
 }
 

--- a/internal/agent/perception/rejection_tracker_test.go
+++ b/internal/agent/perception/rejection_tracker_test.go
@@ -48,6 +48,26 @@ func TestExtractPrefix(t *testing.T) {
 			path: filepath.Join(home, ".config/somefile"),
 			want: "",
 		},
+		{
+			name: "project venv",
+			path: filepath.Join(home, "Projects/felixlm/.venv/lib/python3.12/site-packages/pip/config.py"),
+			want: "./Projects/felixlm/.venv/",
+		},
+		{
+			name: "project node_modules",
+			path: filepath.Join(home, "Projects/webapp/node_modules/express/lib/router.js"),
+			want: "./Projects/webapp/node_modules/",
+		},
+		{
+			name: "project pycache",
+			path: filepath.Join(home, "Projects/myapp/__pycache__/module.cpython-312.pyc"),
+			want: "./Projects/myapp/__pycache__/",
+		},
+		{
+			name: "normal project file (no noise dir)",
+			path: filepath.Join(home, "Projects/myapp/internal/server/handler.go"),
+			want: "",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/agent/reactor/reactor_test.go
+++ b/internal/agent/reactor/reactor_test.go
@@ -191,6 +191,15 @@ func (m *mockStore) ListProjects(context.Context) ([]string, error) { return nil
 func (m *mockStore) RawMemoryExistsByPath(context.Context, string, string, string) (bool, error) {
 	return false, nil
 }
+func (m *mockStore) CountRawUnprocessedByPathPatterns(context.Context, []string) (int, error) {
+	return 0, nil
+}
+func (m *mockStore) BulkMarkRawProcessedByPathPatterns(context.Context, []string) (int, error) {
+	return 0, nil
+}
+func (m *mockStore) ArchiveMemoriesByRawPathPatterns(context.Context, []string) (int, error) {
+	return 0, nil
+}
 func (m *mockStore) BatchWriteRaw(context.Context, []store.RawMemory) error { return nil }
 func (m *mockStore) Close() error                                           { return nil }
 

--- a/internal/agent/retrieval/agent_test.go
+++ b/internal/agent/retrieval/agent_test.go
@@ -294,6 +294,15 @@ func (m *mockStore) ListProjects(ctx context.Context) ([]string, error) { return
 func (m *mockStore) RawMemoryExistsByPath(ctx context.Context, source string, project string, filePath string) (bool, error) {
 	return false, nil
 }
+func (m *mockStore) CountRawUnprocessedByPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	return 0, nil
+}
+func (m *mockStore) BulkMarkRawProcessedByPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	return 0, nil
+}
+func (m *mockStore) ArchiveMemoriesByRawPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	return 0, nil
+}
 func (m *mockStore) BatchWriteRaw(ctx context.Context, raws []store.RawMemory) error { return nil }
 
 func (m *mockStore) Close() error { return nil }

--- a/internal/api/routes/routes_test.go
+++ b/internal/api/routes/routes_test.go
@@ -219,6 +219,15 @@ func (m *mockStore) ListProjects(ctx context.Context) ([]string, error) { return
 func (m *mockStore) RawMemoryExistsByPath(ctx context.Context, source string, project string, filePath string) (bool, error) {
 	return false, nil
 }
+func (m *mockStore) CountRawUnprocessedByPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	return 0, nil
+}
+func (m *mockStore) BulkMarkRawProcessedByPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	return 0, nil
+}
+func (m *mockStore) ArchiveMemoriesByRawPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	return 0, nil
+}
 func (m *mockStore) BatchWriteRaw(ctx context.Context, raws []store.RawMemory) error { return nil }
 
 func (m *mockStore) Close() error { return nil }

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -193,6 +193,15 @@ func (m *mockStore) ListProjects(ctx context.Context) ([]string, error) { return
 func (m *mockStore) RawMemoryExistsByPath(ctx context.Context, source string, project string, filePath string) (bool, error) {
 	return false, nil
 }
+func (m *mockStore) CountRawUnprocessedByPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	return 0, nil
+}
+func (m *mockStore) BulkMarkRawProcessedByPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	return 0, nil
+}
+func (m *mockStore) ArchiveMemoriesByRawPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	return 0, nil
+}
 func (m *mockStore) BatchWriteRaw(ctx context.Context, raws []store.RawMemory) error { return nil }
 
 func (m *mockStore) Close() error { return nil }

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -500,6 +500,96 @@ func (s *SQLiteStore) RawMemoryExistsByPath(ctx context.Context, source string, 
 	return count > 0, nil
 }
 
+// CountRawUnprocessedByPathPatterns counts unprocessed raw memories whose
+// metadata path contains any of the given substring patterns.
+func (s *SQLiteStore) CountRawUnprocessedByPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	if len(patterns) == 0 {
+		return 0, nil
+	}
+
+	conditions := make([]string, len(patterns))
+	args := make([]interface{}, len(patterns))
+	for i, p := range patterns {
+		conditions[i] = "json_extract(metadata, '$.path') LIKE ?"
+		args[i] = "%" + p + "%"
+	}
+
+	query := fmt.Sprintf(
+		"SELECT COUNT(*) FROM raw_memories WHERE processed = 0 AND (%s)",
+		strings.Join(conditions, " OR "),
+	)
+
+	var count int
+	if err := s.db.QueryRowContext(ctx, query, args...).Scan(&count); err != nil {
+		return 0, fmt.Errorf("counting unprocessed raw memories by path patterns: %w", err)
+	}
+	return count, nil
+}
+
+// BulkMarkRawProcessedByPathPatterns marks unprocessed raw memories as processed
+// where the metadata path contains any of the given substring patterns.
+func (s *SQLiteStore) BulkMarkRawProcessedByPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	if len(patterns) == 0 {
+		return 0, nil
+	}
+
+	conditions := make([]string, len(patterns))
+	args := make([]interface{}, len(patterns))
+	for i, p := range patterns {
+		conditions[i] = "json_extract(metadata, '$.path') LIKE ?"
+		args[i] = "%" + p + "%"
+	}
+
+	query := fmt.Sprintf(
+		"UPDATE raw_memories SET processed = 1 WHERE processed = 0 AND (%s)",
+		strings.Join(conditions, " OR "),
+	)
+
+	result, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("bulk marking raw memories processed: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("getting rows affected: %w", err)
+	}
+	return int(affected), nil
+}
+
+// ArchiveMemoriesByRawPathPatterns archives encoded memories whose raw_id
+// references a raw memory with a path matching any of the given patterns.
+func (s *SQLiteStore) ArchiveMemoriesByRawPathPatterns(ctx context.Context, patterns []string) (int, error) {
+	if len(patterns) == 0 {
+		return 0, nil
+	}
+
+	conditions := make([]string, len(patterns))
+	args := make([]interface{}, len(patterns))
+	for i, p := range patterns {
+		conditions[i] = "json_extract(r.metadata, '$.path') LIKE ?"
+		args[i] = "%" + p + "%"
+	}
+
+	query := fmt.Sprintf(`
+		UPDATE memories SET state = 'archived', updated_at = datetime('now')
+		WHERE raw_id IN (
+			SELECT r.id FROM raw_memories r
+			WHERE %s
+		) AND state != 'archived'`,
+		strings.Join(conditions, " OR "),
+	)
+
+	result, err := s.db.ExecContext(ctx, query, args...)
+	if err != nil {
+		return 0, fmt.Errorf("archiving memories by raw path patterns: %w", err)
+	}
+	affected, err := result.RowsAffected()
+	if err != nil {
+		return 0, fmt.Errorf("getting rows affected: %w", err)
+	}
+	return int(affected), nil
+}
+
 // BatchWriteRaw writes multiple raw memories in a single transaction.
 func (s *SQLiteStore) BatchWriteRaw(ctx context.Context, raws []store.RawMemory) error {
 	if len(raws) == 0 {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -300,6 +300,17 @@ type Store interface {
 	// --- Deduplication ---
 	RawMemoryExistsByPath(ctx context.Context, source string, project string, filePath string) (bool, error)
 
+	// --- Cleanup operations ---
+	// CountRawUnprocessedByPathPatterns counts unprocessed raw memories
+	// whose metadata path matches any of the given substring patterns.
+	CountRawUnprocessedByPathPatterns(ctx context.Context, patterns []string) (int, error)
+	// BulkMarkRawProcessedByPathPatterns marks unprocessed raw memories as processed
+	// where the metadata path matches any of the given substring patterns.
+	BulkMarkRawProcessedByPathPatterns(ctx context.Context, patterns []string) (int, error)
+	// ArchiveMemoriesByRawPathPatterns archives encoded memories whose raw_id
+	// references a raw memory with a path matching any of the given patterns.
+	ArchiveMemoriesByRawPathPatterns(ctx context.Context, patterns []string) (int, error)
+
 	// --- Batch operations (for consolidation) ---
 	BatchWriteRaw(ctx context.Context, raws []RawMemory) error
 	BatchUpdateSalience(ctx context.Context, updates map[string]float32) error


### PR DESCRIPTION
## Summary

- **Heuristic hard rejection**: `evaluateSource()` now returns a `hardReject` flag so keyword scoring can't override path-based rejections (the root cause — venv `.py` files with words like "error"/"fix" were scoring above the 0.2 threshold)
- **Encoding agent defense-in-depth**: checks `raw.Metadata["path"]` against exclude patterns before encoding; marks leaked events as processed
- **Rejection tracker expansion**: `extractPrefix()` now handles project-level noise dirs (`.venv/`, `node_modules/`, etc.), not just `.config/` and `.local/share/`
- **New `mnemonic cleanup` CLI command**: bulk-marks raw events matching exclude patterns as processed and archives derived encoded memories

## Context

23,398 raw filesystem events from `~/Projects/felixlm/.venv/lib/python3.12/site-packages/` got into `raw_memories` on March 1st. The encoding agent was slowly grinding through them, creating useless memories about pip internals, keyring providers, and HuggingFace transformers. Running `mnemonic cleanup --yes` cleared 23,388 raw events and archived 146 garbage encoded memories.

## Test plan

- [x] `make test` — all 13 packages pass
- [x] `make check` — go fmt + go vet clean
- [x] `make build` — binary builds
- [x] `mnemonic cleanup --yes` — verified against live DB (23,388 raw events, 146 memories cleaned)
- [x] New heuristic tests verify venv paths with keyword-rich content get `Pass: false`
- [x] New encoding agent test verifies excluded paths are skipped and marked processed
- [x] New rejection tracker tests verify project-level venv prefix extraction

🤖 Generated with [Claude Code](https://claude.com/claude-code)