### PR TITLE
Fix desktop noise leaking through heuristic filter

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -112,12 +112,19 @@ perception:
       - ".config/google-chrome/"
       - ".config/chromium/"
       - ".config/BraveSoftware/"
+      - ".config/gtk-"
+      - ".config/dbus-"
       - ".local/share/gnome-shell/"
       - ".local/share/Trash/"
+      - ".local/state/wireplumber/"
       - "/dconf/"
       - "/gconf/"
       - "/pulse/"
       - "/pipewire/"
+      - ".copilot/"
+      - ".github-copilot/"
+      - "/snap/"
+      - ".egg-info/"
 
     # Maximum file content size to process (in bytes)
     max_content_bytes: 102400

--- a/internal/agent/perception/heuristic.go
+++ b/internal/agent/perception/heuristic.go
@@ -257,7 +257,8 @@ func (h *HeuristicFilter) evaluateSource(source, eventType, path, content string
 func (h *HeuristicFilter) evaluateFilesystem(path, content string) (float32, string, bool) {
 	// Skip if path contains ignored patterns — hard reject, no keyword override
 	ignoredPatterns := []string{".git/", "node_modules/", "__pycache__/", ".DS_Store", "~", ".swp", ".tmp", ".xbel",
-		"venv/", ".venv/", "site-packages/", ".tox/", ".mypy_cache/", ".ruff_cache/", ".pytest_cache/"}
+		"venv/", ".venv/", "site-packages/", ".tox/", ".mypy_cache/", ".ruff_cache/", ".pytest_cache/",
+		".egg-info/", ".eggs/"}
 	for _, pattern := range ignoredPatterns {
 		if strings.Contains(path, pattern) {
 			return 0.0, fmt.Sprintf("filesystem: ignored path pattern '%s'", pattern), true
@@ -272,9 +273,13 @@ func (h *HeuristicFilter) evaluateFilesystem(path, content string) (float32, str
 		"/leveldb/", "/IndexedDB/", "/Local Storage/", "/Session Storage/",
 		"/Cache/", "/GPUCache/", "/ShaderCache/", "/Code Cache/",
 		"/dconf/", "/gconf/",
-		"/pulse/", "/pipewire/",
+		"/pulse/", "/pipewire/", "/wireplumber/",
 		"/gvfs-metadata/", "/tracker3/",
 		"session_migration-",
+		"/.copilot/", "/.github-copilot/",
+		"/snap/", "/.snap/",
+		"/.config/gtk-", "/.config/dbus-",
+		"/.mnemonic/", "/.claude/",
 	}
 	lowerPathCheck := strings.ToLower(path)
 	for _, dir := range appInternalDirs {

--- a/internal/agent/perception/heuristic_test.go
+++ b/internal/agent/perception/heuristic_test.go
@@ -109,6 +109,46 @@ func TestEvaluate_NormalSourceCodePasses(t *testing.T) {
 	}
 }
 
+func TestEvaluate_DesktopNoiseHardReject(t *testing.T) {
+	hf := newTestFilter()
+
+	content := `{"error": "config merge failed", "fix": "update release"}`
+
+	tests := []struct {
+		name string
+		path string
+	}{
+		{"wireplumber restore-stream", "/home/user/.local/state/wireplumber/restore-stream"},
+		{"wireplumber default-routes", "/home/user/.local/state/wireplumber/default-routes"},
+		{"copilot ide lock", "/home/user/.copilot/ide/346d20a4-955c-47fd-adec-84a8195fb292.lock"},
+		{"snap revision", "/home/user/snap/code/current/.last_revision"},
+		{"gtk bookmarks", "/home/user/.config/gtk-3.0/bookmarks"},
+		{"egg-info", "/home/user/Projects/foo/foo.egg-info/PKG-INFO"},
+		{"mnemonic internal", "/home/user/.mnemonic/memory.db-journal"},
+		{"claude internal", "/home/user/.claude/settings.json"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			event := Event{
+				Source:  "filesystem",
+				Type:    "file_modified",
+				Path:    tc.path,
+				Content: content,
+			}
+
+			result := hf.Evaluate(event)
+			if result.Pass {
+				t.Errorf("expected hard reject for %s, got Pass=true (score=%.2f, rationale=%q)",
+					tc.path, result.Score, result.Rationale)
+			}
+			if result.Score != 0.0 {
+				t.Errorf("expected score 0.0 for %s, got %.2f", tc.path, result.Score)
+			}
+		})
+	}
+}
+
 func TestEvaluate_ClipboardURLHardReject(t *testing.T) {
 	hf := newTestFilter()
 

--- a/internal/agent/perception/rejection_tracker.go
+++ b/internal/agent/perception/rejection_tracker.go
@@ -118,6 +118,7 @@ func extractPrefix(path string) string {
 	noiseDirs := []string{
 		".venv/", "venv/", "node_modules/", "__pycache__/",
 		"site-packages/", ".tox/", ".mypy_cache/", ".ruff_cache/", ".pytest_cache/",
+		".egg-info/", ".eggs/",
 	}
 	for _, noiseDir := range noiseDirs {
 		idx := strings.Index(rel, noiseDir)


### PR DESCRIPTION
## Summary
- Added hard-reject patterns for WirePlumber audio state, GitHub Copilot lock files, snap revision files, GTK/dbus config, Python egg-info, and mnemonic/claude self-observation paths
- Updated `config.yaml` watcher exclude patterns to match
- Added `egg-info/` to rejection tracker noise dirs for auto-learning
- Archived 16 existing noisy memories from live DB

## Context
After the venv fix (#35), new noise categories were still leaking through: PipeWire's session manager (`wireplumber/` ≠ `pipewire/`), Copilot IDE locks, snap package revisions, and GTK desktop state.

## Test plan
- [x] New `TestEvaluate_DesktopNoiseHardReject` with 8 cases (wireplumber, copilot, snap, gtk, egg-info, mnemonic, claude)
- [x] All existing tests pass
- [x] `make test`, `make check`, `make build` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)