### PR TITLE
Improve recall quality: cleanup, synthesis, coaching

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,8 @@
+{
+  "mcpServers": {
+    "mnemonic": {
+      "command": "./bin/mnemonic",
+      "args": ["mcp"]
+    }
+  }
+}

--- a/cmd/mnemonic/main.go
+++ b/cmd/mnemonic/main.go
@@ -1700,11 +1700,15 @@ func cleanupCommand(configPath string, args []string) {
 		return
 	}
 
-	// Check for --yes flag
+	// Check for flags
 	autoConfirm := false
+	cleanPatterns := false
 	for _, a := range args {
 		if a == "--yes" || a == "-y" {
 			autoConfirm = true
+		}
+		if a == "--patterns" {
+			cleanPatterns = true
 		}
 	}
 
@@ -1718,14 +1722,20 @@ func cleanupCommand(configPath string, args []string) {
 	fmt.Printf("%sCleanup Summary%s\n", colorBold, colorReset)
 	fmt.Printf("  Exclude patterns:       %d (from config.yaml)\n", len(patterns))
 	fmt.Printf("  Unprocessed raw events:  %s%d%s matching exclude patterns\n", colorYellow, rawCount, colorReset)
+	if cleanPatterns {
+		fmt.Printf("  --patterns flag:        will archive all active patterns and abstractions\n")
+	}
 
-	if rawCount == 0 {
+	if rawCount == 0 && !cleanPatterns {
 		fmt.Println("\nNothing to clean up.")
 		return
 	}
 
 	if !autoConfirm {
 		fmt.Printf("\nThis will mark matching raw events as processed and archive derived memories.\n")
+		if cleanPatterns {
+			fmt.Printf("It will also archive ALL active patterns and abstractions (they regenerate from clean data).\n")
+		}
 		fmt.Printf("Type 'yes' to confirm: ")
 		var confirmation string
 		_, _ = fmt.Scanln(&confirmation)
@@ -1735,23 +1745,47 @@ func cleanupCommand(configPath string, args []string) {
 		}
 	}
 
-	// Mark raw events as processed
-	rawCleaned, err := db.BulkMarkRawProcessedByPathPatterns(ctx, patterns)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error cleaning raw memories: %v\n", err)
-		os.Exit(1)
+	rawCleaned := 0
+	memArchived := 0
+
+	if rawCount > 0 {
+		// Mark raw events as processed
+		rawCleaned, err = db.BulkMarkRawProcessedByPathPatterns(ctx, patterns)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error cleaning raw memories: %v\n", err)
+			os.Exit(1)
+		}
+
+		// Archive derived encoded memories
+		memArchived, err = db.ArchiveMemoriesByRawPathPatterns(ctx, patterns)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error archiving memories: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
-	// Archive derived encoded memories
-	memArchived, err := db.ArchiveMemoriesByRawPathPatterns(ctx, patterns)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error archiving memories: %v\n", err)
-		os.Exit(1)
+	patternsArchived := 0
+	abstractionsArchived := 0
+	if cleanPatterns {
+		patternsArchived, err = db.ArchiveAllPatterns(ctx)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error archiving patterns: %v\n", err)
+			os.Exit(1)
+		}
+		abstractionsArchived, err = db.ArchiveAllAbstractions(ctx)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error archiving abstractions: %v\n", err)
+			os.Exit(1)
+		}
 	}
 
 	fmt.Printf("\n%sCleanup complete%s\n", colorGreen, colorReset)
 	fmt.Printf("  Raw events marked processed:  %d\n", rawCleaned)
 	fmt.Printf("  Encoded memories archived:    %d\n", memArchived)
+	if cleanPatterns {
+		fmt.Printf("  Patterns archived:            %d\n", patternsArchived)
+		fmt.Printf("  Abstractions archived:        %d\n", abstractionsArchived)
+	}
 }
 
 // ============================================================================

--- a/internal/agent/consolidation/agent_test.go
+++ b/internal/agent/consolidation/agent_test.go
@@ -264,6 +264,9 @@ func (m *mockStore) ListPatterns(ctx context.Context, project string, limit int)
 func (m *mockStore) SearchPatternsByEmbedding(ctx context.Context, embedding []float32, limit int) ([]store.Pattern, error) {
 	return nil, nil
 }
+func (m *mockStore) ArchiveAllPatterns(ctx context.Context) (int, error) {
+	return 0, nil
+}
 
 // --- Abstraction operations ---
 func (m *mockStore) WriteAbstraction(ctx context.Context, a store.Abstraction) error { return nil }
@@ -276,6 +279,9 @@ func (m *mockStore) ListAbstractions(ctx context.Context, level int, limit int) 
 }
 func (m *mockStore) SearchAbstractionsByEmbedding(ctx context.Context, embedding []float32, limit int) ([]store.Abstraction, error) {
 	return nil, nil
+}
+func (m *mockStore) ArchiveAllAbstractions(ctx context.Context) (int, error) {
+	return 0, nil
 }
 
 // --- Scoped queries ---

--- a/internal/agent/dreaming/agent_test.go
+++ b/internal/agent/dreaming/agent_test.go
@@ -412,6 +412,9 @@ func (m *mockStore) ListPatterns(ctx context.Context, project string, limit int)
 func (m *mockStore) SearchPatternsByEmbedding(ctx context.Context, embedding []float32, limit int) ([]store.Pattern, error) {
 	return nil, nil
 }
+func (m *mockStore) ArchiveAllPatterns(ctx context.Context) (int, error) {
+	return 0, nil
+}
 
 // --- Abstraction operations ---
 func (m *mockStore) WriteAbstraction(ctx context.Context, a store.Abstraction) error { return nil }
@@ -424,6 +427,9 @@ func (m *mockStore) ListAbstractions(ctx context.Context, level int, limit int) 
 }
 func (m *mockStore) SearchAbstractionsByEmbedding(ctx context.Context, embedding []float32, limit int) ([]store.Abstraction, error) {
 	return nil, nil
+}
+func (m *mockStore) ArchiveAllAbstractions(ctx context.Context) (int, error) {
+	return 0, nil
 }
 
 // --- Scoped queries ---

--- a/internal/agent/encoding/agent_test.go
+++ b/internal/agent/encoding/agent_test.go
@@ -220,6 +220,9 @@ func (m *mockStore) ListPatterns(ctx context.Context, project string, limit int)
 func (m *mockStore) SearchPatternsByEmbedding(ctx context.Context, embedding []float32, limit int) ([]store.Pattern, error) {
 	return nil, nil
 }
+func (m *mockStore) ArchiveAllPatterns(ctx context.Context) (int, error) {
+	return 0, nil
+}
 
 // --- Abstraction operations ---
 func (m *mockStore) WriteAbstraction(ctx context.Context, a store.Abstraction) error { return nil }
@@ -232,6 +235,9 @@ func (m *mockStore) ListAbstractions(ctx context.Context, level int, limit int) 
 }
 func (m *mockStore) SearchAbstractionsByEmbedding(ctx context.Context, embedding []float32, limit int) ([]store.Abstraction, error) {
 	return nil, nil
+}
+func (m *mockStore) ArchiveAllAbstractions(ctx context.Context) (int, error) {
+	return 0, nil
 }
 
 // --- Scoped queries ---

--- a/internal/agent/reactor/reactor_test.go
+++ b/internal/agent/reactor/reactor_test.go
@@ -167,6 +167,9 @@ func (m *mockStore) ListPatterns(context.Context, string, int) ([]store.Pattern,
 func (m *mockStore) SearchPatternsByEmbedding(context.Context, []float32, int) ([]store.Pattern, error) {
 	return nil, nil
 }
+func (m *mockStore) ArchiveAllPatterns(context.Context) (int, error) {
+	return 0, nil
+}
 func (m *mockStore) WriteAbstraction(context.Context, store.Abstraction) error { return nil }
 func (m *mockStore) GetAbstraction(context.Context, string) (store.Abstraction, error) {
 	return store.Abstraction{}, nil
@@ -177,6 +180,9 @@ func (m *mockStore) ListAbstractions(context.Context, int, int) ([]store.Abstrac
 }
 func (m *mockStore) SearchAbstractionsByEmbedding(context.Context, []float32, int) ([]store.Abstraction, error) {
 	return nil, nil
+}
+func (m *mockStore) ArchiveAllAbstractions(context.Context) (int, error) {
+	return 0, nil
 }
 func (m *mockStore) SearchByProject(context.Context, string, string, int) ([]store.Memory, error) {
 	return nil, nil

--- a/internal/agent/retrieval/agent.go
+++ b/internal/agent/retrieval/agent.go
@@ -690,8 +690,8 @@ func (ra *RetrievalAgent) synthesizeNarrative(ctx context.Context, query string,
 
 	// Build the initial prompt with pre-fetched context
 	var prompt strings.Builder
-	prompt.WriteString("Someone is searching their memory. Help them remember — not just the facts, but the meaning. Draw on everything below to give them a thoughtful, useful answer.\n\n")
-	prompt.WriteString("You have tools available to search for more context if the memories below don't fully answer the question. Use them if something seems incomplete or if you want to follow a thread. When you have enough context, respond with your final synthesis.\n\n")
+	prompt.WriteString("Answer this memory search concisely. Summarize what the memories tell you — focus on concrete facts, decisions, and specifics. Do NOT pad with filler or restate what each memory says individually.\n\n")
+	prompt.WriteString("You have tools available to search for more context if needed. Use them only if the memories below are clearly incomplete.\n\n")
 	fmt.Fprintf(&prompt, "They're asking: %s\n\n", query)
 
 	// Memories section — include IDs so the LLM can reference them with tools
@@ -745,7 +745,7 @@ func (ra *RetrievalAgent) synthesizeNarrative(ctx context.Context, query string,
 		prompt.WriteString("\n")
 	}
 
-	prompt.WriteString("Weave these together into a clear, informative response. Reference specific memories when they illuminate the answer. Include concrete details — file names, what changed, why it matters. If patterns or principles apply, share that wisdom. Be honest about what you're confident in and what's fuzzy. Aim for a thorough summary — a short paragraph per major theme or activity, not just a couple of sentences.")
+	prompt.WriteString("Respond in 2-5 sentences. Include specific details (file names, commands, decisions). Skip patterns/principles unless directly relevant to the query. Do not repeat each memory — synthesize.")
 
 	// Build conversation history for the tool-use loop
 	messages := []llm.Message{

--- a/internal/agent/retrieval/agent_test.go
+++ b/internal/agent/retrieval/agent_test.go
@@ -266,6 +266,9 @@ func (m *mockStore) ListPatterns(ctx context.Context, project string, limit int)
 func (m *mockStore) SearchPatternsByEmbedding(ctx context.Context, embedding []float32, limit int) ([]store.Pattern, error) {
 	return nil, nil
 }
+func (m *mockStore) ArchiveAllPatterns(ctx context.Context) (int, error) {
+	return 0, nil
+}
 
 // --- Abstraction operations ---
 func (m *mockStore) WriteAbstraction(ctx context.Context, a store.Abstraction) error { return nil }
@@ -278,6 +281,9 @@ func (m *mockStore) ListAbstractions(ctx context.Context, level int, limit int) 
 }
 func (m *mockStore) SearchAbstractionsByEmbedding(ctx context.Context, embedding []float32, limit int) ([]store.Abstraction, error) {
 	return nil, nil
+}
+func (m *mockStore) ArchiveAllAbstractions(ctx context.Context) (int, error) {
+	return 0, nil
 }
 
 // --- Scoped queries ---

--- a/internal/api/routes/routes_test.go
+++ b/internal/api/routes/routes_test.go
@@ -191,6 +191,9 @@ func (m *mockStore) ListPatterns(ctx context.Context, project string, limit int)
 func (m *mockStore) SearchPatternsByEmbedding(ctx context.Context, embedding []float32, limit int) ([]store.Pattern, error) {
 	return nil, nil
 }
+func (m *mockStore) ArchiveAllPatterns(ctx context.Context) (int, error) {
+	return 0, nil
+}
 
 // --- Abstraction operations ---
 func (m *mockStore) WriteAbstraction(ctx context.Context, a store.Abstraction) error { return nil }
@@ -203,6 +206,9 @@ func (m *mockStore) ListAbstractions(ctx context.Context, level int, limit int) 
 }
 func (m *mockStore) SearchAbstractionsByEmbedding(ctx context.Context, embedding []float32, limit int) ([]store.Abstraction, error) {
 	return nil, nil
+}
+func (m *mockStore) ArchiveAllAbstractions(ctx context.Context) (int, error) {
+	return 0, nil
 }
 
 // --- Scoped queries ---

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -165,6 +165,9 @@ func (m *mockStore) ListPatterns(ctx context.Context, project string, limit int)
 func (m *mockStore) SearchPatternsByEmbedding(ctx context.Context, embedding []float32, limit int) ([]store.Pattern, error) {
 	return nil, nil
 }
+func (m *mockStore) ArchiveAllPatterns(ctx context.Context) (int, error) {
+	return 0, nil
+}
 
 // --- Abstraction operations ---
 func (m *mockStore) WriteAbstraction(ctx context.Context, a store.Abstraction) error { return nil }
@@ -177,6 +180,9 @@ func (m *mockStore) ListAbstractions(ctx context.Context, level int, limit int) 
 }
 func (m *mockStore) SearchAbstractionsByEmbedding(ctx context.Context, embedding []float32, limit int) ([]store.Abstraction, error) {
 	return nil, nil
+}
+func (m *mockStore) ArchiveAllAbstractions(ctx context.Context) (int, error) {
+	return 0, nil
 }
 
 // --- Scoped queries ---

--- a/internal/store/sqlite/abstractions.go
+++ b/internal/store/sqlite/abstractions.go
@@ -255,3 +255,14 @@ func scanAbstractionRows(rows *sql.Rows) ([]store.Abstraction, error) {
 
 	return abstractions, nil
 }
+
+// ArchiveAllAbstractions transitions all active abstractions to archived state.
+func (s *SQLiteStore) ArchiveAllAbstractions(ctx context.Context) (int, error) {
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE abstractions SET state = 'archived', updated_at = datetime('now') WHERE state = 'active'`)
+	if err != nil {
+		return 0, fmt.Errorf("archiving abstractions: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	return int(n), nil
+}

--- a/internal/store/sqlite/patterns.go
+++ b/internal/store/sqlite/patterns.go
@@ -270,4 +270,15 @@ func scanPatternRows(rows *sql.Rows) ([]store.Pattern, error) {
 	return patterns, nil
 }
 
+// ArchiveAllPatterns transitions all active patterns to archived state.
+func (s *SQLiteStore) ArchiveAllPatterns(ctx context.Context) (int, error) {
+	result, err := s.db.ExecContext(ctx,
+		`UPDATE patterns SET state = 'archived', updated_at = datetime('now') WHERE state = 'active'`)
+	if err != nil {
+		return 0, fmt.Errorf("archiving patterns: %w", err)
+	}
+	n, _ := result.RowsAffected()
+	return int(n), nil
+}
+
 // cosineSimilarity and sqrt32 are defined in embindex.go

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -362,6 +362,7 @@ type Store interface {
 	UpdatePattern(ctx context.Context, p Pattern) error
 	ListPatterns(ctx context.Context, project string, limit int) ([]Pattern, error)
 	SearchPatternsByEmbedding(ctx context.Context, embedding []float32, limit int) ([]Pattern, error)
+	ArchiveAllPatterns(ctx context.Context) (int, error)
 
 	// --- Abstraction operations ---
 	WriteAbstraction(ctx context.Context, a Abstraction) error
@@ -369,6 +370,7 @@ type Store interface {
 	UpdateAbstraction(ctx context.Context, a Abstraction) error
 	ListAbstractions(ctx context.Context, level int, limit int) ([]Abstraction, error)
 	SearchAbstractionsByEmbedding(ctx context.Context, embedding []float32, limit int) ([]Abstraction, error)
+	ArchiveAllAbstractions(ctx context.Context) (int, error)
 
 	// --- Scoped queries ---
 	SearchByProject(ctx context.Context, project string, query string, limit int) ([]Memory, error)


### PR DESCRIPTION
## Summary
- Added `--patterns` flag to `mnemonic cleanup` command — archives all active patterns and abstractions so they regenerate from clean memory data
- Tightened retrieval synthesis prompt from verbose "weave a thorough summary" to concise "respond in 2-5 sentences with specific details"
- Added `.mcp.json` for Claude Code MCP server registration
- Updated `coaching.yaml` with instructions to preserve specifics (paths, PR numbers) and treat MCP-source memories with higher fidelity

## Context
After noise filter fixes (#35, #37), the DB had clean memories but 27 garbage patterns and 28 garbage abstractions derived from old noise (pip internals, audio configs, hallucinated "Attention-Based Design" principles). The synthesis was also too verbose for the local LLM (Qwen 9B), producing 500+ word essays with hallucinated connections.

## Test plan
- [x] `make test` — all tests pass
- [x] `make build` + `make check` — clean
- [x] `./bin/mnemonic cleanup --patterns --yes` — archived 27 patterns + 28 abstractions
- [x] Verified 0 active patterns/abstractions remain in DB
- [ ] Monitor next consolidation cycle for clean pattern regeneration

🤖 Generated with [Claude Code](https://claude.com/claude-code)