### PR TITLE
Fix pattern deduplication with embedding-level check

### DIFF
--- a/internal/agent/consolidation/agent.go
+++ b/internal/agent/consolidation/agent.go
@@ -756,6 +756,32 @@ func (ca *ConsolidationAgent) processPatternClusters(ctx context.Context, cluste
 			continue
 		}
 
+		// Second dedup: compare the new pattern's own embedding against existing patterns.
+		// This catches duplicates that the cluster-centroid check misses (e.g., two different
+		// clusters producing the same "Code Modification for System Enhancement" pattern).
+		if len(pattern.Embedding) > 0 {
+			existingPatterns, searchErr := ca.store.SearchPatternsByEmbedding(ctx, pattern.Embedding, 1)
+			if searchErr == nil && len(existingPatterns) > 0 && len(existingPatterns[0].Embedding) > 0 {
+				sim := cosineSimilarity(pattern.Embedding, existingPatterns[0].Embedding)
+				if sim >= 0.85 {
+					// Strengthen the existing pattern instead of creating a duplicate
+					ep := &existingPatterns[0]
+					for _, mem := range cluster {
+						if !containsString(ep.EvidenceIDs, mem.ID) {
+							ep.EvidenceIDs = append(ep.EvidenceIDs, mem.ID)
+						}
+					}
+					ep.Strength = min32(ep.Strength+0.03, 1.0)
+					ep.AccessCount++
+					ep.LastAccessed = time.Now()
+					_ = ca.store.UpdatePattern(ctx, *ep)
+					ca.log.Info("dedup: merged new pattern into existing",
+						"existing_id", ep.ID, "existing_title", ep.Title, "similarity", sim)
+					continue
+				}
+			}
+		}
+
 		if err := ca.store.WritePattern(ctx, *pattern); err != nil {
 			ca.log.Warn("failed to write pattern", "error", err)
 			continue


### PR DESCRIPTION
## Summary
- Added a second dedup pass in `processPatternClusters` that compares the new pattern's own text embedding against existing patterns at 0.85 similarity threshold
- This catches duplicates the cluster-centroid check (0.70) misses — e.g., 4 identical "Code Modification for System Enhancement" patterns were being created from different memory clusters
- When a duplicate is detected, the existing pattern is strengthened instead of creating a new one
- Cleaned up 3 existing duplicate patterns from live DB

## Root cause
`findMatchingPattern` compares a cluster's average memory embedding against pattern embeddings. Two different clusters can have different centroids but produce the same pattern text via LLM. The new check compares pattern-text embedding vs pattern-text embedding (same space), matching how the abstraction agent already deduplicates at 0.85.

## Test plan
- [x] `make test` — all pass
- [x] `make build` + `make check` — clean
- [x] Verified active patterns reduced from 9 (with 4 dupes) to 6 unique
- [ ] Monitor next consolidation cycles for no new duplicates

🤖 Generated with [Claude Code](https://claude.com/claude-code)