### PR TITLE
Fix Windows compile, graph labels, mobile layout, detail panel (#14, #9, #13, #12)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -3,11 +3,8 @@ package daemon
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
-	"syscall"
-	"time"
 )
 
 const (
@@ -76,117 +73,4 @@ func RemovePID() error {
 		return fmt.Errorf("failed to remove PID file: %w", err)
 	}
 	return nil
-}
-
-// IsRunning checks if the daemon process is running.
-// Returns (isRunning, pid).
-func IsRunning() (bool, int) {
-	pid, err := ReadPID()
-	if err != nil {
-		return false, 0
-	}
-
-	// Check if process exists by sending signal 0
-	process, err := os.FindProcess(pid)
-	if err != nil {
-		return false, 0
-	}
-
-	if err := process.Signal(syscall.Signal(0)); err != nil {
-		return false, 0
-	}
-
-	return true, pid
-}
-
-// Start launches the daemon process with the given exec path and config path.
-// It forks the process, redirects stdout/stderr to the log file, and writes the PID.
-func Start(execPath string, configPath string) (int, error) {
-	// Create command
-	cmd := exec.Command(execPath, "--config", configPath, "serve")
-
-	// Open or create log file for appending
-	logPath := LogPath()
-	dir := filepath.Dir(logPath)
-	if err := os.MkdirAll(dir, 0700); err != nil {
-		return 0, fmt.Errorf("failed to create daemon directory: %w", err)
-	}
-
-	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
-	if err != nil {
-		return 0, fmt.Errorf("failed to open log file: %w", err)
-	}
-	defer logFile.Close()
-
-	// Redirect stdout and stderr to log file
-	cmd.Stdout = logFile
-	cmd.Stderr = logFile
-
-	// Set up process attributes to detach from terminal
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Setsid: true,
-	}
-
-	// Start the process
-	if err := cmd.Start(); err != nil {
-		return 0, fmt.Errorf("failed to start daemon: %w", err)
-	}
-
-	pid := cmd.Process.Pid
-
-	// Write PID file
-	if err := WritePID(pid); err != nil {
-		return 0, fmt.Errorf("failed to write PID file: %w", err)
-	}
-
-	return pid, nil
-}
-
-// ============================================================================
-// PID-file-based daemon management
-// ============================================================================
-
-// Stop stops the daemon process by sending SIGTERM and waiting for it to exit.
-// If it doesn't exit within 5 seconds, sends SIGKILL.
-func Stop() error {
-	pid, err := ReadPID()
-	if err != nil {
-		return fmt.Errorf("failed to read PID: %w", err)
-	}
-
-	process, err := os.FindProcess(pid)
-	if err != nil {
-		return fmt.Errorf("failed to find process: %w", err)
-	}
-
-	// Send SIGTERM
-	if err := process.Signal(syscall.SIGTERM); err != nil {
-		return fmt.Errorf("failed to send SIGTERM: %w", err)
-	}
-
-	// Wait up to 5 seconds for process to exit
-	timeout := time.After(5 * time.Second)
-	ticker := time.NewTicker(100 * time.Millisecond)
-	defer ticker.Stop()
-
-	for {
-		select {
-		case <-timeout:
-			// Process didn't exit, send SIGKILL
-			// Process may already be dead; ignore SIGKILL error.
-			_ = process.Signal(syscall.SIGKILL)
-			// Wait a bit for SIGKILL to take effect
-			time.Sleep(500 * time.Millisecond)
-			// Clean up PID file
-			_ = RemovePID()
-			return nil
-		case <-ticker.C:
-			// Check if process still exists
-			if err := process.Signal(syscall.Signal(0)); err != nil {
-				// Process is gone
-				_ = RemovePID()
-				return nil
-			}
-		}
-	}
 }

--- a/internal/daemon/daemon_posix.go
+++ b/internal/daemon/daemon_posix.go
@@ -1,0 +1,121 @@
+//go:build !windows
+
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"syscall"
+	"time"
+)
+
+// IsRunning checks if the daemon process is running.
+// Returns (isRunning, pid).
+func IsRunning() (bool, int) {
+	pid, err := ReadPID()
+	if err != nil {
+		return false, 0
+	}
+
+	// Check if process exists by sending signal 0
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return false, 0
+	}
+
+	if err := process.Signal(syscall.Signal(0)); err != nil {
+		return false, 0
+	}
+
+	return true, pid
+}
+
+// Start launches the daemon process with the given exec path and config path.
+// It forks the process, redirects stdout/stderr to the log file, and writes the PID.
+func Start(execPath string, configPath string) (int, error) {
+	// Create command
+	cmd := exec.Command(execPath, "--config", configPath, "serve")
+
+	// Open or create log file for appending
+	logPath := LogPath()
+	dir := filepath.Dir(logPath)
+	if err := os.MkdirAll(dir, 0700); err != nil {
+		return 0, fmt.Errorf("failed to create daemon directory: %w", err)
+	}
+
+	logFile, err := os.OpenFile(logPath, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return 0, fmt.Errorf("failed to open log file: %w", err)
+	}
+	defer logFile.Close()
+
+	// Redirect stdout and stderr to log file
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+
+	// Set up process attributes to detach from terminal
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Setsid: true,
+	}
+
+	// Start the process
+	if err := cmd.Start(); err != nil {
+		return 0, fmt.Errorf("failed to start daemon: %w", err)
+	}
+
+	pid := cmd.Process.Pid
+
+	// Write PID file
+	if err := WritePID(pid); err != nil {
+		return 0, fmt.Errorf("failed to write PID file: %w", err)
+	}
+
+	return pid, nil
+}
+
+// Stop stops the daemon process by sending SIGTERM and waiting for it to exit.
+// If it doesn't exit within 5 seconds, sends SIGKILL.
+func Stop() error {
+	pid, err := ReadPID()
+	if err != nil {
+		return fmt.Errorf("failed to read PID: %w", err)
+	}
+
+	process, err := os.FindProcess(pid)
+	if err != nil {
+		return fmt.Errorf("failed to find process: %w", err)
+	}
+
+	// Send SIGTERM
+	if err := process.Signal(syscall.SIGTERM); err != nil {
+		return fmt.Errorf("failed to send SIGTERM: %w", err)
+	}
+
+	// Wait up to 5 seconds for process to exit
+	timeout := time.After(5 * time.Second)
+	ticker := time.NewTicker(100 * time.Millisecond)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-timeout:
+			// Process didn't exit, send SIGKILL
+			// Process may already be dead; ignore SIGKILL error.
+			_ = process.Signal(syscall.SIGKILL)
+			// Wait a bit for SIGKILL to take effect
+			time.Sleep(500 * time.Millisecond)
+			// Clean up PID file
+			_ = RemovePID()
+			return nil
+		case <-ticker.C:
+			// Check if process still exists
+			if err := process.Signal(syscall.Signal(0)); err != nil {
+				// Process is gone
+				_ = RemovePID()
+				return nil
+			}
+		}
+	}
+}

--- a/internal/daemon/daemon_windows.go
+++ b/internal/daemon/daemon_windows.go
@@ -1,0 +1,20 @@
+//go:build windows
+
+package daemon
+
+import "fmt"
+
+// IsRunning is not yet implemented on Windows.
+func IsRunning() (bool, int) {
+	return false, 0
+}
+
+// Start is not yet implemented on Windows.
+func Start(execPath string, configPath string) (int, error) {
+	return 0, fmt.Errorf("daemon start is not supported on Windows")
+}
+
+// Stop is not yet implemented on Windows.
+func Stop() error {
+	return fmt.Errorf("daemon stop is not supported on Windows")
+}

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -504,7 +504,7 @@
         .legend-line { width: 20px; height: 2px; flex-shrink: 0; border-radius: 1px; }
         .graph-detail {
             position: absolute; top: 20px; right: 20px;
-            width: 280px; max-height: calc(100% - 40px);
+            width: clamp(200px, 25%, 360px); max-height: calc(100% - 40px);
             background: var(--bg-secondary); border: 1px solid var(--border-color);
             border-radius: var(--radius-md); padding: 16px;
             z-index: 10; overflow-y: auto; display: none;
@@ -796,8 +796,11 @@
             .explore-view { padding: 12px 16px; }
             .explore-search { width: 140px; }
             .activity-drawer { width: 100vw; max-width: 100vw; }
-            .graph-controls { bottom: 10px; left: 10px; padding: 10px; }
-            .graph-legend { top: 10px; left: 10px; padding: 8px 10px; }
+            .graph-controls { bottom: 10px; left: 10px; right: 10px; padding: 10px; }
+            .graph-controls label { flex-wrap: wrap; }
+            .graph-controls input[type="range"] { width: 80px; }
+            .graph-legend { top: auto; bottom: 80px; left: 10px; padding: 8px 10px; max-width: calc(100vw - 20px); }
+            .graph-detail { width: calc(100vw - 20px); left: 10px; right: 10px; }
             .agent-grid { grid-template-columns: 1fr; }
             .agent-view { padding: 12px 16px; }
             .agent-header { flex-direction: column; align-items: flex-start; gap: 8px; }
@@ -1521,7 +1524,7 @@
             .text(function(d) { return (d.summary || '').slice(0, 30); })
             .attr('font-size', 10).attr('fill', '#cbd5e1')
             .attr('dx', function(d) { return Math.max(8, (d.salience || 0.5) * 40) + 4; }).attr('dy', 4)
-            .style('opacity', function(d) { return (d.salience || 0) > 0.5 ? 1 : 0; })
+            .style('opacity', function(d) { return (d.salience || 0) > 0.2 ? 0.9 : 0.4; })
             .style('pointer-events', 'none');
 
         var tooltip = document.getElementById('graphTooltip');
@@ -1550,7 +1553,7 @@
             tooltip.style.display = 'none';
             node.style('opacity', 1);
             link.style('opacity', function(d) { return Math.max(0.3, (d.strength || 0.5) * 0.8); });
-            label.style('opacity', function(d) { return (d.salience || 0) > 0.5 ? 1 : 0; });
+            label.style('opacity', function(d) { return (d.salience || 0) > 0.2 ? 0.9 : 0.4; });
         })
         .on('click', function(event, d) { event.stopPropagation(); showGraphDetail(d, validEdges, nodeMap); });
 


### PR DESCRIPTION
## Summary
- **#14**: Split POSIX-only `Start`/`Stop`/`IsRunning` out of `daemon.go` into `daemon_posix.go` (build tag `!windows`), added `daemon_windows.go` stub so the project compiles on Windows
- **#9**: Lowered graph label visibility threshold from salience > 0.5 to > 0.2, and dimmed low-salience labels (opacity 0.4) instead of hiding them entirely
- **#13**: Fixed graph controls and legend overlapping on mobile — repositioned legend above controls, constrained widths, made detail panel full-width
- **#12**: Replaced fixed `280px` detail panel width with `clamp(200px, 25%, 360px)` so it scales with viewport

## Test plan
- [x] `make build` succeeds
- [x] `make test` — all tests pass
- [x] `make check` — fmt + vet clean
- [x] Daemon restarted and running with new binary
- [ ] Verify dashboard graph labels are visible for most nodes
- [ ] Verify graph detail panel scales on different viewport widths
- [ ] Resize browser to < 640px — controls/legend/detail should not overlap

🤖 Generated with [Claude Code](https://claude.com/claude-code)