### PR TITLE
Improve graph: adaptive forces, fit-to-screen, responsive SVG (#7, #8, #10)

### DIFF
--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -482,8 +482,8 @@
         .strength-fill { height: 100%; border-radius: 2px; background: linear-gradient(90deg, var(--accent-teal), var(--accent-green)); }
 
         /* ── Graph View ── */
-        .graph-view { position: relative; overflow: hidden !important; }
-        .graph-view svg { width: 100%; height: 100%; }
+        .graph-view { position: relative; overflow: hidden !important; height: 100%; }
+        .graph-view svg { width: 100%; height: 100%; display: block; }
         .graph-controls {
             position: absolute; bottom: 20px; left: 20px;
             background: var(--bg-secondary); border: 1px solid var(--border-color);


### PR DESCRIPTION
## Summary
- **#7**: Force simulation parameters now adapt to node count — charge strength scales between -80 and -500, link distance between 40 and 160, center force strengthens for small graphs. Prevents scattering on large graphs and clustering on small ones.
- **#8**: Graph SVG now has a `viewBox` and `preserveAspectRatio`. `resizeGraph()` updates the viewBox and recenters the simulation instead of doing a full re-render with 50ms debounce.
- **#10**: `fitGraph()` computes the actual bounding box of all nodes and calculates proper scale/translate to fit everything with padding, instead of using a hardcoded `scale(0.8)`.

## Test plan
- [x] `make build` succeeds
- [x] `make test` — all tests pass
- [x] Daemon restarted with new binary
- [x] Open Graph tab — nodes should form a coherent layout, not scatter to edges
- [x] Click "Fit to screen" — all nodes should be visible with padding
- [x] Resize browser window — graph should rescale smoothly without flickering/re-rendering
- [x] Test with different salience/strength slider values to vary node count

🤖 Generated with [Claude Code](https://claude.com/claude-code)