### PR TITLE
Add LM Studio startup warning and encoding queue status

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,7 +188,7 @@ make setup-hooks    # Configure git pre-commit hooks
 | macOS ARM (M-series) | **Full** | Primary development platform |
 | macOS x86 | Untested | Should work with CGO enabled |
 | Linux x86_64 | **Full** | All features including systemd daemon management |
-| Windows | Not supported | Clipboard watcher has Windows code; daemon does not |
+| Windows | **Not supported** | Compiles but `start`/`stop`/`install` return errors. Use `mnemonic serve` for foreground mode. Full support planned for a future release. |
 
 ## License
 

--- a/cmd/mnemonic/main.go
+++ b/cmd/mnemonic/main.go
@@ -184,6 +184,8 @@ func startCommand(configPath string) {
 			fmt.Printf("%sMnemonic started%s (%s, PID %d)\n", colorGreen, colorReset, svc.ServiceName(), pid)
 			if cfg != nil {
 				fmt.Printf("  Dashboard: http://%s:%d\n", cfg.API.Host, cfg.API.Port)
+				healthURL := fmt.Sprintf("http://%s:%d/api/v1/health", cfg.API.Host, cfg.API.Port)
+				checkLLMFromAPI(healthURL, cfg.LLM.Endpoint)
 			}
 			fmt.Printf("  Logs:      %s\n", daemon.LogPath())
 		} else {
@@ -249,9 +251,33 @@ func startCommand(configPath string) {
 		fmt.Printf("  Dashboard: http://%s:%d\n", cfg.API.Host, cfg.API.Port)
 		fmt.Printf("  Logs:      %s\n", daemon.LogPath())
 		fmt.Printf("  PID file:  %s\n", daemon.PIDFilePath())
+
+		// Check if LLM is available via health endpoint
+		checkLLMFromAPI(apiURL, cfg.LLM.Endpoint)
 	} else {
 		fmt.Printf("%sWarning:%s Daemon started (PID %d) but health check failed.\n", colorYellow, colorReset, pid)
 		fmt.Printf("  Check logs: %s\n", daemon.LogPath())
+	}
+}
+
+// checkLLMFromAPI queries the health endpoint and warns if LLM is unavailable.
+func checkLLMFromAPI(healthURL, llmEndpoint string) {
+	resp, err := http.Get(healthURL)
+	if err != nil {
+		return
+	}
+	defer resp.Body.Close()
+
+	var health map[string]interface{}
+	if json.NewDecoder(resp.Body).Decode(&health) != nil {
+		return
+	}
+
+	llmAvail, _ := health["llm_available"].(bool)
+	if !llmAvail {
+		fmt.Printf("\n  %s⚠ LM Studio is not reachable at %s%s\n", colorYellow, llmEndpoint, colorReset)
+		fmt.Printf("  Memory encoding will not work until LM Studio is running.\n")
+		fmt.Printf("  Run 'mnemonic diagnose' for details.\n")
 	}
 }
 
@@ -571,6 +597,30 @@ func statusCommand(configPath string) {
 				fmt.Printf("    Merged:         %d\n", stats.MergedMemories)
 				fmt.Printf("    Associations:   %d\n", stats.TotalAssociations)
 				fmt.Printf("    DB size:        %.1f KB\n", float64(stats.StorageSizeBytes)/1024)
+			}
+		}
+	}
+
+	// Encoding queue depth — direct DB query
+	fmt.Printf("\n  %sEncoding Queue%s\n", colorBold, colorReset)
+	{
+		db, err := sqlite.NewSQLiteStore(cfg.Store.DBPath)
+		if err == nil {
+			defer db.Close()
+			ctx := context.Background()
+			var unprocessed int
+			row := db.DB().QueryRowContext(ctx, "SELECT COUNT(*) FROM raw_memories WHERE processed = 0")
+			if row.Scan(&unprocessed) == nil {
+				queueColor := colorGreen
+				queueNote := ""
+				if unprocessed > 500 {
+					queueColor = colorRed
+					queueNote = " (LLM may be down — run 'mnemonic diagnose')"
+				} else if unprocessed > 100 {
+					queueColor = colorYellow
+					queueNote = " (processing)"
+				}
+				fmt.Printf("    Unprocessed:    %s%d%s%s\n", queueColor, unprocessed, colorReset, queueNote)
 			}
 		}
 	}
@@ -1028,10 +1078,14 @@ func serveCommand(configPath string) {
 	bus := events.NewInMemoryBus(bufferSize)
 	defer bus.Close()
 
-	// Check LLM health (log warning if unavailable, don't fail startup)
+	// Check LLM health (warn loudly if unavailable, don't fail startup)
 	ctx, cancel := context.WithTimeout(context.Background(), time.Duration(cfg.LLM.TimeoutSec)*time.Second)
 	if err := llmProvider.Health(ctx); err != nil {
 		log.Warn("LLM provider unavailable at startup", "endpoint", cfg.LLM.Endpoint, "error", err)
+		fmt.Fprintf(os.Stderr, "\n%s⚠ WARNING: LM Studio is not reachable at %s%s\n", colorYellow, cfg.LLM.Endpoint, colorReset)
+		fmt.Fprintf(os.Stderr, "  Memory encoding will not work until LM Studio is running.\n")
+		fmt.Fprintf(os.Stderr, "  Raw observations will queue and be processed once LM Studio is available.\n")
+		fmt.Fprintf(os.Stderr, "  Run 'mnemonic diagnose' for a full health check.\n\n")
 	}
 	cancel()
 

--- a/internal/daemon/daemon_windows.go
+++ b/internal/daemon/daemon_windows.go
@@ -5,16 +5,18 @@ package daemon
 import "fmt"
 
 // IsRunning is not yet implemented on Windows.
+// Windows support is planned for a future release.
 func IsRunning() (bool, int) {
 	return false, 0
 }
 
 // Start is not yet implemented on Windows.
+// Use 'mnemonic serve' to run in the foreground instead.
 func Start(execPath string, configPath string) (int, error) {
-	return 0, fmt.Errorf("daemon start is not supported on Windows")
+	return 0, fmt.Errorf("background daemon is not yet supported on Windows — use 'mnemonic serve' to run in foreground")
 }
 
 // Stop is not yet implemented on Windows.
 func Stop() error {
-	return fmt.Errorf("daemon stop is not supported on Windows")
+	return fmt.Errorf("background daemon is not yet supported on Windows — use Ctrl+C to stop 'mnemonic serve'")
 }


### PR DESCRIPTION
## Summary

- **#48**: Bold warning when LM Studio is unreachable at startup — appears on both `serve` and `start` commands. Points users to `mnemonic diagnose`. Also adds encoding queue depth to `mnemonic status` with color-coded thresholds (green < 100, yellow 100-500, red > 500).
- **#55**: Improve Windows daemon error messages to suggest `mnemonic serve` as a foreground workaround. Update README platform table with clearer Windows status.

### `mnemonic serve` with LM Studio down:
```
⚠ WARNING: LM Studio is not reachable at http://localhost:1234/v1
  Memory encoding will not work until LM Studio is running.
  Raw observations will queue and be processed once LM Studio is available.
  Run 'mnemonic diagnose' for a full health check.
```

### `mnemonic status` now shows:
```
  Encoding Queue
    Unprocessed:    112 (processing)
```

## Test plan

- [ ] `make check` passes
- [ ] `make test` passes
- [ ] `mnemonic serve` with LM Studio stopped prints bold warning to stderr
- [ ] `mnemonic start` with LM Studio stopped prints LLM warning after "started" message
- [ ] `mnemonic status` shows encoding queue depth with appropriate color
- [ ] Windows: `mnemonic start` returns helpful error message suggesting `serve`

🤖 Generated with [Claude Code](https://claude.com/claude-code)