### PR TITLE
Filter sensitive files from ingest, watcher, and perception

### DIFF
--- a/cmd/mnemonic/ingest.go
+++ b/cmd/mnemonic/ingest.go
@@ -70,11 +70,12 @@ func ingestCommand(configPath string, args []string) {
 
 	ctx := context.Background()
 	icfg := ingest.Config{
-		Dir:             dir,
-		Project:         *projectName,
-		DryRun:          *dryRun,
-		ExcludePatterns: cfg.Perception.Filesystem.ExcludePatterns,
-		MaxContentBytes: cfg.Perception.Filesystem.MaxContentBytes,
+		Dir:               dir,
+		Project:           *projectName,
+		DryRun:            *dryRun,
+		ExcludePatterns:   cfg.Perception.Filesystem.ExcludePatterns,
+		SensitivePatterns: cfg.Perception.Filesystem.SensitivePatterns,
+		MaxContentBytes:   cfg.Perception.Filesystem.MaxContentBytes,
 		OnProgress: func(current, total int, path string) {
 			fmt.Printf("  [%d/%d] %s\n", current, total, path)
 		},

--- a/cmd/mnemonic/main.go
+++ b/cmd/mnemonic/main.go
@@ -1157,6 +1157,7 @@ func serveCommand(configPath string) {
 			fsw, err := fswatcher.NewFilesystemWatcher(fswatcher.Config{
 				WatchDirs:          cfg.Perception.Filesystem.WatchDirs,
 				ExcludePatterns:    allExclusions,
+				SensitivePatterns:  cfg.Perception.Filesystem.SensitivePatterns,
 				MaxContentBytes:    cfg.Perception.Filesystem.MaxContentBytes,
 				MaxWatches:         cfg.Perception.Filesystem.MaxWatches,
 				ShallowDepth:       cfg.Perception.Filesystem.ShallowDepth,
@@ -1526,6 +1527,12 @@ func initRuntime(configPath string) (*config.Config, *sqlite.SQLiteStore, *llm.L
 // daemon via API so the daemon's own encoding agent picks it up (no duplicate encoder).
 // If the daemon is NOT running, it spins up a local encoder and waits for it to finish.
 func rememberCommand(configPath, text string) {
+	const maxRememberBytes = 10240 // 10KB
+	if len(text) > maxRememberBytes {
+		fmt.Fprintf(os.Stderr, "Error: input too large (%d bytes, max %d). Pipe large content through 'mnemonic ingest' instead.\n", len(text), maxRememberBytes)
+		os.Exit(1)
+	}
+
 	cfg, db, llmProvider, log := initRuntime(configPath)
 	defer db.Close()
 

--- a/internal/agent/perception/heuristic.go
+++ b/internal/agent/perception/heuristic.go
@@ -288,6 +288,19 @@ func (h *HeuristicFilter) evaluateFilesystem(path, content string) (float32, str
 		}
 	}
 
+	// Hard-reject sensitive files (defense-in-depth — watcher should block these first)
+	sensitiveNames := []string{".env", "id_rsa", "id_ed25519", "id_ecdsa", ".pem", ".key",
+		"credentials", "secret", ".keychain", ".keystore", ".netrc", ".htpasswd"}
+	baseName := strings.ToLower(path)
+	if idx := strings.LastIndex(baseName, "/"); idx >= 0 {
+		baseName = baseName[idx+1:]
+	}
+	for _, s := range sensitiveNames {
+		if strings.Contains(baseName, s) {
+			return 0.0, fmt.Sprintf("filesystem: sensitive file '%s'", s), true
+		}
+	}
+
 	score := float32(0.3)
 	rationale := "filesystem event"
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -75,6 +75,7 @@ type FilesystemPerceptionConfig struct {
 	Enabled            bool     `yaml:"enabled"`
 	WatchDirs          []string `yaml:"watch_dirs"`
 	ExcludePatterns    []string `yaml:"exclude_patterns"`
+	SensitivePatterns  []string `yaml:"sensitive_patterns"` // file patterns to never ingest (e.g. .env, id_rsa)
 	MaxContentBytes    int      `yaml:"max_content_bytes"`
 	MaxWatches         int      `yaml:"max_watches"`          // hard cap on inotify watches (Linux only, 0 = unlimited)
 	ShallowDepth       int      `yaml:"shallow_depth"`        // inotify watch depth at startup (default: 3)
@@ -313,6 +314,30 @@ func Default() *Config {
 					"venv/",
 					".venv/",
 					"site-packages/",
+				},
+				SensitivePatterns: []string{
+					".env",
+					"id_rsa",
+					"id_ed25519",
+					"id_ecdsa",
+					"id_dsa",
+					".pem",
+					".key",
+					".p12",
+					".pfx",
+					"credentials",
+					"secret",
+					".keychain",
+					".keystore",
+					".jks",
+					"known_hosts",
+					"authorized_keys",
+					".netrc",
+					".npmrc",
+					".pypirc",
+					"token.json",
+					"service-account",
+					".htpasswd",
 				},
 				MaxContentBytes:    102400,
 				MaxWatches:         20000,
@@ -603,12 +628,19 @@ func (c *Config) Validate() error {
 
 	// Warn about dangerous watch directories
 	home, _ := os.UserHomeDir()
+	sensitiveDirs := []string{".ssh", ".gnupg", ".aws", ".config/gcloud"}
 	for _, dir := range c.Perception.Filesystem.WatchDirs {
 		if dir == "/" {
 			return fmt.Errorf("perception.filesystem.watch_dirs contains root directory — this will overwhelm the system")
 		}
 		if home != "" && dir == home {
 			return fmt.Errorf("perception.filesystem.watch_dirs contains home directory %q — use specific subdirectories instead (e.g. ~/Documents, ~/Projects)", home)
+		}
+		for _, sensitive := range sensitiveDirs {
+			sensitiveDir := filepath.Join(home, sensitive)
+			if dir == sensitiveDir || strings.HasPrefix(dir, sensitiveDir+"/") {
+				return fmt.Errorf("perception.filesystem.watch_dirs contains sensitive directory %q — this may expose secrets", dir)
+			}
 		}
 	}
 	if c.Memory.MaxWorkingMemory <= 0 {

--- a/internal/ingest/ingest.go
+++ b/internal/ingest/ingest.go
@@ -19,12 +19,13 @@ const batchSize = 50
 
 // Config holds parameters for an ingestion run.
 type Config struct {
-	Dir             string
-	Project         string
-	DryRun          bool
-	ExcludePatterns []string
-	MaxContentBytes int
-	OnProgress      func(current, total int, path string) // optional progress callback
+	Dir               string
+	Project           string
+	DryRun            bool
+	ExcludePatterns   []string
+	SensitivePatterns []string
+	MaxContentBytes   int
+	OnProgress        func(current, total int, path string) // optional progress callback
 }
 
 // Result holds the outcome of an ingestion run.
@@ -77,6 +78,11 @@ func Run(ctx context.Context, cfg Config, s store.Store, bus events.Bus, log *sl
 			return nil
 		}
 		if filesystem.IsBinaryFile(path) {
+			excluded++
+			return nil
+		}
+		if len(cfg.SensitivePatterns) > 0 && filesystem.IsSensitiveFile(path, cfg.SensitivePatterns) {
+			log.Warn("skipping sensitive file", "path", path)
 			excluded++
 			return nil
 		}

--- a/internal/watcher/filesystem/common.go
+++ b/internal/watcher/filesystem/common.go
@@ -12,12 +12,55 @@ import (
 type Config struct {
 	WatchDirs          []string
 	ExcludePatterns    []string
+	SensitivePatterns  []string
 	MaxContentBytes    int
 	MaxWatches         int // hard cap on inotify watches (Linux only, 0 = unlimited)
 	ShallowDepth       int // inotify watch depth at startup (default: 3)
 	PollIntervalSec    int // how often to scan cold directories (default: 45)
 	PromotionThreshold int // changes in poll window to promote to hot (default: 3)
 	DemotionTimeoutMin int // minutes of inactivity before demotion (default: 30)
+}
+
+// DefaultSensitivePatterns returns patterns for files that should never be ingested.
+func DefaultSensitivePatterns() []string {
+	return []string{
+		".env",
+		".env.",
+		"id_rsa",
+		"id_ed25519",
+		"id_ecdsa",
+		"id_dsa",
+		".pem",
+		".key",
+		".p12",
+		".pfx",
+		"credentials",
+		"secret",
+		".keychain",
+		".keystore",
+		".jks",
+		"known_hosts",
+		"authorized_keys",
+		".netrc",
+		".npmrc",
+		".pypirc",
+		"token.json",
+		"service-account",
+		".htpasswd",
+	}
+}
+
+// IsSensitiveFile checks if a file path matches any sensitive pattern.
+// Uses filename-level matching: checks if the base filename contains the pattern.
+func IsSensitiveFile(path string, patterns []string) bool {
+	base := strings.ToLower(filepath.Base(path))
+	for _, pattern := range patterns {
+		p := strings.ToLower(pattern)
+		if strings.Contains(base, p) {
+			return true
+		}
+	}
+	return false
 }
 
 // MatchesExcludePattern checks if a path matches any exclude pattern.

--- a/internal/watcher/filesystem/watcher_darwin.go
+++ b/internal/watcher/filesystem/watcher_darwin.go
@@ -158,8 +158,9 @@ func (fw *FilesystemWatcher) processEvent(event fsevents.Event) {
 	// Skip excluded paths
 	fw.mu.RLock()
 	excluded := MatchesExcludePattern(path, fw.cfg.ExcludePatterns)
+	sensitive := len(fw.cfg.SensitivePatterns) > 0 && IsSensitiveFile(path, fw.cfg.SensitivePatterns)
 	fw.mu.RUnlock()
-	if excluded {
+	if excluded || sensitive {
 		return
 	}
 

--- a/internal/watcher/filesystem/watcher_other.go
+++ b/internal/watcher/filesystem/watcher_other.go
@@ -465,8 +465,9 @@ func (fw *FilesystemWatcher) handleEvents(ctx context.Context) {
 			}
 			fw.mu.RLock()
 			excluded := MatchesExcludePattern(event.Name, fw.cfg.ExcludePatterns)
+			sensitive := len(fw.cfg.SensitivePatterns) > 0 && IsSensitiveFile(event.Name, fw.cfg.SensitivePatterns)
 			fw.mu.RUnlock()
-			if excluded {
+			if excluded || sensitive {
 				continue
 			}
 


### PR DESCRIPTION
## Summary
- Add `sensitive_patterns` config field under `perception.filesystem` with 22 default patterns (.env, SSH keys, .pem, credentials, secrets, keychains, etc.)
- Block sensitive files in all three ingestion paths:
  - **Ingest engine**: skips with warning log
  - **Filesystem watcher**: blocks at event level (darwin FSEvents + Linux fsnotify)
  - **Heuristic filter**: defense-in-depth hard-reject (score 0.0)
- Reject dangerous watch directories (`~/.ssh`, `~/.gnupg`, `~/.aws`, `~/.config/gcloud`) in config validation
- Add 10KB max length to `remember` command with helpful error pointing to `ingest`
- New `IsSensitiveFile()` and `DefaultSensitivePatterns()` helpers in filesystem package

Closes #62

## Test plan
- [x] `make check` passes (go fmt + go vet)
- [x] `make test` passes (all existing tests)
- [x] All binaries build
- [ ] Manual: `mnemonic ingest` on a directory with `.env` file → should skip with warning
- [ ] Manual: `echo "$(head -c 20000 /dev/urandom | base64)" | mnemonic remember` → should reject (>10KB)
- [ ] Manual: set `watch_dirs: ["~/.ssh"]` → should get validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)