### PR TITLE
Add optional bearer token API authentication

### DIFF
--- a/cmd/mnemonic/main.go
+++ b/cmd/mnemonic/main.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"flag"
 	"fmt"
@@ -149,6 +151,8 @@ func main() {
 		autopilotCommand(*configPath)
 	case "diagnose":
 		diagnoseCommand(*configPath)
+	case "generate-token":
+		generateTokenCommand()
 	case "version":
 		fmt.Printf("mnemonic v%s\n", Version)
 	default:
@@ -185,7 +189,7 @@ func startCommand(configPath string) {
 			if cfg != nil {
 				fmt.Printf("  Dashboard: http://%s:%d\n", cfg.API.Host, cfg.API.Port)
 				healthURL := fmt.Sprintf("http://%s:%d/api/v1/health", cfg.API.Host, cfg.API.Port)
-				checkLLMFromAPI(healthURL, cfg.LLM.Endpoint)
+				checkLLMFromAPI(healthURL, cfg.LLM.Endpoint, cfg.API.Token)
 			}
 			fmt.Printf("  Logs:      %s\n", daemon.LogPath())
 		} else {
@@ -235,7 +239,7 @@ func startCommand(configPath string) {
 	apiURL := fmt.Sprintf("http://%s:%d/api/v1/health", cfg.API.Host, cfg.API.Port)
 	healthy := false
 	for i := 0; i < 3; i++ {
-		resp, err := http.Get(apiURL)
+		resp, err := apiGet(apiURL, cfg.API.Token)
 		if err == nil {
 			resp.Body.Close()
 			if resp.StatusCode == http.StatusOK {
@@ -253,16 +257,41 @@ func startCommand(configPath string) {
 		fmt.Printf("  PID file:  %s\n", daemon.PIDFilePath())
 
 		// Check if LLM is available via health endpoint
-		checkLLMFromAPI(apiURL, cfg.LLM.Endpoint)
+		checkLLMFromAPI(apiURL, cfg.LLM.Endpoint, cfg.API.Token)
 	} else {
 		fmt.Printf("%sWarning:%s Daemon started (PID %d) but health check failed.\n", colorYellow, colorReset, pid)
 		fmt.Printf("  Check logs: %s\n", daemon.LogPath())
 	}
 }
 
+// generateTokenCommand generates a random API token and prints it.
+func generateTokenCommand() {
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		fmt.Fprintf(os.Stderr, "Error generating token: %v\n", err)
+		os.Exit(1)
+	}
+	token := hex.EncodeToString(b)
+	fmt.Printf("Generated API token:\n\n  %s\n\n", token)
+	fmt.Printf("Add this to your config.yaml:\n\n  api:\n    token: \"%s\"\n\n", token)
+	fmt.Printf("Then set this environment variable for CLI tools:\n\n  export MNEMONIC_API_TOKEN=\"%s\"\n", token)
+}
+
+// apiGet performs an HTTP GET with optional bearer token auth.
+func apiGet(url, token string) (*http.Response, error) {
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	return http.DefaultClient.Do(req)
+}
+
 // checkLLMFromAPI queries the health endpoint and warns if LLM is unavailable.
-func checkLLMFromAPI(healthURL, llmEndpoint string) {
-	resp, err := http.Get(healthURL)
+func checkLLMFromAPI(healthURL, llmEndpoint, token string) {
+	resp, err := apiGet(healthURL, token)
 	if err != nil {
 		return
 	}
@@ -522,7 +551,7 @@ func statusCommand(configPath string) {
 	apiReachable := false
 
 	// Health check
-	healthResp, err := http.Get(apiBase + "/health")
+	healthResp, err := apiGet(apiBase+"/health", cfg.API.Token)
 	if err == nil {
 		defer healthResp.Body.Close()
 		if healthResp.StatusCode == http.StatusOK {
@@ -556,7 +585,7 @@ func statusCommand(configPath string) {
 	fmt.Printf("\n  %sMemory Store%s\n", colorBold, colorReset)
 
 	if apiReachable {
-		statsResp, err := http.Get(apiBase + "/stats")
+		statsResp, err := apiGet(apiBase+"/stats", cfg.API.Token)
 		if err == nil {
 			defer statsResp.Body.Close()
 			var data map[string]interface{}
@@ -1401,6 +1430,7 @@ func serveCommand(configPath string) {
 			Host:              cfg.API.Host,
 			Port:              cfg.API.Port,
 			RequestTimeoutSec: cfg.API.RequestTimeoutSec,
+			Token:             cfg.API.Token,
 		}, apiDeps)
 
 		if err := apiServer.Start(); err != nil {
@@ -2295,6 +2325,7 @@ MONITORING COMMANDS:
 SETUP COMMANDS:
   install         Install as system service (auto-start on login)
   uninstall       Remove system service
+  generate-token  Generate a random API authentication token
   version         Show version
 
 EXAMPLES:

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -2,9 +2,11 @@ package api
 
 import (
 	"context"
+	"crypto/subtle"
 	"fmt"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/appsprout/mnemonic/internal/agent/retrieval"
@@ -20,6 +22,7 @@ type ServerConfig struct {
 	Host              string
 	Port              int
 	RequestTimeoutSec int
+	Token             string // bearer token for API auth (empty = no auth)
 }
 
 // ServerDeps holds dependencies injected into the server.
@@ -162,6 +165,26 @@ func (s *Server) middleware(next http.Handler) http.Handler {
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusOK)
 			return
+		}
+
+		// Bearer token auth for API routes (when token is configured)
+		if s.config.Token != "" && len(r.URL.Path) > 5 && r.URL.Path[:5] == "/api/" {
+			authorized := false
+			auth := r.Header.Get("Authorization")
+			if strings.HasPrefix(auth, "Bearer ") {
+				provided := auth[7:]
+				authorized = subtle.ConstantTimeCompare([]byte(provided), []byte(s.config.Token)) == 1
+			}
+			if !authorized {
+				// Also check query parameter for dashboard convenience
+				qToken := r.URL.Query().Get("token")
+				authorized = qToken != "" && subtle.ConstantTimeCompare([]byte(qToken), []byte(s.config.Token)) == 1
+			}
+			if !authorized {
+				w.Header().Set("Content-Type", "application/json")
+				http.Error(w, `{"error":"unauthorized"}`, http.StatusUnauthorized)
+				return
+			}
 		}
 
 		// JSON content type for /api/ routes

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -220,6 +220,7 @@ type APIConfig struct {
 	Host              string `yaml:"host"`
 	Port              int    `yaml:"port"`
 	RequestTimeoutSec int    `yaml:"request_timeout_sec"`
+	Token             string `yaml:"token"` // bearer token for API auth (empty = no auth)
 }
 
 // WebConfig holds web UI settings.

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -1100,7 +1100,17 @@
         STATS_POLL: 30000,
         INSIGHTS_POLL: 60000,
         MAX_EVENTS: 100,
+        TOKEN: new URLSearchParams(window.location.search).get('token') || '',
     };
+
+    // Wrapper for fetch that adds auth header when token is configured
+    function apiFetch(url, opts) {
+        opts = opts || {};
+        if (CONFIG.TOKEN) {
+            opts.headers = Object.assign({}, opts.headers, { 'Authorization': 'Bearer ' + CONFIG.TOKEN });
+        }
+        return fetch(url, opts);
+    }
 
     // ── View Switching ──
     function switchView(name) {
@@ -1143,7 +1153,7 @@
         results.innerHTML = '<div class="skeleton skeleton-card"></div><div class="skeleton skeleton-card"></div><div class="skeleton skeleton-card"></div>';
         try {
             var synth = document.getElementById('synthesizeToggle').checked;
-            var resp = await fetch(CONFIG.API_BASE + '/query', {
+            var resp = await apiFetch(CONFIG.API_BASE + '/query', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ query: query, limit: 10, synthesize: synth, include_reasoning: false }),
@@ -1209,7 +1219,7 @@
         bar.querySelectorAll('.feedback-btn').forEach(function(b) { b.classList.remove('selected'); });
         event.target.classList.add('selected');
         try {
-            await fetch(CONFIG.API_BASE + '/feedback', {
+            await apiFetch(CONFIG.API_BASE + '/feedback', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ query_id: state.lastQueryId, quality: quality }),
@@ -1235,7 +1245,7 @@
         var btn = document.querySelector('.remember-submit');
         btn.disabled = true;
         try {
-            await fetch(CONFIG.API_BASE + '/memories', {
+            await apiFetch(CONFIG.API_BASE + '/memories', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify({ content: content, source: 'web_ui', type: type, project: project }),
@@ -1268,7 +1278,7 @@
     }
 
     async function loadEpisodes(section) {
-        var resp = await fetch(CONFIG.API_BASE + '/episodes?limit=50');
+        var resp = await apiFetch(CONFIG.API_BASE + '/episodes?limit=50');
         var data = await resp.json();
         var episodes = data.episodes || [];
         if (episodes.length === 0) { section.innerHTML = '<div class="empty-state"><div class="empty-state-icon">&#128218;</div><div class="empty-state-text">No episodes yet</div><div class="empty-state-sub">Episodes are created as memories accumulate</div></div>'; return; }
@@ -1308,7 +1318,7 @@
     }
 
     async function loadMemories(section) {
-        var resp = await fetch(CONFIG.API_BASE + '/memories?limit=50&state=active');
+        var resp = await apiFetch(CONFIG.API_BASE + '/memories?limit=50&state=active');
         var data = await resp.json();
         var memories = data.memories || [];
         if (memories.length === 0) { section.innerHTML = '<div class="empty-state"><div class="empty-state-icon">&#129504;</div><div class="empty-state-text">No memories yet</div><div class="empty-state-sub">Use the Remember panel to add your first memory</div></div>'; return; }
@@ -1402,7 +1412,7 @@
     }
 
     async function loadPatterns(section) {
-        var resp = await fetch(CONFIG.API_BASE + '/patterns?limit=20');
+        var resp = await apiFetch(CONFIG.API_BASE + '/patterns?limit=20');
         var data = await resp.json();
         var patterns = data.patterns || [];
         if (patterns.length === 0) { section.innerHTML = '<div class="empty-state"><div class="empty-state-icon">&#128200;</div><div class="empty-state-text">No patterns discovered yet</div><div class="empty-state-sub">Patterns emerge after consolidation cycles</div></div>'; return; }
@@ -1428,7 +1438,7 @@
     }
 
     async function loadAbstractions(section) {
-        var resp = await fetch(CONFIG.API_BASE + '/abstractions?limit=20');
+        var resp = await apiFetch(CONFIG.API_BASE + '/abstractions?limit=20');
         var data = await resp.json();
         var abstractions = data.abstractions || [];
         if (abstractions.length === 0) { section.innerHTML = '<div class="empty-state"><div class="empty-state-icon">&#128161;</div><div class="empty-state-text">No abstractions yet</div><div class="empty-state-sub">Abstractions form from patterns during dream cycles</div></div>'; return; }
@@ -1475,7 +1485,7 @@
         var minSalience = document.getElementById('graphSalience').value;
         try {
             var graphView = document.getElementById('graphView').value;
-            var resp = await fetch(CONFIG.API_BASE + '/graph?limit=200&min_strength=' + minStrength + '&min_salience=' + minSalience + '&view=' + graphView);
+            var resp = await apiFetch(CONFIG.API_BASE + '/graph?limit=200&min_strength=' + minStrength + '&min_salience=' + minSalience + '&view=' + graphView);
             var data = await resp.json();
             state.graphData = data;
             renderGraph(data);
@@ -1680,14 +1690,14 @@
     function clearEvents() { document.getElementById('eventsContainer').innerHTML = ''; }
 
     async function triggerConsolidation() {
-        try { await fetch(CONFIG.API_BASE + '/consolidation/run', { method: 'POST' }); showToast('Consolidation triggered', 'success'); }
+        try { await apiFetch(CONFIG.API_BASE + '/consolidation/run', { method: 'POST' }); showToast('Consolidation triggered', 'success'); }
         catch (e) { showToast('Failed to trigger consolidation', 'error'); }
     }
 
     // ── Insights ──
     async function loadInsights() {
         try {
-            var resp = await fetch(CONFIG.API_BASE + '/insights');
+            var resp = await apiFetch(CONFIG.API_BASE + '/insights');
             var data = await resp.json();
             var observations = data.observations || [];
             var container = document.getElementById('insightsContainer');
@@ -1704,7 +1714,7 @@
     // ── Stats ──
     async function loadStats() {
         try {
-            var results = await Promise.all([fetch(CONFIG.API_BASE + '/health'), fetch(CONFIG.API_BASE + '/stats')]);
+            var results = await Promise.all([apiFetch(CONFIG.API_BASE + '/health'), apiFetch(CONFIG.API_BASE + '/stats')]);
             var health = await results[0].json();
             var stats = await results[1].json();
             document.getElementById('navMemoryCount').textContent = (stats.store && stats.store.active_memories) || health.memory_count || 0;
@@ -1722,7 +1732,7 @@
     // ── Projects ──
     async function loadProjects() {
         try {
-            var resp = await fetch(CONFIG.API_BASE + '/projects');
+            var resp = await apiFetch(CONFIG.API_BASE + '/projects');
             var data = await resp.json();
             state.projectList = data.projects || [];
             var select = document.getElementById('rememberProject');
@@ -1825,11 +1835,11 @@
     async function loadAgentData() {
         try {
             var [evoRes, logRes, sessRes, sysRes, cfgRes] = await Promise.all([
-                fetch(CONFIG.API_BASE + '/agent/evolution').then(function(r) { return r.json(); }),
-                fetch(CONFIG.API_BASE + '/agent/changelog').then(function(r) { return r.json(); }),
-                fetch(CONFIG.API_BASE + '/agent/sessions').then(function(r) { return r.json(); }),
-                fetch(CONFIG.API_BASE + '/stats').then(function(r) { return r.json(); }),
-                fetch(CONFIG.API_BASE + '/agent/config').then(function(r) { return r.json(); }).catch(function() { return {}; }),
+                apiFetch(CONFIG.API_BASE + '/agent/evolution').then(function(r) { return r.json(); }),
+                apiFetch(CONFIG.API_BASE + '/agent/changelog').then(function(r) { return r.json(); }),
+                apiFetch(CONFIG.API_BASE + '/agent/sessions').then(function(r) { return r.json(); }),
+                apiFetch(CONFIG.API_BASE + '/stats').then(function(r) { return r.json(); }),
+                apiFetch(CONFIG.API_BASE + '/agent/config').then(function(r) { return r.json(); }).catch(function() { return {}; }),
             ]);
             state.agentData = { evolution: evoRes, changelog: logRes, sessions: sessRes, system: sysRes };
             state.agentLoaded = true;


### PR DESCRIPTION
## Summary
- Add `api.token` config field for optional bearer token authentication
- When set, all `/api/` routes require `Authorization: Bearer <token>` header
- Also supports `?token=<token>` query parameter for dashboard convenience
- Uses `crypto/subtle.ConstantTimeCompare` to prevent timing attacks
- Static files (dashboard), WebSocket, and CORS preflight are exempt from auth
- CLI commands (`status`, `start`) use new `apiGet()` helper that includes the token
- Dashboard JavaScript reads token from URL `?token=` param and injects into all API calls via `apiFetch()` wrapper
- New `generate-token` command generates cryptographically random 256-bit hex token with setup instructions
- When token is empty/unset, behavior is unchanged (localhost-only, no auth)

Closes #53

## Test plan
- [x] `make check` passes (go fmt + go vet)
- [x] `make test` passes (all existing tests)
- [x] `generate-token` command outputs valid token with config instructions
- [ ] Manual: set `api.token` in config → API returns 401 without token, 200 with correct Bearer header
- [ ] Manual: dashboard at `/?token=<token>` can access all API endpoints
- [ ] Manual: without token in config → everything works as before (no auth)

🤖 Generated with [Claude Code](https://claude.com/claude-code)