### PR TITLE
Detect LLM model changes and warn about embedding drift

### DIFF
--- a/cmd/mnemonic/main.go
+++ b/cmd/mnemonic/main.go
@@ -1149,6 +1149,25 @@ func serveCommand(configPath string) {
 		cfg.LLM.MaxConcurrent,
 	)
 
+	// Check for embedding model drift
+	embModel := llmProvider.EmbeddingModelName()
+	if embModel != "" {
+		metaCtx, metaCancel := context.WithTimeout(context.Background(), 5*time.Second)
+		prevModel, _ := memStore.GetMeta(metaCtx, "embedding_model")
+		metaCancel()
+
+		if prevModel != "" && prevModel != embModel {
+			log.Warn("embedding model changed", "previous", prevModel, "current", embModel)
+			fmt.Fprintf(os.Stderr, "\n%s⚠ Embedding model changed: %s → %s%s\n", colorYellow, prevModel, embModel, colorReset)
+			fmt.Fprintf(os.Stderr, "  Existing semantic search may return degraded results.\n")
+			fmt.Fprintf(os.Stderr, "  Old embeddings are from a different vector space.\n\n")
+		}
+
+		metaCtx2, metaCancel2 := context.WithTimeout(context.Background(), 5*time.Second)
+		_ = memStore.SetMeta(metaCtx2, "embedding_model", embModel)
+		metaCancel2()
+	}
+
 	// Create event bus
 	bus := events.NewInMemoryBus(bufferSize)
 	defer bus.Close()

--- a/internal/llm/lmstudio.go
+++ b/internal/llm/lmstudio.go
@@ -518,3 +518,8 @@ func (p *LMStudioProvider) ModelInfo(ctx context.Context) (ModelMetadata, error)
 		MaxTokens:         1024, // Conservative default for response tokens
 	}, nil
 }
+
+// EmbeddingModelName returns the configured embedding model name.
+func (p *LMStudioProvider) EmbeddingModelName() string {
+	return p.embeddingModel
+}

--- a/internal/store/sqlite/schema.go
+++ b/internal/store/sqlite/schema.go
@@ -224,6 +224,15 @@ CREATE INDEX IF NOT EXISTS idx_abstraction_state ON abstractions(state);
 CREATE INDEX IF NOT EXISTS idx_abstraction_confidence ON abstractions(confidence);
 `
 
+const migration005 = `
+-- Migration 005: System metadata key-value store
+CREATE TABLE IF NOT EXISTS system_meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL,
+    updated_at DATETIME DEFAULT (datetime('now'))
+);
+`
+
 // InitSchema initializes the SQLite database schema by creating all tables,
 // indexes, and triggers if they don't already exist. It also configures
 // important PRAGMA settings for performance and safety.
@@ -317,6 +326,11 @@ func InitSchema(db *sql.DB) error {
 	}
 	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_episode_project ON episodes(project)`); err != nil {
 		return fmt.Errorf("failed to create idx_episode_project index: %w", err)
+	}
+
+	// Apply migration 005: System metadata
+	if _, err := db.Exec(migration005); err != nil {
+		return fmt.Errorf("failed to apply migration 005: %w", err)
 	}
 
 	return nil

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1859,6 +1859,32 @@ func (s *SQLiteStore) Close() error {
 	return nil
 }
 
+// GetMeta retrieves a value from the system_meta key-value store.
+// Returns empty string and no error if the key does not exist.
+func (s *SQLiteStore) GetMeta(ctx context.Context, key string) (string, error) {
+	var value string
+	err := s.db.QueryRowContext(ctx, `SELECT value FROM system_meta WHERE key = ?`, key).Scan(&value)
+	if err == sql.ErrNoRows {
+		return "", nil
+	}
+	if err != nil {
+		return "", fmt.Errorf("getting meta %q: %w", key, err)
+	}
+	return value, nil
+}
+
+// SetMeta upserts a value in the system_meta key-value store.
+func (s *SQLiteStore) SetMeta(ctx context.Context, key, value string) error {
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO system_meta (key, value, updated_at) VALUES (?, ?, datetime('now'))
+		 ON CONFLICT(key) DO UPDATE SET value = excluded.value, updated_at = excluded.updated_at`,
+		key, value)
+	if err != nil {
+		return fmt.Errorf("setting meta %q: %w", key, err)
+	}
+	return nil
+}
+
 // Helper functions
 
 // nullableString converts an empty string to nil for SQL NULL, or returns the string.


### PR DESCRIPTION
## Summary
- Adds `system_meta` key-value table for persistent daemon metadata
- On every `serve` startup, records the configured embedding model name
- If the model changed since last run, prints a clear warning about degraded semantic search
- Adds `GetMeta`/`SetMeta` methods to SQLite store for reuse by other features

Closes #60

## Test plan
- [x] `make check` and `make test` pass
- [x] `make build` succeeds
- [x] Schema migration is idempotent (CREATE TABLE IF NOT EXISTS)

🤖 Generated with [Claude Code](https://claude.com/claude-code)