### PR TITLE
Add memory source tracking with dashboard hover-highlight

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ### Added
 - Gemini API support with API key authentication
 - LLM usage monitoring with dashboard, API, and per-agent tracking
+- Live-updating dashboard with real-time data refresh
+- Multi-theme selector: Midnight, Ember, Nord, Slate, Parchment (persists in localStorage)
+- Memory source tracking — `source` field on encoded memories, backfilled from raw observations, rendered as hoverable tags in timeline
 - Optional bearer token API authentication
 - Embedding index scalability monitoring
 - Embedding drift detection (warns on LLM model changes)
@@ -27,8 +30,9 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 - Sensitive file filtering in ingest, watcher, and perception
 
 ### Fixed
-- Graph visualization: adaptive forces, fit-to-screen, responsive SVG, label visibility
+- Graph visualization: reworked D3 force layout, adaptive forces, fit-to-screen, responsive SVG, label visibility
 - Dashboard XSS and silent error handling
+- Dashboard badge colors converted from hardcoded `rgba()` to `color-mix()` for theme compatibility
 - Pattern deduplication with embedding-level checks
 - Noisy memory ingestion filtering
 - Windows compilation errors
@@ -38,6 +42,7 @@ Format follows [Keep a Changelog](https://keepachangelog.com/). Versioning follo
 ### Changed
 - Standardized exit codes and user-facing error messages
 - Improved recall quality: pattern cleanup, concise synthesis
+- Tuned config defaults for Gemini cloud API (higher concurrency, larger context windows)
 
 ## [0.6.0] - 2025-02-01
 

--- a/internal/agent/consolidation/agent.go
+++ b/internal/agent/consolidation/agent.go
@@ -619,6 +619,7 @@ Respond with ONLY a JSON object:
 		AccessCount:  0,
 		LastAccessed: time.Time{},
 		State:        store.MemoryStateActive,
+		Source:       "consolidation",
 		CreatedAt:    now,
 		UpdatedAt:    now,
 	}, nil

--- a/internal/agent/encoding/agent.go
+++ b/internal/agent/encoding/agent.go
@@ -541,6 +541,7 @@ func (ea *EncodingAgent) encodeMemory(ctx context.Context, rawID string) error {
 		CreatedAt:    time.Now(),
 		UpdatedAt:    time.Now(),
 		EpisodeID:    getEpisodeIDForRaw(ea, ctx, raw),
+		Source:       raw.Source,
 		Project:      raw.Project,
 		SessionID:    raw.SessionID,
 	}

--- a/internal/api/routes/graph.go
+++ b/internal/api/routes/graph.go
@@ -17,6 +17,7 @@ type GraphNode struct {
 	Salience      float32  `json:"salience"`
 	State         string   `json:"state"`
 	Concepts      []string `json:"concepts"`
+	Source        string   `json:"source,omitempty"`
 	EmotionalTone string   `json:"emotional_tone,omitempty"`
 	Significance  string   `json:"significance,omitempty"`
 	Timestamp     string   `json:"timestamp"`
@@ -278,6 +279,7 @@ func HandleGraph(s store.Store, log *slog.Logger) http.HandlerFunc {
 					Salience:  mem.Salience,
 					State:     mem.State,
 					Concepts:  mem.Concepts,
+					Source:    mem.Source,
 					Timestamp: mem.Timestamp.Format(time.RFC3339),
 				}
 

--- a/internal/store/sqlite/schema.go
+++ b/internal/store/sqlite/schema.go
@@ -347,6 +347,17 @@ func InitSchema(db *sql.DB) error {
 		return fmt.Errorf("failed to create idx_episode_project index: %w", err)
 	}
 
+	// Migration 007: Add source column to memories
+	_, err = db.Exec(`ALTER TABLE memories ADD COLUMN source TEXT`)
+	if err != nil && !isAlterTableDuplicateColumn(err) {
+		return fmt.Errorf("failed to add memories.source column: %w", err)
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_memory_source ON memories(source)`); err != nil {
+		return fmt.Errorf("failed to create idx_memory_source index: %w", err)
+	}
+	// Backfill source from raw_memories where possible
+	_, _ = db.Exec(`UPDATE memories SET source = (SELECT raw_memories.source FROM raw_memories WHERE raw_memories.id = memories.raw_id) WHERE source IS NULL AND raw_id IS NOT NULL AND raw_id != ''`)
+
 	// Apply migration 005: System metadata
 	if _, err := db.Exec(migration005); err != nil {
 		return fmt.Errorf("failed to apply migration 005: %w", err)

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -343,7 +343,7 @@ func scanRawMemoryRows(rows *sql.Rows) ([]store.RawMemory, error) {
 }
 
 // memoryColumns is the standard column list for memory queries.
-const memoryColumns = `id, raw_id, timestamp, content, summary, concepts, embedding, salience, access_count, last_accessed, state, gist_of, episode_id, project, session_id, created_at, updated_at`
+const memoryColumns = `id, raw_id, timestamp, content, summary, concepts, embedding, salience, access_count, last_accessed, state, gist_of, episode_id, source, project, session_id, created_at, updated_at`
 
 // scanMemory scans a memory row from the database.
 func scanMemory(row *sql.Row) (store.Memory, error) {
@@ -353,6 +353,7 @@ func scanMemory(row *sql.Row) (store.Memory, error) {
 	var gistOfStr sql.NullString
 	var lastAccessedStr sql.NullString
 	var episodeID sql.NullString
+	var source sql.NullString
 	var project, sessionID sql.NullString
 
 	err := row.Scan(
@@ -369,6 +370,7 @@ func scanMemory(row *sql.Row) (store.Memory, error) {
 		&mem.State,
 		&gistOfStr,
 		&episodeID,
+		&source,
 		&project,
 		&sessionID,
 		&mem.CreatedAt,
@@ -410,6 +412,9 @@ func scanMemory(row *sql.Row) (store.Memory, error) {
 	// Decode episode_id
 	mem.EpisodeID = episodeID.String
 
+	// Decode source
+	mem.Source = source.String
+
 	// Decode project and session_id
 	mem.Project = project.String
 	mem.SessionID = sessionID.String
@@ -437,6 +442,7 @@ func scanMemoryRows(rows *sql.Rows) ([]store.Memory, error) {
 		var gistOfStr sql.NullString
 		var lastAccessedStr sql.NullString
 		var episodeID sql.NullString
+		var source sql.NullString
 		var project, sessionID sql.NullString
 
 		err := rows.Scan(
@@ -453,6 +459,7 @@ func scanMemoryRows(rows *sql.Rows) ([]store.Memory, error) {
 			&mem.State,
 			&gistOfStr,
 			&episodeID,
+			&source,
 			&project,
 			&sessionID,
 			&mem.CreatedAt,
@@ -493,6 +500,9 @@ func scanMemoryRows(rows *sql.Rows) ([]store.Memory, error) {
 
 		// Decode episode_id
 		mem.EpisodeID = episodeID.String
+
+		// Decode source
+		mem.Source = source.String
 
 		// Decode project and session_id
 		mem.Project = project.String
@@ -781,8 +791,8 @@ func (s *SQLiteStore) WriteMemory(ctx context.Context, mem store.Memory) error {
 
 	query := `
 	INSERT INTO memories
-	(id, raw_id, timestamp, content, summary, concepts, embedding, salience, access_count, last_accessed, state, gist_of, episode_id, project, session_id, created_at, updated_at)
-	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	(id, raw_id, timestamp, content, summary, concepts, embedding, salience, access_count, last_accessed, state, gist_of, episode_id, source, project, session_id, created_at, updated_at)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 
 	// Convert empty episode ID to nil so FK constraint allows NULL
@@ -805,6 +815,7 @@ func (s *SQLiteStore) WriteMemory(ctx context.Context, mem store.Memory) error {
 		mem.State,
 		gistOfStr,
 		episodeID,
+		nullableString(mem.Source),
 		nullableString(mem.Project),
 		nullableString(mem.SessionID),
 		mem.CreatedAt.Format(time.RFC3339),
@@ -861,7 +872,7 @@ func (s *SQLiteStore) UpdateMemory(ctx context.Context, mem store.Memory) error 
 	UPDATE memories
 	SET raw_id = ?, timestamp = ?, content = ?, summary = ?, concepts = ?, embedding = ?,
 	    salience = ?, access_count = ?, last_accessed = ?, state = ?, gist_of = ?,
-	    project = ?, session_id = ?, updated_at = ?
+	    source = ?, project = ?, session_id = ?, updated_at = ?
 	WHERE id = ?
 	`
 
@@ -877,6 +888,7 @@ func (s *SQLiteStore) UpdateMemory(ctx context.Context, mem store.Memory) error 
 		mem.LastAccessed.Format(time.RFC3339),
 		mem.State,
 		gistOfStr,
+		nullableString(mem.Source),
 		nullableString(mem.Project),
 		nullableString(mem.SessionID),
 		mem.UpdatedAt.Format(time.RFC3339),
@@ -1384,8 +1396,8 @@ func (s *SQLiteStore) BatchMergeMemories(ctx context.Context, sourceIDs []string
 
 	writeQuery := `
 	INSERT INTO memories
-	(id, raw_id, timestamp, content, summary, concepts, embedding, salience, access_count, last_accessed, state, gist_of, episode_id, project, session_id, created_at, updated_at)
-	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	(id, raw_id, timestamp, content, summary, concepts, embedding, salience, access_count, last_accessed, state, gist_of, episode_id, source, project, session_id, created_at, updated_at)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 
 	// Convert empty episode ID to nil so FK constraint allows NULL
@@ -1408,6 +1420,7 @@ func (s *SQLiteStore) BatchMergeMemories(ctx context.Context, sourceIDs []string
 		gist.State,
 		gistOfStr,
 		gistEpisodeID,
+		nullableString(gist.Source),
 		nullableString(gist.Project),
 		nullableString(gist.SessionID),
 		gist.CreatedAt.Format(time.RFC3339),

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -56,6 +56,7 @@ type Memory struct {
 	State        string    `json:"state"`                // "active", "fading", "archived", "merged"
 	GistOf       []string  `json:"gist_of,omitempty"`    // if merged: source memory IDs
 	EpisodeID    string    `json:"episode_id,omitempty"` // link to parent episode
+	Source       string    `json:"source,omitempty"`     // origin: "filesystem", "terminal", "clipboard", "mcp", "consolidation"
 	Project      string    `json:"project,omitempty"`
 	SessionID    string    `json:"session_id,omitempty"`
 	CreatedAt    time.Time `json:"created_at"`

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -760,6 +760,14 @@
         }
         .tl-concept:hover { background: rgba(139, 92, 246, 0.2); }
         .tl-concept.concept-active { background: rgba(6,182,212,0.2); color: var(--accent-cyan); }
+        .tl-source {
+            padding: 1px 7px; border-radius: 8px;
+            font-size: 0.67rem; font-weight: 500;
+            background: rgba(6, 182, 212, 0.1); color: var(--accent-teal);
+            cursor: default; transition: background 0.15s;
+        }
+        .tl-source:hover { background: rgba(6, 182, 212, 0.2); }
+        .tl-source.concept-active { background: rgba(6,182,212,0.25); color: var(--accent-cyan); }
 
         .tl-card-detail {
             display: none; margin-top: 10px; padding-top: 10px;
@@ -1949,9 +1957,12 @@
         var time = relativeTime(item._date);
         var absTime = item._date.toLocaleString(undefined, { hour: '2-digit', minute: '2-digit' });
         var concepts = item._concepts || [];
+        var source = item._source || '';
 
+        // Include source in data-concepts so hover-highlight works across source tags
+        var allTags = source ? [source].concat(concepts) : concepts;
         var html = '<div class="tl-card tl-' + kind + '" data-id="' + escapeHtml(item._id) + '" onclick="expandTimelineCard(this)" ';
-        html += 'data-concepts="' + escapeHtml(concepts.join(',')) + '">';
+        html += 'data-concepts="' + escapeHtml(allTags.join(',')) + '">';
         html += '<div class="tl-card-head">';
         html += '<span class="tl-card-type ct-' + kind + '">' + escapeHtml(kind) + '</span>';
         html += '<span class="tl-card-title">' + escapeHtml(item._title) + '</span>';
@@ -1976,8 +1987,11 @@
             html += '</div>';
         }
 
-        if (concepts.length > 0) {
+        if (source || concepts.length > 0) {
             html += '<div class="tl-card-concepts">';
+            if (source) {
+                html += '<span class="tl-source" onmouseenter="highlightTimelineConcept(this.textContent)" onmouseleave="clearTimelineHighlight()">' + escapeHtml(source) + '</span>';
+            }
             concepts.slice(0, 8).forEach(function(c) {
                 html += '<span class="tl-concept" onmouseenter="highlightTimelineConcept(this.textContent)" onmouseleave="clearTimelineHighlight()">' + escapeHtml(c) + '</span>';
             });
@@ -2039,7 +2053,7 @@
                 card.classList.remove('highlighted');
             }
         });
-        document.querySelectorAll('.tl-concept').forEach(function(tag) {
+        document.querySelectorAll('.tl-concept, .tl-source').forEach(function(tag) {
             if (tag.textContent === concept) tag.classList.add('concept-active');
         });
     }
@@ -2048,7 +2062,7 @@
         document.querySelectorAll('.tl-card').forEach(function(card) {
             card.classList.remove('dimmed', 'highlighted');
         });
-        document.querySelectorAll('.tl-concept').forEach(function(tag) {
+        document.querySelectorAll('.tl-concept, .tl-source').forEach(function(tag) {
             tag.classList.remove('concept-active');
         });
     }
@@ -2101,6 +2115,7 @@
                     _title: m.summary,
                     _date: new Date(m.timestamp || m.created_at),
                     _concepts: m.concepts || [],
+                    _source: m.source || '',
                     _tone: '',
                     _salience: m.salience || 0,
                     _fileCount: 0,

--- a/migrations/004_memory_source.sql
+++ b/migrations/004_memory_source.sql
@@ -1,0 +1,7 @@
+-- Add source column to memories table to track origin (filesystem, terminal, clipboard, mcp, consolidation, etc.)
+ALTER TABLE memories ADD COLUMN source TEXT;
+
+-- Backfill source from raw_memories where possible
+UPDATE memories SET source = (
+    SELECT raw_memories.source FROM raw_memories WHERE raw_memories.id = memories.raw_id
+) WHERE memories.raw_id IS NOT NULL AND memories.raw_id != '';


### PR DESCRIPTION
## Summary
- Added `source` field to the `Memory` struct, propagated from `RawMemory` through encoding
- Consolidation agent tags merged memories with `source: "consolidation"`
- Migration adds `source TEXT` column with backfill from `raw_memories`
- Dashboard timeline renders source as a teal tag with the same hover-highlight behavior as concepts — hover "filesystem" and all filesystem memories light up
- Updated changelog for 0.7.0

## Test plan
- [x] `make build` passes
- [x] `make test` passes (all tests green)
- [x] Daemon restarted, API confirms `source` field populated (34 filesystem, 22 git in current DB)
- [x] Verify source tags render in timeline at http://127.0.0.1:9999/#timeline
- [x] Verify hover-highlight works across source tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)