### PR TITLE
refactor: remove duplicate Agent interface in perception

### DIFF
--- a/internal/agent/perception/agent.go
+++ b/internal/agent/perception/agent.go
@@ -8,6 +8,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/appsprout/mnemonic/internal/agent"
 	"github.com/appsprout/mnemonic/internal/events"
 	"github.com/appsprout/mnemonic/internal/llm"
 	"github.com/appsprout/mnemonic/internal/store"
@@ -434,13 +435,5 @@ func (pa *PerceptionAgent) mergeMetadata(
 	return merged
 }
 
-// Ensure PerceptionAgent implements agent.Agent interface
-var _ Agent = (*PerceptionAgent)(nil)
-
-// Agent defines the interface that perception agents must implement.
-type Agent interface {
-	Name() string
-	Start(ctx context.Context, bus events.Bus) error
-	Stop() error
-	Health(ctx context.Context) error
-}
+// Ensure PerceptionAgent implements agent.Agent interface.
+var _ agent.Agent = (*PerceptionAgent)(nil)


### PR DESCRIPTION
## Summary
- Removed duplicate `Agent` interface from `internal/agent/perception/agent.go` that was identical to the canonical `agent.Agent` in `internal/agent/agent.go`
- Updated compile-time interface check to reference `agent.Agent` directly

## Test plan
- [x] `go build` passes
- [x] Pre-commit hooks pass (fmt, vet, lint)

Closes #86

🤖 Generated with [Claude Code](https://claude.com/claude-code)