### PR TITLE
refactor: consolidate duplicate CORS origin lists

### DIFF
--- a/internal/api/routes/ws.go
+++ b/internal/api/routes/ws.go
@@ -30,8 +30,9 @@ type wsConn struct {
 	log             *slog.Logger
 }
 
-// allowedWSOrigins is the set of origins allowed to open WebSocket connections.
-var allowedWSOrigins = map[string]bool{
+// AllowedOrigins is the set of origins allowed for CORS and WebSocket connections.
+// Used by both the CORS middleware in server.go and the WebSocket upgrader here.
+var AllowedOrigins = map[string]bool{
 	"http://localhost:3000": true,
 	"http://localhost:8080": true,
 	"http://127.0.0.1:3000": true,
@@ -49,7 +50,7 @@ var upgrader = websocket.Upgrader{
 		if origin == "" {
 			return true // Allow requests with no origin (e.g., CLI tools)
 		}
-		return allowedWSOrigins[origin]
+		return AllowedOrigins[origin]
 	},
 }
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -133,15 +133,6 @@ func (s *Server) registerRoutes() {
 	}
 }
 
-// allowedCORSOrigins is the set of origins allowed for CORS requests.
-var allowedCORSOrigins = map[string]bool{
-	"http://localhost:3000": true,
-	"http://localhost:8080": true,
-	"http://127.0.0.1:3000": true,
-	"http://127.0.0.1:8080": true,
-	"http://localhost:9999": true,
-	"http://127.0.0.1:9999": true,
-}
 
 // middleware applies global middleware to the request handler.
 func (s *Server) middleware(next http.Handler) http.Handler {
@@ -158,7 +149,7 @@ func (s *Server) middleware(next http.Handler) http.Handler {
 		// Access-Control-Allow-Origin only supports a single origin value,
 		// so we check the request Origin against an allowlist.
 		origin := r.Header.Get("Origin")
-		if allowedCORSOrigins[origin] {
+		if routes.AllowedOrigins[origin] {
 			w.Header().Set("Access-Control-Allow-Origin", origin)
 			w.Header().Set("Vary", "Origin")
 		}


### PR DESCRIPTION
## Summary
- Exported `AllowedOrigins` from `routes` package as single source of truth
- Removed duplicate `allowedCORSOrigins` map from `server.go`
- Both CORS middleware and WebSocket upgrader now reference the same map

## Test plan
- [x] `go build` passes
- [x] Pre-commit hooks pass

Closes #87

🤖 Generated with [Claude Code](https://claude.com/claude-code)