### PR TITLE
refactor: deduplicate scan function pairs in SQLite store

### DIFF
--- a/internal/store/sqlite/abstractions.go
+++ b/internal/store/sqlite/abstractions.go
@@ -168,13 +168,13 @@ func (s *SQLiteStore) SearchAbstractionsByEmbedding(ctx context.Context, embeddi
 	return abstractions, nil
 }
 
-// scanAbstraction scans a single abstraction row.
-func scanAbstraction(row *sql.Row) (store.Abstraction, error) {
+// scanAbstractionFrom scans a single Abstraction from any scanner.
+func scanAbstractionFrom(s scanner) (store.Abstraction, error) {
 	var a store.Abstraction
 	var parentID, sourcePatternIDsStr, sourceMemoryIDsStr, conceptsStr sql.NullString
 	var embeddingBlob []byte
 
-	err := row.Scan(
+	err := s.Scan(
 		&a.ID,
 		&a.Level,
 		&a.Title,
@@ -191,10 +191,7 @@ func scanAbstraction(row *sql.Row) (store.Abstraction, error) {
 		&a.UpdatedAt,
 	)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			return a, fmt.Errorf("abstraction: %w", store.ErrNotFound)
-		}
-		return a, fmt.Errorf("failed to scan abstraction: %w", err)
+		return a, err
 	}
 
 	a.ParentID = parentID.String
@@ -208,44 +205,28 @@ func scanAbstraction(row *sql.Row) (store.Abstraction, error) {
 	return a, nil
 }
 
+// scanAbstraction scans a single abstraction row.
+func scanAbstraction(row *sql.Row) (store.Abstraction, error) {
+	a, err := scanAbstractionFrom(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return a, fmt.Errorf("abstraction: %w", store.ErrNotFound)
+		}
+		return a, fmt.Errorf("failed to scan abstraction: %w", err)
+	}
+	return a, nil
+}
+
 // scanAbstractionRows scans multiple abstraction rows.
 func scanAbstractionRows(rows *sql.Rows) ([]store.Abstraction, error) {
 	defer rows.Close()
 	var abstractions []store.Abstraction
 
 	for rows.Next() {
-		var a store.Abstraction
-		var parentID, sourcePatternIDsStr, sourceMemoryIDsStr, conceptsStr sql.NullString
-		var embeddingBlob []byte
-
-		err := rows.Scan(
-			&a.ID,
-			&a.Level,
-			&a.Title,
-			&a.Description,
-			&parentID,
-			&sourcePatternIDsStr,
-			&sourceMemoryIDsStr,
-			&a.Confidence,
-			&conceptsStr,
-			&embeddingBlob,
-			&a.AccessCount,
-			&a.State,
-			&a.CreatedAt,
-			&a.UpdatedAt,
-		)
+		a, err := scanAbstractionFrom(rows)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan abstraction row: %w", err)
 		}
-
-		a.ParentID = parentID.String
-		a.SourcePatternIDs, _ = decodeStringSlice(sourcePatternIDsStr.String)
-		a.SourceMemoryIDs, _ = decodeStringSlice(sourceMemoryIDsStr.String)
-		a.Concepts, _ = decodeStringSlice(conceptsStr.String)
-		if len(embeddingBlob) > 0 {
-			a.Embedding = decodeEmbedding(embeddingBlob)
-		}
-
 		abstractions = append(abstractions, a)
 	}
 

--- a/internal/store/sqlite/episodes.go
+++ b/internal/store/sqlite/episodes.go
@@ -143,15 +143,15 @@ func (s *SQLiteStore) CloseEpisode(ctx context.Context, id string) error {
 	return nil
 }
 
-// scanEpisode scans a single row into an Episode.
-func scanEpisode(row *sql.Row) (store.Episode, error) {
+// scanEpisodeFrom scans a single Episode from any scanner.
+func scanEpisodeFrom(s scanner) (store.Episode, error) {
 	var ep store.Episode
 	var startStr, endStr, createdStr, updatedStr string
 	var rawIDsStr, memIDsStr string
 	var title, summary, narrative, emotionalTone, outcome sql.NullString
 	var conceptsStr, filesStr, timelineStr sql.NullString
 
-	err := row.Scan(
+	err := s.Scan(
 		&ep.ID, &title, &startStr, &endStr, &ep.DurationSec,
 		&rawIDsStr, &memIDsStr, &summary, &narrative,
 		&ep.Salience, &emotionalTone, &outcome, &ep.State,
@@ -159,10 +159,7 @@ func scanEpisode(row *sql.Row) (store.Episode, error) {
 		&conceptsStr, &filesStr, &timelineStr,
 	)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			return ep, fmt.Errorf("episode: %w", store.ErrNotFound)
-		}
-		return ep, fmt.Errorf("failed to scan episode: %w", err)
+		return ep, err
 	}
 
 	ep.Title = title.String
@@ -185,41 +182,23 @@ func scanEpisode(row *sql.Row) (store.Episode, error) {
 	return ep, nil
 }
 
+// scanEpisode scans a single row into an Episode.
+func scanEpisode(row *sql.Row) (store.Episode, error) {
+	ep, err := scanEpisodeFrom(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return ep, fmt.Errorf("episode: %w", store.ErrNotFound)
+		}
+		return ep, fmt.Errorf("failed to scan episode: %w", err)
+	}
+	return ep, nil
+}
+
 // scanEpisodeRow scans from sql.Rows (for list queries).
 func scanEpisodeRow(rows *sql.Rows) (store.Episode, error) {
-	var ep store.Episode
-	var startStr, endStr, createdStr, updatedStr string
-	var rawIDsStr, memIDsStr string
-	var title, summary, narrative, emotionalTone, outcome sql.NullString
-	var conceptsStr, filesStr, timelineStr sql.NullString
-
-	err := rows.Scan(
-		&ep.ID, &title, &startStr, &endStr, &ep.DurationSec,
-		&rawIDsStr, &memIDsStr, &summary, &narrative,
-		&ep.Salience, &emotionalTone, &outcome, &ep.State,
-		&createdStr, &updatedStr,
-		&conceptsStr, &filesStr, &timelineStr,
-	)
+	ep, err := scanEpisodeFrom(rows)
 	if err != nil {
 		return ep, fmt.Errorf("failed to scan episode row: %w", err)
 	}
-
-	ep.Title = title.String
-	ep.Summary = summary.String
-	ep.Narrative = narrative.String
-	ep.EmotionalTone = emotionalTone.String
-	ep.Outcome = outcome.String
-	ep.StartTime, _ = time.Parse(time.RFC3339, startStr)
-	ep.EndTime, _ = time.Parse(time.RFC3339, endStr)
-	ep.CreatedAt, _ = time.Parse(time.RFC3339, createdStr)
-	ep.UpdatedAt, _ = time.Parse(time.RFC3339, updatedStr)
-	ep.RawMemoryIDs, _ = decodeStringSlice(rawIDsStr)
-	ep.MemoryIDs, _ = decodeStringSlice(memIDsStr)
-	ep.Concepts, _ = decodeStringSlice(conceptsStr.String)
-	ep.FilesModified, _ = decodeStringSlice(filesStr.String)
-	if timelineStr.Valid && timelineStr.String != "" {
-		_ = json.Unmarshal([]byte(timelineStr.String), &ep.EventTimeline)
-	}
-
 	return ep, nil
 }

--- a/internal/store/sqlite/patterns.go
+++ b/internal/store/sqlite/patterns.go
@@ -176,14 +176,14 @@ func nullableTime(t time.Time) interface{} {
 	return t.Format(time.RFC3339)
 }
 
-// scanPattern scans a single pattern row.
-func scanPattern(row *sql.Row) (store.Pattern, error) {
+// scanPatternFrom scans a single Pattern from any scanner.
+func scanPatternFrom(s scanner) (store.Pattern, error) {
 	var p store.Pattern
 	var evidenceIDsStr, conceptsStr sql.NullString
 	var embeddingBlob []byte
 	var project, lastAccessedStr sql.NullString
 
-	err := row.Scan(
+	err := s.Scan(
 		&p.ID,
 		&p.PatternType,
 		&p.Title,
@@ -200,10 +200,7 @@ func scanPattern(row *sql.Row) (store.Pattern, error) {
 		&p.UpdatedAt,
 	)
 	if err != nil {
-		if err == sql.ErrNoRows {
-			return p, fmt.Errorf("pattern: %w", store.ErrNotFound)
-		}
-		return p, fmt.Errorf("failed to scan pattern: %w", err)
+		return p, err
 	}
 
 	p.Project = project.String
@@ -219,47 +216,28 @@ func scanPattern(row *sql.Row) (store.Pattern, error) {
 	return p, nil
 }
 
+// scanPattern scans a single pattern row.
+func scanPattern(row *sql.Row) (store.Pattern, error) {
+	p, err := scanPatternFrom(row)
+	if err != nil {
+		if err == sql.ErrNoRows {
+			return p, fmt.Errorf("pattern: %w", store.ErrNotFound)
+		}
+		return p, fmt.Errorf("failed to scan pattern: %w", err)
+	}
+	return p, nil
+}
+
 // scanPatternRows scans multiple pattern rows.
 func scanPatternRows(rows *sql.Rows) ([]store.Pattern, error) {
 	defer rows.Close()
 	var patterns []store.Pattern
 
 	for rows.Next() {
-		var p store.Pattern
-		var evidenceIDsStr, conceptsStr sql.NullString
-		var embeddingBlob []byte
-		var project, lastAccessedStr sql.NullString
-
-		err := rows.Scan(
-			&p.ID,
-			&p.PatternType,
-			&p.Title,
-			&p.Description,
-			&evidenceIDsStr,
-			&p.Strength,
-			&project,
-			&conceptsStr,
-			&embeddingBlob,
-			&p.AccessCount,
-			&lastAccessedStr,
-			&p.State,
-			&p.CreatedAt,
-			&p.UpdatedAt,
-		)
+		p, err := scanPatternFrom(rows)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan pattern row: %w", err)
 		}
-
-		p.Project = project.String
-		p.EvidenceIDs, _ = decodeStringSlice(evidenceIDsStr.String)
-		p.Concepts, _ = decodeStringSlice(conceptsStr.String)
-		if len(embeddingBlob) > 0 {
-			p.Embedding = decodeEmbedding(embeddingBlob)
-		}
-		if lastAccessedStr.Valid && lastAccessedStr.String != "" {
-			p.LastAccessed, _ = time.Parse(time.RFC3339, lastAccessedStr.String)
-		}
-
 		patterns = append(patterns, p)
 	}
 

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -17,6 +17,11 @@ import (
 	store "github.com/appsprout/mnemonic/internal/store"
 )
 
+// scanner is satisfied by both *sql.Row and *sql.Rows.
+type scanner interface {
+	Scan(dest ...any) error
+}
+
 // SQLiteStore implements the Store interface using SQLite as the backend.
 type SQLiteStore struct {
 	db            *sql.DB
@@ -346,7 +351,7 @@ func scanRawMemoryRows(rows *sql.Rows) ([]store.RawMemory, error) {
 const memoryColumns = `id, raw_id, timestamp, content, summary, concepts, embedding, salience, access_count, last_accessed, state, gist_of, episode_id, source, project, session_id, created_at, updated_at`
 
 // scanMemory scans a memory row from the database.
-func scanMemory(row *sql.Row) (store.Memory, error) {
+func scanMemoryFrom(s scanner) (store.Memory, error) {
 	var mem store.Memory
 	var conceptsStr sql.NullString
 	var embeddingBlob []byte
@@ -356,7 +361,7 @@ func scanMemory(row *sql.Row) (store.Memory, error) {
 	var source sql.NullString
 	var project, sessionID sql.NullString
 
-	err := row.Scan(
+	err := s.Scan(
 		&mem.ID,
 		&mem.RawID,
 		&mem.Timestamp,
@@ -430,92 +435,20 @@ func scanMemory(row *sql.Row) (store.Memory, error) {
 	return mem, nil
 }
 
+func scanMemory(row *sql.Row) (store.Memory, error) {
+	return scanMemoryFrom(row)
+}
+
 // scanMemoryRows scans multiple memory rows from rows.
 func scanMemoryRows(rows *sql.Rows) ([]store.Memory, error) {
 	defer rows.Close()
 	var memories []store.Memory
 
 	for rows.Next() {
-		var mem store.Memory
-		var conceptsStr sql.NullString
-		var embeddingBlob []byte
-		var gistOfStr sql.NullString
-		var lastAccessedStr sql.NullString
-		var episodeID sql.NullString
-		var source sql.NullString
-		var project, sessionID sql.NullString
-
-		err := rows.Scan(
-			&mem.ID,
-			&mem.RawID,
-			&mem.Timestamp,
-			&mem.Content,
-			&mem.Summary,
-			&conceptsStr,
-			&embeddingBlob,
-			&mem.Salience,
-			&mem.AccessCount,
-			&lastAccessedStr,
-			&mem.State,
-			&gistOfStr,
-			&episodeID,
-			&source,
-			&project,
-			&sessionID,
-			&mem.CreatedAt,
-			&mem.UpdatedAt,
-		)
+		mem, err := scanMemoryFrom(rows)
 		if err != nil {
 			return nil, fmt.Errorf("failed to scan memory row: %w", err)
 		}
-
-		// Decode concepts
-		if conceptsStr.Valid && conceptsStr.String != "" {
-			concepts, err := decodeStringSlice(conceptsStr.String)
-			if err != nil {
-				return nil, err
-			}
-			mem.Concepts = concepts
-		} else {
-			mem.Concepts = []string{}
-		}
-
-		// Decode embedding
-		if len(embeddingBlob) > 0 {
-			mem.Embedding = decodeEmbedding(embeddingBlob)
-		} else {
-			mem.Embedding = []float32{}
-		}
-
-		// Decode gist_of
-		if gistOfStr.Valid && gistOfStr.String != "" {
-			gistOf, err := decodeStringSlice(gistOfStr.String)
-			if err != nil {
-				return nil, err
-			}
-			mem.GistOf = gistOf
-		} else {
-			mem.GistOf = []string{}
-		}
-
-		// Decode episode_id
-		mem.EpisodeID = episodeID.String
-
-		// Decode source
-		mem.Source = source.String
-
-		// Decode project and session_id
-		mem.Project = project.String
-		mem.SessionID = sessionID.String
-
-		// Parse last_accessed
-		if lastAccessedStr.Valid && lastAccessedStr.String != "" {
-			lastAccessed, err := time.Parse(time.RFC3339, lastAccessedStr.String)
-			if err == nil {
-				mem.LastAccessed = lastAccessed
-			}
-		}
-
 		memories = append(memories, mem)
 	}
 


### PR DESCRIPTION
## Summary
- Introduced `scanner` interface (satisfied by both `*sql.Row` and `*sql.Rows`)
- Extracted shared `scanXFrom(s scanner)` for memory, pattern, abstraction, and episode
- `scanX(row)` and `scanXRows(rows)` now delegate to the shared implementation
- Net change: **-129 lines** of duplicated decode logic

## Test plan
- [x] All 19 sqlite store tests pass
- [x] Full build passes
- [x] Pre-commit hooks pass

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)