### PR TITLE
fix: render markdown in evolution timeline changelog

### DIFF
--- a/internal/api/routes/agent.go
+++ b/internal/api/routes/agent.go
@@ -165,13 +165,11 @@ func HandleAgentChangelog(evolutionDir string, log *slog.Logger) http.HandlerFun
 					Title: strings.TrimSpace(title),
 				}
 			} else if currentEntry != nil && trimmed != "" {
-				// Accumulate rationale text
-				text := strings.TrimPrefix(trimmed, "- ")
-				text = strings.TrimPrefix(text, "* ")
+				// Accumulate rationale text, preserving line structure
 				if currentEntry.Rationale != "" {
-					currentEntry.Rationale += " "
+					currentEntry.Rationale += "\n"
 				}
-				currentEntry.Rationale += text
+				currentEntry.Rationale += trimmed
 			}
 		}
 		if currentEntry != nil {

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -1038,6 +1038,11 @@
         .changelog-date { font-size: 0.7rem; color: var(--text-dim); text-transform: uppercase; letter-spacing: 0.05em; }
         .changelog-title { font-size: 0.88rem; color: var(--text-primary); font-weight: 500; margin: 2px 0; }
         .changelog-rationale { font-size: 0.8rem; color: var(--text-secondary); line-height: 1.35; }
+        .changelog-rationale ul { margin: 4px 0; padding-left: 18px; }
+        .changelog-rationale li { margin: 2px 0; }
+        .changelog-rationale p { margin: 4px 0; }
+        .changelog-rationale code { background: var(--bg-tertiary); padding: 1px 4px; border-radius: 3px; font-size: 0.85em; }
+        .changelog-rationale strong { color: var(--text-primary); }
 
         .session-group { margin-bottom: 14px; }
         .session-group:last-child { margin-bottom: 0; }
@@ -2830,6 +2835,31 @@
 
     // ── Utilities ──
     function escapeHtml(str) { if (!str) return ''; var div = document.createElement('div'); div.textContent = str; return div.innerHTML; }
+    function simpleMarkdown(str) {
+        if (!str) return '';
+        var lines = str.split('\n');
+        var html = '';
+        var inList = false;
+        for (var i = 0; i < lines.length; i++) {
+            var line = lines[i];
+            var isBullet = /^[-*]\s/.test(line);
+            if (isBullet) {
+                if (!inList) { html += '<ul>'; inList = true; }
+                var content = escapeHtml(line.replace(/^[-*]\s+/, ''));
+                content = content.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+                content = content.replace(/`([^`]+)`/g, '<code>$1</code>');
+                html += '<li>' + content + '</li>';
+            } else {
+                if (inList) { html += '</ul>'; inList = false; }
+                var content = escapeHtml(line);
+                content = content.replace(/\*\*(.+?)\*\*/g, '<strong>$1</strong>');
+                content = content.replace(/`([^`]+)`/g, '<code>$1</code>');
+                if (content) html += '<p style="margin:4px 0">' + content + '</p>';
+            }
+        }
+        if (inList) html += '</ul>';
+        return html;
+    }
     function toggleToolDetail(e) {
         var pill = e.currentTarget;
         var toolId = pill.getAttribute('data-tool-use-id');
@@ -3126,7 +3156,7 @@
             return '<div class="changelog-entry">' +
                 '<div class="changelog-date">' + escapeHtml(e.date) + '</div>' +
                 '<div class="changelog-title">' + escapeHtml(e.title) + '</div>' +
-                (e.rationale ? '<div class="changelog-rationale">' + escapeHtml(e.rationale) + '</div>' : '') +
+                (e.rationale ? '<div class="changelog-rationale">' + simpleMarkdown(e.rationale) + '</div>' : '') +
                 '</div>';
         }).join('');
     }


### PR DESCRIPTION
## Summary
- **API (agent.go)**: Changelog rationale lines now preserve original markdown structure (newline-separated with bullet prefixes) instead of stripping `- `/`* ` and joining with spaces
- **Dashboard (index.html)**: Added `simpleMarkdown()` renderer that converts `- ` bullets to `<ul>/<li>`, `**bold**` to `<strong>`, and backtick code to `<code>`. Applied to changelog rationale in the evolution timeline
- Added CSS for rendered markdown elements (list spacing, code background, bold color)

## Test plan
- [x] Open dashboard at http://127.0.0.1:9999/, go to Agent tab
- [x] Verify evolution timeline entries show formatted bullets, bold text, and inline code
- [x] Verify no XSS — text is still escaped before markdown conversion

🤖 Generated with [Claude Code](https://claude.com/claude-code)