### PR TITLE
ci: add workflow_dispatch trigger to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,6 +5,7 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  workflow_dispatch:
 
 jobs:
   test:


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the CI workflow so it can be manually run on any branch
- Needed because release-please PRs are created by `GITHUB_TOKEN`, which doesn't fire `pull_request` events, so those PRs never get CI checks

## Test plan
- [x] Verify CI runs on this PR itself
- [x] After merge, run `gh workflow run ci.yml --ref release-please--branches--main` to trigger CI on PR #110

🤖 Generated with [Claude Code](https://claude.com/claude-code)