### PR TITLE
fix: use GitHub App token for release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -5,15 +5,19 @@ on:
     branches:
       - main
 
-permissions:
-  contents: write
-  pull-requests: write
-
 jobs:
   release-please:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate App Token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+
       - uses: googleapis/release-please-action@v4
         with:
           config-file: release-please-config.json
           manifest-file: .release-please-manifest.json
+          token: ${{ steps.app-token.outputs.token }}


### PR DESCRIPTION
## Summary
- Replace `GITHUB_TOKEN` with a GitHub App token in the release-please workflow
- Fixes the issue where CI never triggers on release-please PRs (GitHub prevents `GITHUB_TOKEN` events from triggering other workflows)
- Uses `actions/create-github-app-token@v1` with `APP_ID` and `APP_PRIVATE_KEY` secrets (already configured)

## Test plan
- [x] Merge this PR
- [ ] Next push to main triggers release-please with the app token
- [ ] Verify CI runs on the resulting release-please PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)