### PR TITLE
feat: timeline tag filtering + perception project inference

### DIFF
--- a/internal/agent/perception/agent.go
+++ b/internal/agent/perception/agent.go
@@ -5,6 +5,9 @@ import (
 	"encoding/json"
 	"fmt"
 	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -269,6 +272,7 @@ func (pa *PerceptionAgent) processEvent(ctx context.Context, event Event) {
 		HeuristicScore:  heuristicResult.Score,
 		InitialSalience: salience,
 		Processed:       false,
+		Project:         inferProjectFromPath(event.Path),
 	}
 
 	// 4. Write to store
@@ -433,6 +437,39 @@ func (pa *PerceptionAgent) mergeMetadata(
 	merged["heuristic_score"] = heuristicScore
 
 	return merged
+}
+
+// knownProjectParents are directory names that typically contain project directories.
+var knownProjectParents = map[string]bool{
+	"Projects":  true,
+	"projects":  true,
+	"src":       true,
+	"repos":     true,
+	"workspace": true,
+	"Workspace": true,
+}
+
+// inferProjectFromPath extracts a project name from a file path by looking for
+// known project parent directories (e.g., ~/Projects/felixlm/foo.go → "felixlm").
+func inferProjectFromPath(path string) string {
+	if path == "" {
+		return ""
+	}
+
+	// Expand ~ if present
+	if strings.HasPrefix(path, "~") {
+		if home, err := os.UserHomeDir(); err == nil {
+			path = filepath.Join(home, path[1:])
+		}
+	}
+
+	parts := strings.Split(filepath.Clean(path), string(os.PathSeparator))
+	for i, part := range parts {
+		if knownProjectParents[part] && i+1 < len(parts) {
+			return parts[i+1]
+		}
+	}
+	return ""
 }
 
 // Ensure PerceptionAgent implements agent.Agent interface.

--- a/internal/agent/perception/project_infer_test.go
+++ b/internal/agent/perception/project_infer_test.go
@@ -1,0 +1,30 @@
+package perception
+
+import "testing"
+
+func TestInferProjectFromPath(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"Projects dir", "/home/user/Projects/felixlm/train.py", "felixlm"},
+		{"Projects nested", "/home/user/Projects/mnemonic/internal/agent/foo.go", "mnemonic"},
+		{"src dir", "/home/user/src/webapp/index.js", "webapp"},
+		{"repos dir", "/home/user/repos/mylib/lib.go", "mylib"},
+		{"workspace dir", "/home/user/workspace/tool/main.go", "tool"},
+		{"no project parent", "/etc/nginx/nginx.conf", ""},
+		{"empty path", "", ""},
+		{"just Projects dir", "/home/user/Projects", ""},
+		{"lowercase projects", "/home/user/projects/app/main.go", "app"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := inferProjectFromPath(tt.path)
+			if got != tt.want {
+				t.Errorf("inferProjectFromPath(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -763,15 +763,19 @@
             padding: 1px 7px; border-radius: 8px;
             font-size: 0.67rem; font-weight: 500;
             background: rgba(139, 92, 246, 0.1); color: var(--accent-violet);
-            cursor: default; transition: background 0.15s;
+            cursor: pointer; transition: background 0.15s;
         }
         .tl-concept:hover { background: rgba(139, 92, 246, 0.2); }
         .tl-concept.concept-active { background: rgba(6,182,212,0.2); color: var(--accent-cyan); }
+        .tl-concept.concept-selected, .tl-source.concept-selected {
+            background: rgba(6,182,212,0.3); color: var(--accent-cyan);
+            box-shadow: 0 0 0 1px var(--accent-cyan);
+        }
         .tl-source {
             padding: 1px 7px; border-radius: 8px;
             font-size: 0.67rem; font-weight: 500;
             background: rgba(6, 182, 212, 0.1); color: var(--accent-teal);
-            cursor: default; transition: background 0.15s;
+            cursor: pointer; transition: background 0.15s;
         }
         .tl-source:hover { background: rgba(6, 182, 212, 0.2); }
         .tl-source.concept-active { background: rgba(6,182,212,0.25); color: var(--accent-cyan); }
@@ -2107,10 +2111,10 @@
         if (source || concepts.length > 0) {
             html += '<div class="tl-card-concepts">';
             if (source) {
-                html += '<span class="tl-source" onmouseenter="highlightTimelineConcept(this.textContent)" onmouseleave="clearTimelineHighlight()">' + escapeHtml(source) + '</span>';
+                html += '<span class="tl-source" onclick="toggleTimelineTag(event, this.textContent)" onmouseenter="hoverTimelineTag(this.textContent)" onmouseleave="unhoverTimelineTag()">' + escapeHtml(source) + '</span>';
             }
             concepts.slice(0, 8).forEach(function(c) {
-                html += '<span class="tl-concept" onmouseenter="highlightTimelineConcept(this.textContent)" onmouseleave="clearTimelineHighlight()">' + escapeHtml(c) + '</span>';
+                html += '<span class="tl-concept" onclick="toggleTimelineTag(event, this.textContent)" onmouseenter="hoverTimelineTag(this.textContent)" onmouseleave="unhoverTimelineTag()">' + escapeHtml(c) + '</span>';
             });
             html += '</div>';
         }
@@ -2158,11 +2162,53 @@
         if (detail) detail.classList.toggle('open');
     }
 
-    function highlightTimelineConcept(concept) {
+    var _selectedTimelineTags = new Set();
+
+    function toggleTimelineTag(event, concept) {
+        event.stopPropagation();
+        if (_selectedTimelineTags.has(concept)) {
+            _selectedTimelineTags.delete(concept);
+        } else {
+            _selectedTimelineTags.add(concept);
+        }
+        applyTimelineTagHighlight();
+    }
+
+    function hoverTimelineTag(concept) {
+        if (_selectedTimelineTags.size > 0) return; // don't hover-highlight when tags are pinned
+        highlightTimelineCards(new Set([concept]));
+    }
+
+    function unhoverTimelineTag() {
+        if (_selectedTimelineTags.size > 0) return; // keep pinned selection
+        clearAllTimelineHighlight();
+    }
+
+    function applyTimelineTagHighlight() {
+        if (_selectedTimelineTags.size === 0) {
+            clearAllTimelineHighlight();
+            return;
+        }
+        highlightTimelineCards(_selectedTimelineTags);
+        // Mark selected tag pills
+        document.querySelectorAll('.tl-concept, .tl-source').forEach(function(tag) {
+            if (_selectedTimelineTags.has(tag.textContent)) {
+                tag.classList.add('concept-selected');
+            } else {
+                tag.classList.remove('concept-selected');
+            }
+        });
+    }
+
+    function highlightTimelineCards(activeTags) {
         var cards = document.querySelectorAll('.tl-card');
         cards.forEach(function(card) {
             var cardConcepts = (card.getAttribute('data-concepts') || '').split(',');
-            if (cardConcepts.indexOf(concept) !== -1) {
+            var match = true;
+            activeTags.forEach(function(tag) {
+                if (cardConcepts.indexOf(tag) === -1) match = false;
+            });
+            if (match) {
                 card.classList.add('highlighted');
                 card.classList.remove('dimmed');
             } else {
@@ -2171,16 +2217,20 @@
             }
         });
         document.querySelectorAll('.tl-concept, .tl-source').forEach(function(tag) {
-            if (tag.textContent === concept) tag.classList.add('concept-active');
+            if (activeTags.has(tag.textContent)) {
+                tag.classList.add('concept-active');
+            } else {
+                tag.classList.remove('concept-active');
+            }
         });
     }
 
-    function clearTimelineHighlight() {
+    function clearAllTimelineHighlight() {
         document.querySelectorAll('.tl-card').forEach(function(card) {
             card.classList.remove('dimmed', 'highlighted');
         });
         document.querySelectorAll('.tl-concept, .tl-source').forEach(function(tag) {
-            tag.classList.remove('concept-active');
+            tag.classList.remove('concept-active', 'concept-selected');
         });
     }
 


### PR DESCRIPTION
## Summary
- **Timeline tag click-to-filter**: Tags in the dashboard timeline can now be clicked to pin selections. Multiple selected tags use AND logic — only cards matching *all* selected tags are shown. Hover highlighting still works when nothing is pinned. Selected tags get a cyan outline for visual feedback.
- **Perception project inference**: The perception agent now infers the project name from file paths by detecting known parent directories (`Projects`, `src`, `repos`, `workspace`). New watcher-sourced memories will carry the correct project tag, which flows through to patterns during consolidation — fixing the missing `[project]` tags on pattern cards.

## Test plan
- [x] Unit tests for `inferProjectFromPath` (9 cases, all passing)
- [x] Open dashboard timeline, click a tag — verify it pins and dims non-matching cards
- [x] Click additional tags — verify AND filtering (only cards with all selected tags visible)
- [x] Click a selected tag again — verify it deselects
- [x] Hover over tags with nothing selected — verify original hover behavior works
- [x] Trigger filesystem changes in a project dir, verify new memories have project field set
- [x] After next consolidation cycle, verify new patterns show project tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)