### PR TITLE
fix: use go-version-file in CI and release workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
 
       - name: Vet
         shell: bash
@@ -48,7 +48,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
@@ -65,7 +65,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
 
       - name: Build
         shell: bash

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,7 +31,7 @@ jobs:
 
       - uses: actions/setup-go@v6
         with:
-          go-version: "1.23"
+          go-version-file: go.mod
 
       - name: Build
         env:


### PR DESCRIPTION
## Summary

- Replace hardcoded `go-version: "1.23"` with `go-version-file: go.mod` in both CI and release workflows
- Fixes post-merge CI failures caused by Dependabot bumping `go.mod` to `go 1.25.0` while CI still pinned Go 1.23

## Root cause

Dependabot PR #122 updated Go dependencies, which bumped `go 1.25.0` in `go.mod`. The PR checks passed (ran against the branch with old go.mod), but after merging into main, CI couldn't build because `go 1.23.12` can't load a module requiring `go >= 1.25.0`.

## Test plan

- [x] CI on this PR should pass (validates the fix)
- [x] `release.yml` updated too so future tagged releases won't break

🤖 Generated with [Claude Code](https://claude.com/claude-code)