### PR TITLE
feat: show version in dashboard header

### DIFF
--- a/cmd/mnemonic/main.go
+++ b/cmd/mnemonic/main.go
@@ -1552,6 +1552,7 @@ func serveCommand(configPath string) {
 			Retriever:             retriever,
 			IngestExcludePatterns: cfg.Perception.Filesystem.ExcludePatterns,
 			IngestMaxContentBytes: cfg.Perception.Filesystem.MaxContentBytes,
+			Version:               Version,
 			Log:                   log,
 		}
 		// Only set Consolidator if it's non-nil (avoids Go nil-interface trap)

--- a/internal/api/routes/routes_test.go
+++ b/internal/api/routes/routes_test.go
@@ -590,7 +590,7 @@ func TestHandleHealthCheck(t *testing.T) {
 			},
 		}
 		llmProv := &mockLLMProvider{}
-		handler := HandleHealth(ms, llmProv, testLogger())
+		handler := HandleHealth(ms, llmProv, "test", testLogger())
 
 		req := httptest.NewRequest(http.MethodGet, "/health", nil)
 		rr := httptest.NewRecorder()
@@ -629,7 +629,7 @@ func TestHandleHealthCheck(t *testing.T) {
 			},
 		}
 		llmProv := &failingLLMProvider{}
-		handler := HandleHealth(ms, llmProv, testLogger())
+		handler := HandleHealth(ms, llmProv, "test", testLogger())
 
 		req := httptest.NewRequest(http.MethodGet, "/health", nil)
 		rr := httptest.NewRecorder()
@@ -662,7 +662,7 @@ func TestHandleHealthCheck(t *testing.T) {
 			},
 		}
 		llmProv := &mockLLMProvider{}
-		handler := HandleHealth(ms, llmProv, testLogger())
+		handler := HandleHealth(ms, llmProv, "test", testLogger())
 
 		req := httptest.NewRequest(http.MethodGet, "/health", nil)
 		rr := httptest.NewRecorder()

--- a/internal/api/routes/system.go
+++ b/internal/api/routes/system.go
@@ -13,6 +13,7 @@ import (
 // HealthResponse is the JSON response for the health check endpoint.
 type HealthResponse struct {
 	Status       string `json:"status"`
+	Version      string `json:"version,omitempty"`
 	LLMAvailable bool   `json:"llm_available"`
 	LLMModel     string `json:"llm_model,omitempty"`
 	StoreHealthy bool   `json:"store_healthy"`
@@ -23,7 +24,7 @@ type HealthResponse struct {
 // HandleHealth returns an HTTP handler that performs a health check.
 // Checks LLM availability with 2s timeout and store health.
 // Returns 200 with health status JSON.
-func HandleHealth(s store.Store, llmProv llm.Provider, log *slog.Logger) http.HandlerFunc {
+func HandleHealth(s store.Store, llmProv llm.Provider, version string, log *slog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Debug("health check requested")
 
@@ -64,6 +65,7 @@ func HandleHealth(s store.Store, llmProv llm.Provider, log *slog.Logger) http.Ha
 
 		resp := HealthResponse{
 			Status:       status,
+			Version:      version,
 			LLMAvailable: llmAvailable,
 			LLMModel:     llmModel,
 			StoreHealthy: storeHealthy,

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -36,6 +36,7 @@ type ServerDeps struct {
 	AgentWebPort          int                        // 0 = agent chat disabled
 	IngestExcludePatterns []string
 	IngestMaxContentBytes int
+	Version               string
 	Log                   *slog.Logger
 }
 
@@ -74,7 +75,7 @@ func NewServer(cfg ServerConfig, deps ServerDeps) *Server {
 // registerRoutes registers all API routes with the mux.
 func (s *Server) registerRoutes() {
 	// Health and stats
-	s.mux.HandleFunc("GET /api/v1/health", routes.HandleHealth(s.deps.Store, s.deps.LLM, s.deps.Log))
+	s.mux.HandleFunc("GET /api/v1/health", routes.HandleHealth(s.deps.Store, s.deps.LLM, s.deps.Version, s.deps.Log))
 	s.mux.HandleFunc("GET /api/v1/stats", routes.HandleStats(s.deps.Store, s.deps.Log))
 
 	// Memory CRUD

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -1209,7 +1209,7 @@
     <div id="app">
         <!-- Nav -->
         <nav class="nav">
-            <div class="nav-brand"><span>&#9670;</span> Mnemonic</div>
+            <div class="nav-brand"><span>&#9670;</span> Mnemonic <span id="navVersion" style="font-size:0.7rem;color:var(--text-dim);font-weight:400"></span></div>
             <div class="nav-tabs">
                 <button class="nav-tab active" data-view="recall" onclick="switchView('recall')">
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
@@ -2633,6 +2633,7 @@
             var dot = document.getElementById('navHealth');
             dot.className = health.status === 'ok' ? 'nav-health' : 'nav-health degraded';
             dot.title = health.status === 'ok' ? 'System healthy' : 'System degraded';
+            if (health.version) document.getElementById('navVersion').textContent = 'v' + health.version;
             state.previousStats = stats;
         } catch (e) {
             document.getElementById('navHealth').className = 'nav-health down';


### PR DESCRIPTION
## Summary

- Add `version` field to the `/api/v1/health` response, sourced from the binary's ldflags-injected version
- Display version next to "Mnemonic" in the dashboard nav bar (e.g. "Mnemonic v0.13.0")
- Stays in sync automatically — no extra files to maintain

## Test plan

- [x] `HandleHealth` tests updated and passing
- [x] Full build succeeds (`make build`)
- [x] Verified on running daemon: health endpoint returns `"version": "0.13.0"`
- [x] Dashboard displays version in header

🤖 Generated with [Claude Code](https://claude.com/claude-code)