### PR TITLE
fix: add summary fallback in consolidation createGist

### DIFF
--- a/internal/agent/consolidation/agent.go
+++ b/internal/agent/consolidation/agent.go
@@ -608,6 +608,11 @@ Respond with ONLY a JSON object:
 		}
 	}
 
+	// Fallback: if LLM returned an empty summary, truncate content (matches encoding agent)
+	if gistSummary == "" {
+		gistSummary = agentutil.Truncate(gistContent, 100)
+	}
+
 	// Inherit project from cluster — use the most common non-empty project
 	project := inferProjectFromCluster(cluster)
 

--- a/internal/agent/consolidation/agent_test.go
+++ b/internal/agent/consolidation/agent_test.go
@@ -1213,3 +1213,67 @@ func TestExtractJSONFromResponse(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateGistEmptySummaryFallback(t *testing.T) {
+	t.Run("LLM returns empty summary, fallback uses content", func(t *testing.T) {
+		ms := &mockStore{
+			batchMergeMemoriesFn: func(ctx context.Context, sourceIDs []string, gist store.Memory) error {
+				return nil
+			},
+		}
+		mlp := newMockLLMProvider()
+		mlp.completeFn = func(ctx context.Context, req llm.CompletionRequest) (llm.CompletionResponse, error) {
+			return llm.CompletionResponse{
+				Content: `{"summary":"","content":"important details about the merge"}`,
+			}, nil
+		}
+
+		ca := NewConsolidationAgent(ms, mlp, DefaultConfig(), slog.New(slog.NewTextHandler(os.Stderr, nil)))
+
+		cluster := []store.Memory{
+			{ID: "a", Summary: "mem A", Embedding: []float32{1, 0, 0}},
+			{ID: "b", Summary: "mem B", Embedding: []float32{1, 0, 0}},
+			{ID: "c", Summary: "mem C", Embedding: []float32{1, 0, 0}},
+		}
+
+		gist, err := ca.createGist(context.Background(), cluster)
+		if err != nil {
+			t.Fatalf("createGist failed: %v", err)
+		}
+		if gist.Summary == "" {
+			t.Error("expected non-empty summary from fallback, got empty string")
+		}
+		if gist.Summary != "important details about the merge" {
+			t.Errorf("expected summary to be truncated content, got %q", gist.Summary)
+		}
+	})
+
+	t.Run("LLM returns valid summary, no fallback needed", func(t *testing.T) {
+		ms := &mockStore{
+			batchMergeMemoriesFn: func(ctx context.Context, sourceIDs []string, gist store.Memory) error {
+				return nil
+			},
+		}
+		mlp := newMockLLMProvider()
+		mlp.completeFn = func(ctx context.Context, req llm.CompletionRequest) (llm.CompletionResponse, error) {
+			return llm.CompletionResponse{
+				Content: `{"summary":"consolidated insight","content":"details"}`,
+			}, nil
+		}
+
+		ca := NewConsolidationAgent(ms, mlp, DefaultConfig(), slog.New(slog.NewTextHandler(os.Stderr, nil)))
+
+		cluster := []store.Memory{
+			{ID: "a", Summary: "mem A", Embedding: []float32{1, 0, 0}},
+			{ID: "b", Summary: "mem B", Embedding: []float32{1, 0, 0}},
+		}
+
+		gist, err := ca.createGist(context.Background(), cluster)
+		if err != nil {
+			t.Fatalf("createGist failed: %v", err)
+		}
+		if gist.Summary != "consolidated insight" {
+			t.Errorf("expected 'consolidated insight', got %q", gist.Summary)
+		}
+	})
+}


### PR DESCRIPTION
## Summary
- Adds a summary fallback in `createGist` when the LLM returns an empty summary string, matching the encoding agent's existing pattern (`agentutil.Truncate(content, 100)`)
- Adds two test cases covering the empty-summary fallback and the normal path

## Test plan
- [x] `make check` passes (fmt + vet)
- [x] `golangci-lint run` passes
- [x] All consolidation agent tests pass, including the two new cases
- [x] Daemon rebuilt and restarted successfully

Closes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)