### PR TITLE
fix: refresh activity panel timestamps every 30s

### DIFF
--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -2563,7 +2563,7 @@
         var container = document.getElementById('eventsContainer');
         var el = document.createElement('div');
         el.className = 'event-item';
-        el.innerHTML = '<div class="event-dot ' + (dotColors[type] || 'cyan') + '"></div><div class="event-body"><div class="event-type">' + escapeHtml(type.replace(/_/g, ' ')) + '</div><div class="event-desc">' + escapeHtml(description) + '</div><div class="event-time">' + relativeTime(new Date(timestamp)) + '</div></div>';
+        el.innerHTML = '<div class="event-dot ' + (dotColors[type] || 'cyan') + '"></div><div class="event-body"><div class="event-type">' + escapeHtml(type.replace(/_/g, ' ')) + '</div><div class="event-desc">' + escapeHtml(description) + '</div><div class="event-time" data-ts="' + new Date(timestamp).toISOString() + '">' + relativeTime(new Date(timestamp)) + '</div></div>';
         container.prepend(el);
         while (container.children.length > CONFIG.MAX_EVENTS) container.removeChild(container.lastChild);
         if (!state.drawerOpen) { state.unreadEvents++; updateBadge(); }
@@ -3804,6 +3804,11 @@
         setInterval(loadStats, CONFIG.STATS_POLL);
         setInterval(loadInsights, CONFIG.INSIGHTS_POLL);
         setInterval(checkForUpdate, 3600000); // Check for updates every hour
+        setInterval(function() {
+            document.querySelectorAll('.event-time[data-ts]').forEach(function(el) {
+                el.textContent = relativeTime(new Date(el.getAttribute('data-ts')));
+            });
+        }, 30000); // Refresh event timestamps every 30s
         handleHash();
     }
 


### PR DESCRIPTION
## Summary
- Activity panel event timestamps were rendered once and never updated, permanently showing "just now"
- Store ISO timestamp in `data-ts` attribute on each `.event-time` element
- Add 30-second `setInterval` to re-evaluate `relativeTime()` on all event timestamps

## Test plan
- [x] Build succeeds (`make build`)
- [x] Dashboard loads without console errors
- [x] New events show `data-ts` attribute with valid ISO timestamp
- [x] After 30s+, timestamps update from "just now" to "Xm ago"
- [x] Verified visually via screenshot — one event shows "5m ago", another "just now"

🤖 Generated with [Claude Code](https://claude.com/claude-code)