### PR TITLE
chore: gitignore config.yaml, ship config.example.yaml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,6 +29,9 @@ sdk/agent/evolution/sessions.json
 sdk/agent/evolution/changelog.md
 sdk/agent/evolution/conversations/
 
+# Machine-specific config (copy config.example.yaml to config.yaml)
+config.yaml
+
 # IDE / local config
 .claude/settings.local.json
 .claude/plans/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -33,7 +33,7 @@ archives:
     files:
       - README.md
       - LICENSE
-      - config.yaml
+      - config.example.yaml
       - docs/*
 
 checksum:

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -1,4 +1,6 @@
 # Mnemonic Configuration File
+# Copy this file to config.yaml and adjust for your machine:
+#   cp config.example.yaml config.yaml
 # All paths support ~ expansion for home directory
 
 # Project Registry
@@ -20,17 +22,17 @@ llm:
   # Endpoint URL for the LLM API
   # LM Studio (local):  "http://localhost:1234/v1"
   # Google Gemini:       "https://generativelanguage.googleapis.com/v1beta/openai"
-  endpoint: "https://generativelanguage.googleapis.com/v1beta/openai"
+  endpoint: "http://localhost:1234/v1"
 
   # Model name for chat/conversation
   # LM Studio:  "qwen/qwen3.5-9b"
-  # Gemini:     "gemini-3.1-flash-lite-preview"
-  chat_model: "gemini-3-flash-preview"
+  # Gemini:     "gemini-3-flash-preview"
+  chat_model: "qwen/qwen3.5-9b"
 
   # Model name for embeddings
   # LM Studio:  "text-embedding-embeddinggemma-300m-qat"
   # Gemini:     "gemini-embedding-2-preview"
-  embedding_model: "gemini-embedding-2-preview"
+  embedding_model: "text-embedding-embeddinggemma-300m-qat"
 
   # Maximum tokens in model responses (thinking models need headroom for reasoning)
   max_tokens: 8192


### PR DESCRIPTION
## Summary
- `config.yaml` contains machine-specific LLM settings (endpoint, models) that differ between macOS/Linux and local/cloud providers
- Gitignore `config.yaml` so it stays local and doesn't cause drift across machines
- Ship `config.example.yaml` with safe LM Studio defaults as the template
- Update `.goreleaser.yaml` to include `config.example.yaml` in releases

## Test plan
- [x] `config.yaml` still exists locally (not deleted, just untracked)
- [x] `git status` no longer shows `config.yaml` changes
- [x] `config.example.yaml` has LM Studio defaults and setup instructions
- [x] `make build` / `make run` still works with local `config.yaml`
- [x] Fresh clone: `cp config.example.yaml config.yaml` → edit LLM section → works

🤖 Generated with [Claude Code](https://claude.com/claude-code)