### PR TITLE
ci: fix release workflow to package config.example.yaml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,7 +46,7 @@ jobs:
         run: |
           VERSION=${GITHUB_REF_NAME#v}
           ARCHIVE="mnemonic_${VERSION}_${{ matrix.name }}.tar.gz"
-          tar czf "${ARCHIVE}" mnemonic README.md LICENSE config.yaml docs/
+          tar czf "${ARCHIVE}" mnemonic README.md LICENSE config.example.yaml docs/
           echo "ARCHIVE=${ARCHIVE}" >> $GITHUB_ENV
 
       - name: Upload artifact


### PR DESCRIPTION
## Summary
- The `config.yaml` → `config.example.yaml` rename in #141 wasn't updated in the release workflow
- v0.14.2 release build failed with `tar: config.yaml: Cannot stat: No such file or directory`
- One-line fix: `config.yaml` → `config.example.yaml` in the tar command

## Test plan
- [x] After merge, re-tag v0.14.2 or let release-please cut a new version to verify

🤖 Generated with [Claude Code](https://claude.com/claude-code)