### PR TITLE
feat: training data capture pipeline for bespoke local LLM

### DIFF
--- a/cmd/mnemonic/main.go
+++ b/cmd/mnemonic/main.go
@@ -1335,9 +1335,14 @@ func serveCommand(configPath string) {
 	rootCtx, rootCancel := context.WithCancel(context.Background())
 	defer rootCancel()
 
-	// Instrumented provider wrapper — gives each agent its own usage tracking
+	// Instrumented provider wrapper — gives each agent its own usage tracking.
+	// If training data capture is enabled, wrap with TrainingCaptureProvider too.
 	wrap := func(caller string) llm.Provider {
-		return llm.NewInstrumentedProvider(llmProvider, memStore, caller, cfg.LLM.ChatModel)
+		var p llm.Provider = llm.NewInstrumentedProvider(llmProvider, memStore, caller, cfg.LLM.ChatModel)
+		if cfg.Training.CaptureEnabled && cfg.Training.CaptureDir != "" {
+			p = llm.NewTrainingCaptureProvider(p, caller, cfg.Training.CaptureDir)
+		}
+		return p
 	}
 
 	// --- Start episoding agent (groups raw events into episodes) ---
@@ -1740,7 +1745,8 @@ func serveCommand(configPath string) {
 // ============================================================================
 
 // initRuntime loads config, opens store and LLM for CLI commands.
-func initRuntime(configPath string) (*config.Config, *sqlite.SQLiteStore, *llm.LMStudioProvider, *slog.Logger) {
+// The returned Provider includes training data capture if enabled in config.
+func initRuntime(configPath string) (*config.Config, *sqlite.SQLiteStore, llm.Provider, *slog.Logger) {
 	cfg, err := config.Load(configPath)
 	if err != nil {
 		die(exitConfig, fmt.Sprintf("loading config: %v", err), "mnemonic diagnose")
@@ -1758,7 +1764,7 @@ func initRuntime(configPath string) (*config.Config, *sqlite.SQLiteStore, *llm.L
 		die(exitDatabase, fmt.Sprintf("opening database: %v", err), "mnemonic diagnose")
 	}
 
-	llmProvider := llm.NewLMStudioProvider(
+	var provider llm.Provider = llm.NewLMStudioProvider(
 		cfg.LLM.Endpoint,
 		cfg.LLM.ChatModel,
 		cfg.LLM.EmbeddingModel,
@@ -1767,7 +1773,12 @@ func initRuntime(configPath string) (*config.Config, *sqlite.SQLiteStore, *llm.L
 		cfg.LLM.MaxConcurrent,
 	)
 
-	return cfg, db, llmProvider, log
+	// Wrap with training data capture if enabled
+	if cfg.Training.CaptureEnabled && cfg.Training.CaptureDir != "" {
+		provider = llm.NewTrainingCaptureProvider(provider, "cli", cfg.Training.CaptureDir)
+	}
+
+	return cfg, db, provider, log
 }
 
 // rememberCommand stores text in the memory system.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -451,6 +451,14 @@ agent_sdk:
   # Port for the Python WebSocket chat server (default: 9998)
   web_port: 9998
 
+# Training Data Capture
+# Captures full LLM request/response pairs as JSONL for fine-tuning a bespoke local model.
+# Data is written to capture_dir as daily JSONL files (e.g., capture_2026-03-17.jsonl).
+# Enable this when you want to collect training data from the running daemon.
+training:
+  capture_enabled: false
+  capture_dir: "~/.mnemonic/training-data"
+
 # Coaching Configuration (Claude teaches the local LLM)
 coaching:
   # Path to the YAML file Claude writes to improve local LLM prompts.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -29,6 +29,7 @@ type Config struct {
 	Orchestrator  OrchestratorConfig  `yaml:"orchestrator"`
 	MCP           MCPConfig           `yaml:"mcp"`
 	AgentSDK      AgentSDKConfig      `yaml:"agent_sdk"`
+	Training      TrainingConfig      `yaml:"training"`
 	Coaching      CoachingConfig      `yaml:"coaching"`
 	API           APIConfig           `yaml:"api"`
 	Web           WebConfig           `yaml:"web"`
@@ -231,6 +232,12 @@ type APIConfig struct {
 // WebConfig holds web UI settings.
 type WebConfig struct {
 	Enabled bool `yaml:"enabled"`
+}
+
+// TrainingConfig holds settings for LLM training data capture.
+type TrainingConfig struct {
+	CaptureEnabled bool   `yaml:"capture_enabled"` // enable full request/response capture for training data
+	CaptureDir     string `yaml:"capture_dir"`     // directory for captured JSONL files (default: ~/.mnemonic/training-data)
 }
 
 // CoachingConfig holds settings for the Claude→local LLM coaching system.
@@ -459,6 +466,10 @@ func Default() *Config {
 			EvolutionDir: "",
 			WebPort:      9998,
 		},
+		Training: TrainingConfig{
+			CaptureEnabled: false,
+			CaptureDir:     "~/.mnemonic/training-data",
+		},
 		Coaching: CoachingConfig{
 			CoachingFile: "~/.mnemonic/coaching.yaml",
 		},
@@ -551,6 +562,14 @@ func (c *Config) process(configDir string) error {
 		c.AgentSDK.EvolutionDir, err = resolvePath(c.AgentSDK.EvolutionDir, configDir)
 		if err != nil {
 			return fmt.Errorf("expanding agent_sdk.evolution_dir: %w", err)
+		}
+	}
+
+	// Expand Training capture dir
+	if c.Training.CaptureDir != "" {
+		c.Training.CaptureDir, err = resolvePath(c.Training.CaptureDir, configDir)
+		if err != nil {
+			return fmt.Errorf("expanding training.capture_dir: %w", err)
 		}
 	}
 

--- a/internal/llm/training_capture.go
+++ b/internal/llm/training_capture.go
@@ -1,0 +1,290 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+)
+
+// TrainingExample captures a full LLM request/response pair for training data generation.
+type TrainingExample struct {
+	Timestamp      time.Time        `json:"timestamp"`
+	TaskType       string           `json:"task_type"` // "encoding", "synthesis", "abstraction", "perception", "classification"
+	Caller         string           `json:"caller"`
+	Request        TrainingRequest  `json:"request"`
+	Response       TrainingResponse `json:"response"`
+	ParseSuccess   bool             `json:"parse_success"`
+	LatencyMs      int64            `json:"latency_ms"`
+	PromptTokens   int              `json:"prompt_tokens"`
+	CompletionToks int              `json:"completion_tokens"`
+	Error          string           `json:"error,omitempty"`
+}
+
+// TrainingRequest captures the input side of an LLM call.
+type TrainingRequest struct {
+	Messages       []Message       `json:"messages"`
+	Model          string          `json:"model,omitempty"`
+	Tools          []Tool          `json:"tools,omitempty"`
+	ResponseFormat *ResponseFormat `json:"response_format,omitempty"`
+	MaxTokens      int             `json:"max_tokens,omitempty"`
+	Temperature    float32         `json:"temperature,omitempty"`
+	TopP           float32         `json:"top_p,omitempty"`
+	Stop           []string        `json:"stop,omitempty"`
+}
+
+// TrainingResponse captures the output side of an LLM call.
+type TrainingResponse struct {
+	Content    string     `json:"content"`
+	ToolCalls  []ToolCall `json:"tool_calls,omitempty"`
+	StopReason string     `json:"stop_reason,omitempty"`
+}
+
+// TrainingCaptureProvider wraps a Provider to capture full request/response pairs
+// as JSONL training data for fine-tuning a bespoke local model.
+type TrainingCaptureProvider struct {
+	inner    Provider
+	caller   string
+	dir      string
+	mu       sync.Mutex
+	file     *os.File
+	fileDate string // tracks which date the current file belongs to
+	enabled  bool
+}
+
+// NewTrainingCaptureProvider creates a capture-enabled provider wrapper.
+// dir is the directory to write JSONL files into (e.g., ~/.mnemonic/training-data).
+// If dir is empty or creation fails, capture is silently disabled.
+func NewTrainingCaptureProvider(inner Provider, caller, dir string) *TrainingCaptureProvider {
+	p := &TrainingCaptureProvider{
+		inner:  inner,
+		caller: caller,
+		dir:    dir,
+	}
+
+	if dir == "" {
+		return p
+	}
+
+	if err := os.MkdirAll(dir, 0o750); err != nil {
+		slog.Warn("training capture disabled: cannot create directory", "dir", dir, "error", err)
+		return p
+	}
+
+	if err := p.openFileForDate(time.Now()); err != nil {
+		slog.Warn("training capture disabled: cannot open file", "error", err)
+		return p
+	}
+
+	p.enabled = true
+	slog.Info("training data capture enabled", "caller", caller, "file", p.filePath(p.fileDate))
+	return p
+}
+
+// filePath returns the JSONL file path for the given date string.
+func (p *TrainingCaptureProvider) filePath(date string) string {
+	return filepath.Join(p.dir, fmt.Sprintf("capture_%s.jsonl", date))
+}
+
+// openFileForDate opens (or creates) the capture file for the given date.
+// Caller must hold p.mu or be called during initialization.
+func (p *TrainingCaptureProvider) openFileForDate(t time.Time) error {
+	date := t.Format("2006-01-02")
+
+	if p.file != nil {
+		_ = p.file.Close()
+	}
+
+	fpath := p.filePath(date)
+	f, err := os.OpenFile(fpath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o640)
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", fpath, err)
+	}
+
+	p.file = f
+	p.fileDate = date
+	return nil
+}
+
+// ensureCurrentFile checks if the date has rolled over and opens a new file if needed.
+// Must be called with p.mu held.
+func (p *TrainingCaptureProvider) ensureCurrentFile() {
+	today := time.Now().Format("2006-01-02")
+	if today == p.fileDate {
+		return
+	}
+
+	slog.Info("training capture: rolling to new daily file", "caller", p.caller, "date", today)
+	if err := p.openFileForDate(time.Now()); err != nil {
+		slog.Warn("training capture: failed to roll file, continuing with old file", "error", err)
+	}
+}
+
+// classifyTask infers the task type from the request content.
+// Examines both system and user messages to handle agents that don't use system prompts
+// (e.g., retrieval synthesis uses user-role messages only).
+func classifyTask(req CompletionRequest) string {
+	// First pass: check system messages (most agents use these)
+	for _, msg := range req.Messages {
+		if msg.Role != "system" {
+			continue
+		}
+		content := msg.Content
+
+		if containsAny(content, "memory encoder", "encode this observation", "gist", "structured_concepts") {
+			return "encoding"
+		}
+		// Episoding check before synthesis (episoding prompts contain "synthesize")
+		if containsAny(content, "episode synthesizer", "episode summary") {
+			return "episoding"
+		}
+		// Abstraction check before synthesis (abstraction prompts contain "synthesizer")
+		if containsAny(content, "principle synthesizer", "principle", "patterns have emerged", "axiom") {
+			return "abstraction"
+		}
+		// Consolidation
+		if containsAny(content, "memory consolidator", "consolidat", "merge related memories") {
+			return "consolidation"
+		}
+		if containsAny(content, "synthesize", "memories tell you", "recall") {
+			return "synthesis"
+		}
+		if containsAny(content, "worth remembering", "perception", "memory perception") {
+			return "perception"
+		}
+		if containsAny(content, "classify the relationship", "relation_type") {
+			return "classification"
+		}
+	}
+
+	// Second pass: check user messages for agents that skip system prompts.
+	// The retrieval agent builds synthesis prompts as user messages.
+	for _, msg := range req.Messages {
+		if msg.Role != "user" {
+			continue
+		}
+		content := msg.Content
+
+		if containsAny(content, "synthesize", "memories tell you", "Summarize what the memories") {
+			return "synthesis"
+		}
+	}
+
+	// Third pass: infer from request structure.
+	// If tools are present, it's almost certainly synthesis (only retrieval uses tools).
+	if len(req.Tools) > 0 {
+		return "synthesis"
+	}
+
+	return "unknown"
+}
+
+// containsAny returns true if s contains any of the substrings (case-insensitive).
+func containsAny(s string, subs ...string) bool {
+	lower := strings.ToLower(s)
+	for _, sub := range subs {
+		if strings.Contains(lower, strings.ToLower(sub)) {
+			return true
+		}
+	}
+	return false
+}
+
+func (p *TrainingCaptureProvider) capture(req CompletionRequest, resp CompletionResponse, latencyMs int64, callErr error) {
+	if !p.enabled {
+		return
+	}
+
+	example := TrainingExample{
+		Timestamp: time.Now().UTC(),
+		TaskType:  classifyTask(req),
+		Caller:    p.caller,
+		Request: TrainingRequest{
+			Messages:       req.Messages,
+			Model:          req.Model,
+			Tools:          req.Tools,
+			ResponseFormat: req.ResponseFormat,
+			MaxTokens:      req.MaxTokens,
+			Temperature:    req.Temperature,
+			TopP:           req.TopP,
+			Stop:           req.Stop,
+		},
+		Response: TrainingResponse{
+			Content:    resp.Content,
+			ToolCalls:  resp.ToolCalls,
+			StopReason: resp.StopReason,
+		},
+		LatencyMs:      latencyMs,
+		PromptTokens:   resp.PromptTokens,
+		CompletionToks: resp.CompletionTokens,
+	}
+
+	if callErr != nil {
+		example.Error = callErr.Error()
+	} else {
+		// Quick JSON parse check for structured output responses.
+		if req.ResponseFormat != nil && req.ResponseFormat.Type == "json_schema" {
+			var js json.RawMessage
+			example.ParseSuccess = json.Unmarshal([]byte(resp.Content), &js) == nil
+		} else {
+			example.ParseSuccess = true // non-JSON responses are always "valid"
+		}
+	}
+
+	data, err := json.Marshal(example)
+	if err != nil {
+		slog.Warn("training capture: marshal failed", "error", err)
+		return
+	}
+
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	p.ensureCurrentFile()
+
+	if _, err := p.file.Write(append(data, '\n')); err != nil {
+		slog.Warn("training capture: write failed", "error", err)
+	}
+}
+
+// Complete delegates to the inner provider and captures the exchange.
+func (p *TrainingCaptureProvider) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	start := time.Now()
+	resp, err := p.inner.Complete(ctx, req)
+	latency := time.Since(start).Milliseconds()
+	p.capture(req, resp, latency, err)
+	return resp, err
+}
+
+// Embed delegates to the inner provider (embeddings are not captured for training).
+func (p *TrainingCaptureProvider) Embed(ctx context.Context, text string) ([]float32, error) {
+	return p.inner.Embed(ctx, text)
+}
+
+// BatchEmbed delegates to the inner provider (embeddings are not captured for training).
+func (p *TrainingCaptureProvider) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	return p.inner.BatchEmbed(ctx, texts)
+}
+
+// Health delegates to the inner provider.
+func (p *TrainingCaptureProvider) Health(ctx context.Context) error {
+	return p.inner.Health(ctx)
+}
+
+// ModelInfo delegates to the inner provider.
+func (p *TrainingCaptureProvider) ModelInfo(ctx context.Context) (ModelMetadata, error) {
+	return p.inner.ModelInfo(ctx)
+}
+
+// Close flushes and closes the capture file.
+func (p *TrainingCaptureProvider) Close() error {
+	if p.file != nil {
+		return p.file.Close()
+	}
+	return nil
+}

--- a/internal/llm/training_capture_test.go
+++ b/internal/llm/training_capture_test.go
@@ -1,0 +1,362 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// mockProvider is a minimal Provider for testing.
+type mockProvider struct {
+	completeResp CompletionResponse
+	completeErr  error
+}
+
+func (m *mockProvider) Complete(_ context.Context, _ CompletionRequest) (CompletionResponse, error) {
+	return m.completeResp, m.completeErr
+}
+
+func (m *mockProvider) Embed(_ context.Context, _ string) ([]float32, error) {
+	return []float32{0.1, 0.2}, nil
+}
+
+func (m *mockProvider) BatchEmbed(_ context.Context, _ []string) ([][]float32, error) {
+	return nil, nil
+}
+
+func (m *mockProvider) Health(_ context.Context) error { return nil }
+
+func (m *mockProvider) ModelInfo(_ context.Context) (ModelMetadata, error) {
+	return ModelMetadata{Name: "test"}, nil
+}
+
+func TestTrainingCaptureProvider_CapturesCompletion(t *testing.T) {
+	dir := t.TempDir()
+
+	inner := &mockProvider{
+		completeResp: CompletionResponse{
+			Content:          `{"gist":"test gist","summary":"test summary"}`,
+			StopReason:       "stop",
+			PromptTokens:     100,
+			CompletionTokens: 50,
+		},
+	}
+
+	p := NewTrainingCaptureProvider(inner, "encoding", dir)
+	defer func() { _ = p.Close() }()
+
+	if !p.enabled {
+		t.Fatal("capture should be enabled with valid dir")
+	}
+
+	req := CompletionRequest{
+		Messages: []Message{
+			{Role: "system", Content: "You are a memory encoder. Produce structured_concepts and a gist."},
+			{Role: "user", Content: "User saved a file"},
+		},
+		Model: "gemini-3-flash",
+		ResponseFormat: &ResponseFormat{
+			Type: "json_schema",
+			JSONSchema: &JSONSchema{
+				Name:   "encoding_response",
+				Strict: true,
+				Schema: json.RawMessage(`{"type":"object"}`),
+			},
+		},
+		MaxTokens:   1024,
+		Temperature: 0.3,
+		TopP:        0.9,
+		Stop:        []string{"\n\n"},
+	}
+
+	resp, err := p.Complete(context.Background(), req)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != inner.completeResp.Content {
+		t.Fatal("response should pass through from inner provider")
+	}
+
+	// Close to flush
+	_ = p.Close()
+	p.enabled = false // prevent double-close issues
+
+	// Read the captured file
+	files, err := filepath.Glob(filepath.Join(dir, "capture_*.jsonl"))
+	if err != nil || len(files) == 0 {
+		t.Fatal("expected capture file to exist")
+	}
+
+	data, err := os.ReadFile(files[0])
+	if err != nil {
+		t.Fatalf("failed to read capture file: %v", err)
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(data)), "\n")
+	if len(lines) != 1 {
+		t.Fatalf("expected 1 captured example, got %d", len(lines))
+	}
+
+	var example TrainingExample
+	if err := json.Unmarshal([]byte(lines[0]), &example); err != nil {
+		t.Fatalf("failed to parse captured example: %v", err)
+	}
+
+	// Task type and caller
+	if example.TaskType != "encoding" {
+		t.Errorf("expected task_type 'encoding', got %q", example.TaskType)
+	}
+	if example.Caller != "encoding" {
+		t.Errorf("expected caller 'encoding', got %q", example.Caller)
+	}
+
+	// Parse success
+	if !example.ParseSuccess {
+		t.Error("expected parse_success=true for valid JSON response")
+	}
+
+	// Token counts
+	if example.PromptTokens != 100 {
+		t.Errorf("expected prompt_tokens=100, got %d", example.PromptTokens)
+	}
+	if example.CompletionToks != 50 {
+		t.Errorf("expected completion_tokens=50, got %d", example.CompletionToks)
+	}
+
+	// Request fields (including previously missing ones)
+	if len(example.Request.Messages) != 2 {
+		t.Errorf("expected 2 messages captured, got %d", len(example.Request.Messages))
+	}
+	if example.Request.Model != "gemini-3-flash" {
+		t.Errorf("expected model 'gemini-3-flash', got %q", example.Request.Model)
+	}
+	if example.Request.TopP != 0.9 {
+		t.Errorf("expected top_p=0.9, got %v", example.Request.TopP)
+	}
+	if len(example.Request.Stop) != 1 || example.Request.Stop[0] != "\n\n" {
+		t.Errorf("expected stop=[\\n\\n], got %v", example.Request.Stop)
+	}
+	if example.Request.Temperature != 0.3 {
+		t.Errorf("expected temperature=0.3, got %v", example.Request.Temperature)
+	}
+	if example.Request.MaxTokens != 1024 {
+		t.Errorf("expected max_tokens=1024, got %d", example.Request.MaxTokens)
+	}
+
+	// Response fields (including previously missing StopReason)
+	if example.Response.StopReason != "stop" {
+		t.Errorf("expected stop_reason='stop', got %q", example.Response.StopReason)
+	}
+}
+
+func TestTrainingCaptureProvider_DisabledWithEmptyDir(t *testing.T) {
+	inner := &mockProvider{
+		completeResp: CompletionResponse{Content: "hello"},
+	}
+
+	p := NewTrainingCaptureProvider(inner, "test", "")
+	if p.enabled {
+		t.Error("capture should be disabled with empty dir")
+	}
+
+	// Should still pass through to inner
+	resp, err := p.Complete(context.Background(), CompletionRequest{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "hello" {
+		t.Error("response should pass through even when capture disabled")
+	}
+}
+
+func TestClassifyTask(t *testing.T) {
+	tests := []struct {
+		name     string
+		messages []Message
+		tools    []Tool
+		expected string
+	}{
+		{
+			name: "encoding prompt (system)",
+			messages: []Message{
+				{Role: "system", Content: "You are a memory encoder. Produce a gist and structured_concepts."},
+			},
+			expected: "encoding",
+		},
+		{
+			name: "synthesis prompt (system with tools)",
+			messages: []Message{
+				{Role: "system", Content: "Summarize what the memories tell you."},
+			},
+			tools:    []Tool{{Type: "function"}},
+			expected: "synthesis",
+		},
+		{
+			name: "synthesis prompt (user-only, no system)",
+			messages: []Message{
+				{Role: "user", Content: "Summarize what the memories tell you about this topic."},
+			},
+			expected: "synthesis",
+		},
+		{
+			name: "synthesis inferred from tools (no keywords)",
+			messages: []Message{
+				{Role: "user", Content: "Find relevant information about authentication."},
+			},
+			tools:    []Tool{{Type: "function", Function: ToolFunction{Name: "search_memories"}}},
+			expected: "synthesis",
+		},
+		{
+			name: "abstraction prompt (patterns)",
+			messages: []Message{
+				{Role: "system", Content: "These patterns have emerged from work. Is there a principle?"},
+			},
+			expected: "abstraction",
+		},
+		{
+			name: "abstraction prompt (principle synthesizer)",
+			messages: []Message{
+				{Role: "system", Content: "You are a principle synthesizer. Extract general principles from patterns. Output JSON only."},
+			},
+			expected: "abstraction",
+		},
+		{
+			name: "consolidation prompt",
+			messages: []Message{
+				{Role: "system", Content: "You are a memory consolidator. Merge related memories into a single summary. Output JSON only."},
+			},
+			expected: "consolidation",
+		},
+		{
+			name: "perception prompt",
+			messages: []Message{
+				{Role: "system", Content: "Evaluate if this is worth remembering."},
+			},
+			expected: "perception",
+		},
+		{
+			name: "classification prompt",
+			messages: []Message{
+				{Role: "system", Content: "classify the relationship between these memories. Return relation_type."},
+			},
+			expected: "classification",
+		},
+		{
+			name: "episoding prompt",
+			messages: []Message{
+				{Role: "system", Content: "You are an episode synthesizer. Create an episode summary."},
+			},
+			expected: "episoding",
+		},
+		{
+			name: "unknown prompt",
+			messages: []Message{
+				{Role: "system", Content: "You are a helpful assistant."},
+			},
+			expected: "unknown",
+		},
+		{
+			name: "case insensitive matching",
+			messages: []Message{
+				{Role: "system", Content: "YOU ARE A MEMORY ENCODER. PRODUCE STRUCTURED_CONCEPTS."},
+			},
+			expected: "encoding",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := CompletionRequest{
+				Messages: tt.messages,
+				Tools:    tt.tools,
+			}
+			got := classifyTask(req)
+			if got != tt.expected {
+				t.Errorf("classifyTask() = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestTrainingCaptureProvider_RecordsParseFailure(t *testing.T) {
+	dir := t.TempDir()
+
+	inner := &mockProvider{
+		completeResp: CompletionResponse{
+			Content: "not valid json at all",
+		},
+	}
+
+	p := NewTrainingCaptureProvider(inner, "encoding", dir)
+	defer func() { _ = p.Close() }()
+
+	req := CompletionRequest{
+		Messages: []Message{{Role: "system", Content: "memory encoder with gist and structured_concepts"}},
+		ResponseFormat: &ResponseFormat{
+			Type:       "json_schema",
+			JSONSchema: &JSONSchema{Name: "test", Strict: true},
+		},
+	}
+
+	_, _ = p.Complete(context.Background(), req)
+	_ = p.Close()
+	p.enabled = false
+
+	files, _ := filepath.Glob(filepath.Join(dir, "capture_*.jsonl"))
+	data, _ := os.ReadFile(files[0])
+
+	var example TrainingExample
+	_ = json.Unmarshal([]byte(strings.TrimSpace(string(data))), &example)
+
+	if example.ParseSuccess {
+		t.Error("expected parse_success=false for invalid JSON response")
+	}
+}
+
+func TestTrainingCaptureProvider_FileRollover(t *testing.T) {
+	dir := t.TempDir()
+
+	inner := &mockProvider{
+		completeResp: CompletionResponse{Content: "hello"},
+	}
+
+	p := NewTrainingCaptureProvider(inner, "test", dir)
+	defer func() { _ = p.Close() }()
+
+	if !p.enabled {
+		t.Fatal("capture should be enabled")
+	}
+
+	// Verify fileDate is set
+	if p.fileDate == "" {
+		t.Fatal("expected fileDate to be set")
+	}
+
+	// Simulate a date rollover by manually changing the tracked date
+	p.mu.Lock()
+	p.fileDate = "2020-01-01" // force a stale date
+	p.mu.Unlock()
+
+	// Next capture should trigger rollover
+	_, _ = p.Complete(context.Background(), CompletionRequest{
+		Messages: []Message{{Role: "user", Content: "test"}},
+	})
+
+	// The file should now have today's date
+	p.mu.Lock()
+	currentDate := p.fileDate
+	p.mu.Unlock()
+
+	if currentDate == "2020-01-01" {
+		t.Error("expected file to roll over to today's date")
+	}
+
+	// Verify today's file exists
+	todayFile := filepath.Join(dir, "capture_"+currentDate+".jsonl")
+	if _, err := os.Stat(todayFile); os.IsNotExist(err) {
+		t.Errorf("expected today's capture file to exist: %s", todayFile)
+	}
+}

--- a/training/.gitignore
+++ b/training/.gitignore
@@ -1,0 +1,23 @@
+# Model checkpoints (large binary files)
+checkpoints/
+
+# Training data (generated, not committed)
+data/raw/
+data/validated/
+data/rejected/
+data/eval/
+
+# Python
+.venv/
+__pycache__/
+*.pyc
+*.egg-info/
+
+# Experiment artifacts
+*.pt
+*.safetensors
+*.gguf
+autoresearch_results.tsv
+
+# Weights & Biases
+wandb/

--- a/training/README.md
+++ b/training/README.md
@@ -1,0 +1,91 @@
+# Mnemonic-LM Training Infrastructure
+
+Training pipeline for building a bespoke local LLM to replace cloud LLM dependencies in mnemonic.
+
+## Overview
+
+Mnemonic's LLM tasks are narrow and repetitive: 4 task types, fixed JSON schemas, a controlled vocabulary of ~60 terms. This makes it tractable to train a small, specialized model that matches or exceeds cloud LLM quality for these specific tasks.
+
+## Architecture
+
+| Model | Task | Size | Toolchain |
+|-------|------|------|-----------|
+| Encoder | Encoding, abstraction, perception (80%+ of calls) | 500M -> 4B | Unsloth |
+| Synthesizer | Retrieval synthesis with tool-use | Qwen 3.5 4B | Unsloth |
+| Embedder | Vector embeddings | 100-300M | sentence-transformers |
+
+## Directory Structure
+
+```
+training/
+  data/
+    raw/           # Unfiltered captures from InstrumentedProvider (JSONL)
+    validated/     # Passed quality gates (JSONL)
+    rejected/      # Failed quality gates, kept for analysis (JSONL)
+    eval/          # Frozen evaluation set (never trained on)
+  scripts/
+    validate.py    # Quality gate pipeline
+    finetune.py    # Unsloth fine-tuning script
+    evaluate.py    # Mnemonic quality score evaluation
+    serve.py       # Model serving (vLLM wrapper)
+  configs/
+    encoder.yaml   # Encoder model training config
+    synthesizer.yaml
+    embedder.yaml
+  checkpoints/     # Model checkpoints (gitignored)
+  program.md       # Autoresearch steering instructions
+```
+
+## Data Capture
+
+The Go daemon captures training data automatically via the `TrainingDataCapture` wrapper around the LLM provider. Enable it in `config.yaml`:
+
+```yaml
+training:
+  capture_enabled: true
+  capture_dir: "~/.mnemonic/training-data"
+```
+
+Captured data flows through quality gates before inclusion in the training set.
+
+## Quality Gates
+
+Every training example must pass:
+
+**Hard gates (auto-reject):**
+- Valid JSON matching the encoding schema
+- Field constraints (gist <60 chars, summary <100 chars, salience in [0,1])
+- Concepts from controlled vocabulary or clearly content-derived
+- No empty/placeholder content
+
+**Soft gates (flagged for review):**
+- Salience outliers
+- Emotional tone mismatches
+- Low concept coverage
+- Suspiciously similar outputs
+
+## Quick Start
+
+```bash
+# 1. Enable data capture in mnemonic
+# Edit config.yaml to set training.capture_enabled: true
+
+# 2. Set up Python environment
+cd training
+python -m venv .venv
+source .venv/bin/activate
+pip install unsloth torch transformers datasets
+
+# 3. Run quality validation on captured data
+python scripts/validate.py
+
+# 4. Fine-tune (once you have enough validated data)
+python scripts/finetune.py --config configs/encoder.yaml
+```
+
+## Prerequisites
+
+- Python 3.12+
+- PyTorch with ROCm support
+- Unsloth
+- AMD RX 7800 XT (16GB VRAM) or compatible GPU

--- a/training/scripts/test_validate.py
+++ b/training/scripts/test_validate.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Tests for the training data quality gate pipeline."""
+
+import json
+import sys
+from pathlib import Path
+
+# Add scripts dir to path
+sys.path.insert(0, str(Path(__file__).parent))
+from validate import validate_encoding, validate_example, ValidationResult
+
+
+def good_encoding() -> str:
+    """Return a valid encoding JSON response."""
+    return json.dumps({
+        "gist": "User modified auth middleware",
+        "summary": "Updated authentication middleware to validate JWT tokens on every request",
+        "content": "The auth middleware was updated to check JWT expiry and validate signatures.",
+        "narrative": "During a security review, the user identified that the auth middleware was not properly validating JWT tokens. They added expiry checks and signature validation to prevent unauthorized access.",
+        "concepts": ["security", "authentication", "api", "fix"],
+        "structured_concepts": {
+            "topics": [{"label": "auth", "path": "security/auth"}],
+            "entities": [{"name": "JWT", "type": "technology", "context": "token validation"}],
+            "actions": [{"verb": "updated", "object": "middleware", "details": "added validation"}],
+            "causality": [{"relation": "caused_by", "description": "security review identified gap"}],
+        },
+        "significance": "important",
+        "emotional_tone": "satisfying",
+        "outcome": "success",
+        "salience": 0.7,
+    })
+
+
+def test_valid_encoding():
+    result = validate_encoding(good_encoding())
+    assert result.valid, f"Expected valid, got failures: {result.hard_failures}"
+    assert not result.hard_failures
+    print("PASS: test_valid_encoding")
+
+
+def test_invalid_json():
+    result = validate_encoding("not json at all")
+    assert not result.valid
+    assert "json_parse_failure" in result.hard_failures
+    print("PASS: test_invalid_json")
+
+
+def test_missing_fields():
+    result = validate_encoding(json.dumps({"gist": "hello"}))
+    assert not result.valid
+    assert any("missing_field" in f for f in result.hard_failures)
+    print("PASS: test_missing_fields")
+
+
+def test_gist_too_long():
+    data = json.loads(good_encoding())
+    data["gist"] = "x" * 61
+    result = validate_encoding(json.dumps(data))
+    assert not result.valid
+    assert any("gist_too_long" in f for f in result.hard_failures)
+    print("PASS: test_gist_too_long")
+
+
+def test_summary_too_long():
+    data = json.loads(good_encoding())
+    data["summary"] = "x" * 101
+    result = validate_encoding(json.dumps(data))
+    assert not result.valid
+    assert any("summary_too_long" in f for f in result.hard_failures)
+    print("PASS: test_summary_too_long")
+
+
+def test_salience_out_of_range():
+    data = json.loads(good_encoding())
+    data["salience"] = 1.5
+    result = validate_encoding(json.dumps(data))
+    assert not result.valid
+    assert any("salience_out_of_range" in f for f in result.hard_failures)
+    print("PASS: test_salience_out_of_range")
+
+
+def test_invalid_significance():
+    data = json.loads(good_encoding())
+    data["significance"] = "super_important"
+    result = validate_encoding(json.dumps(data))
+    assert not result.valid
+    assert any("invalid_significance" in f for f in result.hard_failures)
+    print("PASS: test_invalid_significance")
+
+
+def test_placeholder_gist():
+    data = json.loads(good_encoding())
+    data["gist"] = "user did something"
+    result = validate_encoding(json.dumps(data))
+    assert not result.valid
+    assert "placeholder_gist" in result.hard_failures
+    print("PASS: test_placeholder_gist")
+
+
+def test_empty_content():
+    data = json.loads(good_encoding())
+    data["content"] = "   "
+    result = validate_encoding(json.dumps(data))
+    assert not result.valid
+    assert "empty_content" in result.hard_failures
+    print("PASS: test_empty_content")
+
+
+def test_soft_warning_low_vocab_coverage():
+    data = json.loads(good_encoding())
+    data["concepts"] = ["xyzzy", "plugh", "plover", "frobnicate"]
+    result = validate_encoding(json.dumps(data))
+    assert result.valid  # soft gate, not a hard failure
+    assert any("low_vocab_coverage" in w for w in result.soft_warnings)
+    print("PASS: test_soft_warning_low_vocab_coverage")
+
+
+def test_soft_warning_strict_mode():
+    data = json.loads(good_encoding())
+    data["concepts"] = ["xyzzy", "plugh", "plover", "frobnicate"]
+    result = validate_encoding(json.dumps(data), strict=True)
+    assert not result.valid  # strict mode rejects soft warnings
+    print("PASS: test_soft_warning_strict_mode")
+
+
+def test_soft_warning_high_salience_routine():
+    data = json.loads(good_encoding())
+    data["salience"] = 0.95
+    data["significance"] = "routine"
+    result = validate_encoding(json.dumps(data))
+    assert result.valid
+    assert "high_salience_routine" in result.soft_warnings
+    print("PASS: test_soft_warning_high_salience_routine")
+
+
+def test_validate_example_with_error():
+    example = {"task_type": "encoding", "error": "connection refused", "response": {"content": ""}}
+    result = validate_example(example)
+    assert not result.valid
+    print("PASS: test_validate_example_with_error")
+
+
+if __name__ == "__main__":
+    test_valid_encoding()
+    test_invalid_json()
+    test_missing_fields()
+    test_gist_too_long()
+    test_summary_too_long()
+    test_salience_out_of_range()
+    test_invalid_significance()
+    test_placeholder_gist()
+    test_empty_content()
+    test_soft_warning_low_vocab_coverage()
+    test_soft_warning_strict_mode()
+    test_soft_warning_high_salience_routine()
+    test_validate_example_with_error()
+    print(f"\nAll {13} tests passed.")

--- a/training/scripts/validate.py
+++ b/training/scripts/validate.py
@@ -1,0 +1,356 @@
+#!/usr/bin/env python3
+"""
+Quality gate pipeline for mnemonic training data.
+
+Reads raw JSONL captures from the training data directory, applies hard and soft
+quality gates, and writes validated examples to the validated/ directory.
+Rejected examples go to rejected/ with rejection reasons.
+
+Usage:
+    python validate.py [--input-dir DIR] [--output-dir DIR] [--strict]
+
+Hard gates (auto-reject):
+    - JSON parse failure
+    - Missing required fields
+    - Field constraint violations (gist >60 chars, summary >100 chars, etc.)
+    - Salience outside [0, 1]
+    - Invalid significance/emotional_tone/outcome enum values
+    - Empty or placeholder content
+
+Soft gates (flagged for review, pass by default):
+    - Low concept vocabulary coverage
+    - Suspiciously short narrative
+    - Salience outliers (> 0.9 or < 0.1 for non-trivial content)
+    With --strict, soft gate failures also reject.
+"""
+
+import argparse
+import json
+import os
+import sys
+from collections import Counter
+from dataclasses import dataclass, field
+from pathlib import Path
+
+# Controlled vocabulary from config.example.yaml
+CONTROLLED_VOCABULARY = {
+    "go", "python", "javascript", "typescript", "sql", "bash", "html", "css",
+    "docker", "git", "linux", "macos", "systemd", "build", "ci", "deployment",
+    "debugging", "testing", "refactoring", "configuration", "migration",
+    "documentation", "review", "api", "database", "filesystem", "networking",
+    "security", "authentication", "performance", "logging", "ui", "cli",
+    "memory", "encoding", "retrieval", "embedding", "agent", "llm", "daemon",
+    "mcp", "watcher", "decision", "error", "fix", "insight", "learning",
+    "planning", "research", "dependency", "schema", "config",
+}
+
+VALID_SIGNIFICANCE = {"routine", "notable", "important", "critical"}
+VALID_EMOTIONAL_TONE = {"neutral", "satisfying", "frustrating", "exciting", "concerning"}
+VALID_OUTCOME = {"success", "failure", "ongoing", "unknown"}
+
+PLACEHOLDER_GISTS = {
+    "user did something",
+    "something happened",
+    "file changed",
+    "event occurred",
+    "unknown event",
+    "observation",
+}
+
+
+@dataclass
+class ValidationResult:
+    valid: bool = True
+    hard_failures: list = field(default_factory=list)
+    soft_warnings: list = field(default_factory=list)
+
+
+def validate_encoding(response_content: str, strict: bool = False) -> ValidationResult:
+    """Validate an encoding task response against quality gates."""
+    result = ValidationResult()
+
+    # Hard gate: JSON parse
+    try:
+        data = json.loads(response_content)
+    except (json.JSONDecodeError, TypeError):
+        result.valid = False
+        result.hard_failures.append("json_parse_failure")
+        return result
+
+    if not isinstance(data, dict):
+        result.valid = False
+        result.hard_failures.append("response_not_object")
+        return result
+
+    # Hard gate: required fields
+    required = [
+        "gist", "summary", "content", "narrative", "concepts",
+        "structured_concepts", "significance", "emotional_tone",
+        "outcome", "salience",
+    ]
+    for f in required:
+        if f not in data:
+            result.valid = False
+            result.hard_failures.append(f"missing_field:{f}")
+
+    if not result.valid:
+        return result
+
+    # Hard gate: field types
+    if not isinstance(data.get("gist"), str):
+        result.valid = False
+        result.hard_failures.append("gist_not_string")
+    if not isinstance(data.get("summary"), str):
+        result.valid = False
+        result.hard_failures.append("summary_not_string")
+    if not isinstance(data.get("concepts"), list):
+        result.valid = False
+        result.hard_failures.append("concepts_not_array")
+    if not isinstance(data.get("salience"), (int, float)):
+        result.valid = False
+        result.hard_failures.append("salience_not_number")
+
+    if not result.valid:
+        return result
+
+    # Hard gate: field constraints
+    gist = data["gist"]
+    summary = data["summary"]
+    content = data.get("content", "")
+    narrative = data.get("narrative", "")
+    salience = data["salience"]
+    significance = data.get("significance", "")
+    emotional_tone = data.get("emotional_tone", "")
+    outcome = data.get("outcome", "")
+    concepts = data.get("concepts", [])
+
+    if len(gist) > 60:
+        result.valid = False
+        result.hard_failures.append(f"gist_too_long:{len(gist)}")
+
+    if len(summary) > 100:
+        result.valid = False
+        result.hard_failures.append(f"summary_too_long:{len(summary)}")
+
+    if not (0.0 <= salience <= 1.0):
+        result.valid = False
+        result.hard_failures.append(f"salience_out_of_range:{salience}")
+
+    if significance and significance not in VALID_SIGNIFICANCE:
+        result.valid = False
+        result.hard_failures.append(f"invalid_significance:{significance}")
+
+    if emotional_tone and emotional_tone not in VALID_EMOTIONAL_TONE:
+        result.valid = False
+        result.hard_failures.append(f"invalid_emotional_tone:{emotional_tone}")
+
+    if outcome and outcome not in VALID_OUTCOME:
+        result.valid = False
+        result.hard_failures.append(f"invalid_outcome:{outcome}")
+
+    # Hard gate: placeholder content
+    if gist.lower().strip() in PLACEHOLDER_GISTS:
+        result.valid = False
+        result.hard_failures.append("placeholder_gist")
+
+    if not content.strip():
+        result.valid = False
+        result.hard_failures.append("empty_content")
+
+    if not result.valid:
+        return result
+
+    # Soft gate: concept vocabulary coverage
+    if concepts:
+        vocab_hits = sum(1 for c in concepts if c.lower() in CONTROLLED_VOCABULARY)
+        coverage = vocab_hits / len(concepts) if concepts else 0
+        if coverage < 0.3:
+            result.soft_warnings.append(f"low_vocab_coverage:{coverage:.2f}")
+
+    # Soft gate: short narrative
+    if len(narrative) < 20:
+        result.soft_warnings.append(f"short_narrative:{len(narrative)}")
+
+    # Soft gate: salience outliers
+    if salience > 0.9 and significance == "routine":
+        result.soft_warnings.append("high_salience_routine")
+    if salience < 0.1 and significance in ("important", "critical"):
+        result.soft_warnings.append("low_salience_important")
+
+    # Soft gate: few concepts for substantive content
+    if len(content) > 200 and len(concepts) < 3:
+        result.soft_warnings.append(f"few_concepts:{len(concepts)}")
+
+    if strict and result.soft_warnings:
+        result.valid = False
+
+    return result
+
+
+def validate_example(example: dict, strict: bool = False) -> ValidationResult:
+    """Validate a single captured training example."""
+    task_type = example.get("task_type", "unknown")
+
+    # Only validate encoding tasks for now (the primary training target)
+    if task_type == "encoding":
+        response_content = example.get("response", {}).get("content", "")
+        return validate_encoding(response_content, strict=strict)
+
+    # For non-encoding tasks, just check basic structure
+    result = ValidationResult()
+    if example.get("error"):
+        result.valid = False
+        result.hard_failures.append("call_error")
+    if not example.get("parse_success", True):
+        result.valid = False
+        result.hard_failures.append("parse_failure")
+    return result
+
+
+def process_file(
+    input_path: Path,
+    validated_dir: Path,
+    rejected_dir: Path,
+    strict: bool = False,
+) -> dict:
+    """Process a single JSONL capture file through quality gates."""
+    stats = Counter()
+
+    validated_path = validated_dir / input_path.name
+    rejected_path = rejected_dir / input_path.name
+
+    with (
+        open(input_path) as fin,
+        open(validated_path, "a") as fval,
+        open(rejected_path, "a") as frej,
+    ):
+        for line_num, line in enumerate(fin, 1):
+            line = line.strip()
+            if not line:
+                continue
+
+            try:
+                example = json.loads(line)
+            except json.JSONDecodeError:
+                stats["parse_error"] += 1
+                continue
+
+            task_type = example.get("task_type", "unknown")
+            stats[f"total_{task_type}"] += 1
+
+            result = validate_example(example, strict=strict)
+
+            if result.valid:
+                stats[f"valid_{task_type}"] += 1
+                # Add validation metadata
+                example["_validation"] = {
+                    "warnings": result.soft_warnings,
+                    "validated_at": None,  # Will be set by downstream
+                }
+                fval.write(json.dumps(example) + "\n")
+            else:
+                stats[f"rejected_{task_type}"] += 1
+                example["_rejection"] = {
+                    "hard_failures": result.hard_failures,
+                    "soft_warnings": result.soft_warnings,
+                    "source_file": str(input_path),
+                    "source_line": line_num,
+                }
+                frej.write(json.dumps(example) + "\n")
+
+            if result.soft_warnings:
+                stats["soft_warnings"] += len(result.soft_warnings)
+                for w in result.soft_warnings:
+                    stats[f"warning_{w.split(':')[0]}"] += 1
+
+            for f in result.hard_failures:
+                stats[f"failure_{f.split(':')[0]}"] += 1
+
+    return dict(stats)
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Validate mnemonic training data")
+    parser.add_argument(
+        "--input-dir",
+        default=os.path.expanduser("~/.mnemonic/training-data"),
+        help="Directory containing raw JSONL captures",
+    )
+    parser.add_argument(
+        "--output-dir",
+        default="data",
+        help="Base output directory (validated/ and rejected/ subdirs)",
+    )
+    parser.add_argument(
+        "--strict",
+        action="store_true",
+        help="Reject examples that fail soft gates too",
+    )
+    args = parser.parse_args()
+
+    input_dir = Path(args.input_dir)
+    output_dir = Path(args.output_dir)
+    validated_dir = output_dir / "validated"
+    rejected_dir = output_dir / "rejected"
+
+    validated_dir.mkdir(parents=True, exist_ok=True)
+    rejected_dir.mkdir(parents=True, exist_ok=True)
+
+    if not input_dir.exists():
+        print(f"Input directory does not exist: {input_dir}")
+        print("Enable training data capture in config.yaml first.")
+        sys.exit(1)
+
+    jsonl_files = sorted(input_dir.glob("capture_*.jsonl"))
+    if not jsonl_files:
+        print(f"No capture files found in {input_dir}")
+        sys.exit(1)
+
+    total_stats = Counter()
+    for fpath in jsonl_files:
+        print(f"Processing {fpath.name}...")
+        stats = process_file(fpath, validated_dir, rejected_dir, strict=args.strict)
+        total_stats.update(stats)
+
+    # Print summary
+    print("\n--- Validation Summary ---")
+    total = sum(v for k, v in total_stats.items() if k.startswith("total_"))
+    valid = sum(v for k, v in total_stats.items() if k.startswith("valid_"))
+    rejected = sum(v for k, v in total_stats.items() if k.startswith("rejected_"))
+
+    print(f"Total examples:    {total}")
+    print(f"Validated:         {valid} ({valid/total*100:.1f}%)" if total else "")
+    print(f"Rejected:          {rejected} ({rejected/total*100:.1f}%)" if total else "")
+
+    if total_stats.get("soft_warnings"):
+        print(f"Soft warnings:     {total_stats['soft_warnings']}")
+
+    print("\nBy task type:")
+    for key in sorted(total_stats):
+        if key.startswith("total_"):
+            task = key.replace("total_", "")
+            v = total_stats.get(f"valid_{task}", 0)
+            r = total_stats.get(f"rejected_{task}", 0)
+            t = total_stats[key]
+            print(f"  {task}: {t} total, {v} valid, {r} rejected")
+
+    if any(k.startswith("failure_") for k in total_stats):
+        print("\nRejection reasons:")
+        for key in sorted(total_stats):
+            if key.startswith("failure_"):
+                reason = key.replace("failure_", "")
+                print(f"  {reason}: {total_stats[key]}")
+
+    if any(k.startswith("warning_") for k in total_stats):
+        print("\nWarning types:")
+        for key in sorted(total_stats):
+            if key.startswith("warning_"):
+                reason = key.replace("warning_", "")
+                print(f"  {reason}: {total_stats[key]}")
+
+    print(f"\nValidated data written to: {validated_dir}")
+    print(f"Rejected data written to:  {rejected_dir}")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Adds `TrainingCaptureProvider` that wraps any LLM provider and captures full request/response pairs as daily JSONL files
- Captures all request fields (messages, model, tools, response_format, temperature, top_p, stop) and response fields (content, tool_calls, stop_reason)
- Auto-classifies task type from prompt content: encoding, synthesis, abstraction, consolidation, perception, episoding, classification
- Handles midnight file rollover for long-running daemon
- CLI commands (remember, recall, consolidate, etc.) also capture when enabled
- Python quality gate pipeline (`training/scripts/validate.py`) with hard gates (JSON compliance, field constraints, enum validation) and soft gates (vocab coverage, salience outliers)

Enable with one line in config.yaml:
```yaml
training:
  capture_enabled: true
```

## Context

First step toward training a bespoke local model to replace cloud LLM dependencies. The daemon is now collecting training data from every Gemini call -- encoding, retrieval synthesis, abstraction, consolidation. After accumulating enough validated examples, we'll fine-tune with Unsloth targeting the encoding task first (80% of LLM calls, fixed JSON schema, controlled vocabulary).

## Test plan

- [x] 16 Go tests: capture, task classification (12 cases), file rollover, disabled mode, parse failure detection
- [x] 13 Python tests: all quality gate types (valid, invalid JSON, field constraints, enums, placeholders, soft gates, strict mode)
- [x] `make build` and `make check` pass
- [x] Full test suite passes (no regressions)
- [x] Verified live: daemon captures data to `~/.mnemonic/training-data/`, 48+ examples collected

🤖 Generated with [Claude Code](https://claude.com/claude-code)