### PR TITLE
fix: aggregate LLM chart data server-side for accurate time bucketing

### DIFF
--- a/.claude/hooks/require-branch.sh
+++ b/.claude/hooks/require-branch.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block Edit/Write when on main branch.
+# Forces Claude to create a feature branch before making code changes.
+
+set -euo pipefail
+
+# Only check inside the project git repo
+cd "$CLAUDE_PROJECT_DIR" 2>/dev/null || exit 0
+
+branch=$(git rev-parse --abbrev-ref HEAD 2>/dev/null) || exit 0
+
+if [ "$branch" = "main" ] || [ "$branch" = "master" ]; then
+    echo "BLOCKED: You are on the '$branch' branch. Create a feature branch (fix/* or feat/*) before editing files."
+    exit 2
+fi

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -43,6 +43,26 @@
             "timeout": 10
           }
         ]
+      },
+      {
+        "matcher": "Edit",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/require-branch.sh",
+            "timeout": 5
+          }
+        ]
+      },
+      {
+        "matcher": "Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"$CLAUDE_PROJECT_DIR\"/.claude/hooks/require-branch.sh",
+            "timeout": 5
+          }
+        ]
       }
     ],
     "PostToolUse": [

--- a/internal/api/routes/llm_usage.go
+++ b/internal/api/routes/llm_usage.go
@@ -11,16 +11,25 @@ import (
 
 // LLMUsageResponse is the JSON response for the LLM usage endpoint.
 type LLMUsageResponse struct {
-	Summary          store.LLMUsageSummary `json:"summary"`
-	EstimatedCostUSD float64               `json:"estimated_cost_usd"`
-	Log              []LLMUsageLogEntry    `json:"log"`
-	Timestamp        string                `json:"timestamp"`
+	Summary          store.LLMUsageSummary  `json:"summary"`
+	EstimatedCostUSD float64                `json:"estimated_cost_usd"`
+	Log              []LLMUsageLogEntry     `json:"log"`
+	ChartBuckets     []store.LLMChartBucket `json:"chart_buckets"`
+	Timestamp        string                 `json:"timestamp"`
 }
 
 // LLMUsageLogEntry extends a usage record with estimated cost.
 type LLMUsageLogEntry struct {
 	llm.LLMUsageRecord
 	EstimatedCostUSD float64 `json:"estimated_cost_usd"`
+}
+
+// bucketSeconds maps range durations to chart bucket sizes.
+var bucketSeconds = map[string]int{
+	"1h":   5 * 60,        // 5-minute buckets
+	"6h":   30 * 60,       // 30-minute buckets
+	"24h":  60 * 60,       // 1-hour buckets
+	"168h": 24 * 60 * 60,  // 1-day buckets
 }
 
 // HandleLLMUsage returns an HTTP handler that returns LLM usage summary and log.
@@ -54,12 +63,24 @@ func HandleLLMUsage(s store.Store, log *slog.Logger) http.HandlerFunc {
 			return
 		}
 
-		// Get log
-		records, err := s.GetLLMUsageLog(r.Context(), limit)
+		// Get log (limited for the request table)
+		records, err := s.GetLLMUsageLog(r.Context(), since, limit)
 		if err != nil {
 			log.Error("failed to get llm usage log", "error", err)
 			writeError(w, http.StatusInternalServerError, "failed to retrieve usage log", "STORE_ERROR")
 			return
+		}
+
+		// Get pre-aggregated chart data
+		bSecs := bucketSeconds[sinceStr]
+		if bSecs == 0 {
+			bSecs = 3600 // default 1-hour buckets
+		}
+		chartBuckets, err := s.GetLLMUsageChart(r.Context(), since, bSecs)
+		if err != nil {
+			log.Error("failed to get llm chart data", "error", err)
+			// Non-fatal: chart data is optional, continue with empty buckets
+			chartBuckets = nil
 		}
 
 		// Compute per-record cost and total cost
@@ -78,6 +99,7 @@ func HandleLLMUsage(s store.Store, log *slog.Logger) http.HandlerFunc {
 			Summary:          summary,
 			EstimatedCostUSD: totalCost,
 			Log:              logEntries,
+			ChartBuckets:     chartBuckets,
 			Timestamp:        time.Now().UTC().Format(time.RFC3339),
 		}
 

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1979,15 +1979,16 @@ func (s *SQLiteStore) GetLLMUsageSummary(ctx context.Context, since time.Time) (
 	return summary, nil
 }
 
-// GetLLMUsageLog returns the most recent LLM usage records.
-func (s *SQLiteStore) GetLLMUsageLog(ctx context.Context, limit int) ([]llm.LLMUsageRecord, error) {
+// GetLLMUsageLog returns the most recent LLM usage records within the given time range.
+func (s *SQLiteStore) GetLLMUsageLog(ctx context.Context, since time.Time, limit int) ([]llm.LLMUsageRecord, error) {
 	if limit <= 0 {
 		limit = 50
 	}
 	rows, err := s.db.QueryContext(ctx,
 		`SELECT timestamp, operation, caller, model, prompt_tokens, completion_tokens,
 		        total_tokens, latency_ms, success, error_message
-		 FROM llm_usage ORDER BY timestamp DESC LIMIT ?`, limit)
+		 FROM llm_usage WHERE timestamp >= ? ORDER BY timestamp DESC LIMIT ?`,
+		since.UTC().Format(time.RFC3339), limit)
 	if err != nil {
 		return nil, fmt.Errorf("querying LLM usage log: %w", err)
 	}
@@ -2006,6 +2007,38 @@ func (s *SQLiteStore) GetLLMUsageLog(ctx context.Context, limit int) ([]llm.LLMU
 		records = append(records, r)
 	}
 	return records, rows.Err()
+}
+
+// GetLLMUsageChart returns pre-aggregated token counts bucketed by the given interval.
+func (s *SQLiteStore) GetLLMUsageChart(ctx context.Context, since time.Time, bucketSecs int) ([]store.LLMChartBucket, error) {
+	if bucketSecs <= 0 {
+		bucketSecs = 3600
+	}
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT datetime(CAST(strftime('%s', timestamp) / ? AS INTEGER) * ?, 'unixepoch') AS bucket_ts,
+		        SUM(prompt_tokens), SUM(completion_tokens), COUNT(*),
+		        SUM(CASE WHEN success = 0 THEN 1 ELSE 0 END)
+		 FROM llm_usage
+		 WHERE timestamp >= ?
+		 GROUP BY bucket_ts
+		 ORDER BY bucket_ts`,
+		bucketSecs, bucketSecs, since.UTC().Format(time.RFC3339))
+	if err != nil {
+		return nil, fmt.Errorf("querying LLM usage chart: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var buckets []store.LLMChartBucket
+	for rows.Next() {
+		var b store.LLMChartBucket
+		var ts string
+		if err := rows.Scan(&ts, &b.PromptTokens, &b.CompletionTokens, &b.Requests, &b.Errors); err != nil {
+			return nil, fmt.Errorf("scanning LLM chart bucket: %w", err)
+		}
+		b.Timestamp, _ = time.Parse("2006-01-02 15:04:05", ts)
+		buckets = append(buckets, b)
+	}
+	return buckets, rows.Err()
 }
 
 // Close closes the database connection.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -107,6 +107,15 @@ type AgentUsage struct {
 	TotalTokens int `json:"total_tokens"`
 }
 
+// LLMChartBucket holds pre-aggregated token counts for a single time bucket.
+type LLMChartBucket struct {
+	Timestamp        time.Time `json:"timestamp"`
+	PromptTokens     int       `json:"prompt_tokens"`
+	CompletionTokens int       `json:"completion_tokens"`
+	Requests         int       `json:"requests"`
+	Errors           int       `json:"errors"`
+}
+
 // StoreStatistics aggregates memory health metrics.
 type StoreStatistics struct {
 	TotalMemories         int       `json:"total_memories"`
@@ -410,7 +419,8 @@ type Store interface {
 	// --- LLM usage tracking ---
 	RecordLLMUsage(ctx context.Context, record llm.LLMUsageRecord) error
 	GetLLMUsageSummary(ctx context.Context, since time.Time) (LLMUsageSummary, error)
-	GetLLMUsageLog(ctx context.Context, limit int) ([]llm.LLMUsageRecord, error)
+	GetLLMUsageLog(ctx context.Context, since time.Time, limit int) ([]llm.LLMUsageRecord, error)
+	GetLLMUsageChart(ctx context.Context, since time.Time, bucketSecs int) ([]LLMChartBucket, error)
 
 	// --- Lifecycle ---
 	Close() error

--- a/internal/store/storetest/mock.go
+++ b/internal/store/storetest/mock.go
@@ -256,7 +256,10 @@ func (MockStore) RecordLLMUsage(context.Context, llm.LLMUsageRecord) error { ret
 func (MockStore) GetLLMUsageSummary(context.Context, time.Time) (store.LLMUsageSummary, error) {
 	return store.LLMUsageSummary{}, nil
 }
-func (MockStore) GetLLMUsageLog(context.Context, int) ([]llm.LLMUsageRecord, error) {
+func (MockStore) GetLLMUsageLog(context.Context, time.Time, int) ([]llm.LLMUsageRecord, error) {
+	return nil, nil
+}
+func (MockStore) GetLLMUsageChart(context.Context, time.Time, int) ([]store.LLMChartBucket, error) {
 	return nil, nil
 }
 

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -2845,57 +2845,47 @@
                 }).join('');
             }
 
-            renderLLMChart(log, _llmRange);
+            renderLLMChart(data.chart_buckets || [], _llmRange);
         } catch (e) {
             document.getElementById('llmRequests').textContent = 'ERR';
         }
     }
 
-    function renderLLMChart(log, range) {
+    function renderLLMChart(chartBuckets, range) {
         var container = document.getElementById('llmChart');
         var tooltip = document.getElementById('llmChartTooltip');
         container.innerHTML = '';
-        if (!log || log.length === 0) { container.innerHTML = '<div class="llm-empty">No data for chart</div>'; return; }
+        if (!chartBuckets || chartBuckets.length === 0) { container.innerHTML = '<div class="llm-empty">No data for chart</div>'; return; }
 
-        // Determine bucket size and count from range
-        var now = new Date();
-        var bucketMs, bucketCount, labelFmt, labelEvery;
+        // Determine label format and frequency from range
+        var labelFmt, labelEvery;
         if (range === '1h') {
-            bucketMs = 5 * 60 * 1000; bucketCount = 12;
             labelFmt = function(d) { return String(d.getHours()).padStart(2,'0') + ':' + String(d.getMinutes()).padStart(2,'0'); };
             labelEvery = 3;
         } else if (range === '6h') {
-            bucketMs = 30 * 60 * 1000; bucketCount = 12;
             labelFmt = function(d) { return String(d.getHours()).padStart(2,'0') + ':' + String(d.getMinutes()).padStart(2,'0'); };
             labelEvery = 2;
         } else if (range === '168h') {
-            bucketMs = 24 * 60 * 60 * 1000; bucketCount = 7;
             var days = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
             labelFmt = function(d) { return days[d.getDay()]; };
             labelEvery = 1;
         } else { // 24h default
-            bucketMs = 60 * 60 * 1000; bucketCount = 24;
             labelFmt = function(d) { return String(d.getHours()).padStart(2,'0') + ':00'; };
             labelEvery = 4;
         }
 
-        var rangeStart = new Date(now.getTime() - bucketCount * bucketMs);
-        var buckets = [];
-        for (var i = 0; i < bucketCount; i++) {
-            var bStart = new Date(rangeStart.getTime() + i * bucketMs);
-            buckets.push({ idx: i, start: bStart, label: labelFmt(bStart), prompt: 0, completion: 0, requests: 0, errors: 0 });
-        }
-        log.forEach(function(r) {
-            if (!r.timestamp) return;
-            var offset = new Date(r.timestamp).getTime() - rangeStart.getTime();
-            if (offset < 0) return;
-            var idx = Math.floor(offset / bucketMs);
-            if (idx >= 0 && idx < bucketCount) {
-                buckets[idx].prompt += (r.prompt_tokens || 0);
-                buckets[idx].completion += (r.completion_tokens || 0);
-                buckets[idx].requests++;
-                if (!r.success) buckets[idx].errors++;
-            }
+        // Map server-aggregated buckets to chart data
+        var buckets = chartBuckets.map(function(b, i) {
+            var ts = new Date(b.timestamp);
+            return {
+                idx: i,
+                start: ts,
+                label: labelFmt(ts),
+                prompt: b.prompt_tokens || 0,
+                completion: b.completion_tokens || 0,
+                requests: b.requests || 0,
+                errors: b.errors || 0
+            };
         });
 
         var w = container.clientWidth || 400;


### PR DESCRIPTION
## Summary
- **LLM chart showed only 1 bar** regardless of time range (1h/6h/24h/7d) because `GetLLMUsageLog` had no `since` filter and a low record limit — all returned records clustered into one time bucket
- Added `GetLLMUsageChart` store method that aggregates token counts via SQL `GROUP BY` with configurable bucket intervals (5min/30min/1hr/1day)
- API now returns pre-aggregated `chart_buckets` alongside the limited `log` entries, so the chart renders complete data without sending thousands of raw records
- Also adds a `require-branch.sh` PreToolUse hook that blocks Edit/Write on main to enforce feature-branch workflow

## Test plan
- [x] `make build` passes
- [x] `make test` — all tests pass
- [x] Verified API returns correct bucket distribution: 7 daily buckets for 7d, 25 hourly buckets for 24h
- [x] Dashboard charts visually confirmed to show bars across the full selected time range
- [x] Verify 1h and 6h ranges render correctly with active LLM usage

🤖 Generated with [Claude Code](https://claude.com/claude-code)