### PR TITLE
fix: use macos-13 runner for darwin/amd64 release builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
             goos: darwin
             goarch: arm64
             name: darwin_arm64
-          - os: macos-15
+          - os: macos-13
             goos: darwin
             goarch: amd64
             name: darwin_amd64


### PR DESCRIPTION
## Summary

- The v0.15.0 release build failed on macOS because `macos-15` (ARM64) was used to build `GOARCH=amd64`
- `fsevents` requires CGO (C bindings to CoreServices), and CGO can't cross-compile arm64→amd64 without a special toolchain
- Fix: use `macos-13` which is the last x86_64 GitHub Actions runner, so the build is native

**Failed run:** https://github.com/AppSprout-dev/mnemonic/actions/runs/23208785176

## Test plan

- [ ] Merge, re-tag v0.15.0, verify all three builds pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)