### PR TITLE
fix: drop darwin/amd64 release build

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,10 +17,6 @@ jobs:
             goos: darwin
             goarch: arm64
             name: darwin_arm64
-          - os: macos-13
-            goos: darwin
-            goarch: amd64
-            name: darwin_amd64
           - os: ubuntu-latest
             goos: linux
             goarch: amd64


### PR DESCRIPTION
## Summary

- Remove the darwin/amd64 build target from the release workflow
- Intel Macs are EOL and GitHub retired the `macos-13` runner (last x86_64 macOS runner)
- ARM runners can't cross-compile CGO for amd64 (`fsevents` requires C bindings)
- Release now ships: **darwin/arm64** + **linux/amd64**

🤖 Generated with [Claude Code](https://claude.com/claude-code)