### PR TITLE
fix: propagate memory type to API and web UI

### DIFF
--- a/internal/agent/encoding/agent.go
+++ b/internal/agent/encoding/agent.go
@@ -600,6 +600,7 @@ func (ea *EncodingAgent) encodeMemory(ctx context.Context, rawID string) error {
 		ID:           memoryID,
 		RawID:        raw.ID,
 		Timestamp:    raw.Timestamp,
+		Type:         raw.Type,
 		Content:      compression.Content,
 		Summary:      compression.Summary,
 		Concepts:     compression.Concepts,

--- a/internal/store/sqlite/schema.go
+++ b/internal/store/sqlite/schema.go
@@ -252,6 +252,11 @@ CREATE INDEX IF NOT EXISTS idx_llm_usage_timestamp ON llm_usage(timestamp);
 CREATE INDEX IF NOT EXISTS idx_llm_usage_caller ON llm_usage(caller);
 `
 
+const migration008 = `
+-- Migration 008: Add type column to memories (propagated from raw_memories)
+-- This enables the web UI to filter memories by type (decision, error, insight, learning, general).
+`
+
 // InitSchema initializes the SQLite database schema by creating all tables,
 // indexes, and triggers if they don't already exist. It also configures
 // important PRAGMA settings for performance and safety.
@@ -367,6 +372,20 @@ func InitSchema(db *sql.DB) error {
 	if _, err := db.Exec(migration006); err != nil {
 		return fmt.Errorf("failed to apply migration 006: %w", err)
 	}
+
+	// Apply migration 008: Add type column to memories
+	if _, err := db.Exec(migration008); err != nil {
+		return fmt.Errorf("failed to apply migration 008: %w", err)
+	}
+	_, err = db.Exec(`ALTER TABLE memories ADD COLUMN type TEXT`)
+	if err != nil && !isAlterTableDuplicateColumn(err) {
+		return fmt.Errorf("failed to add memories.type column: %w", err)
+	}
+	if _, err := db.Exec(`CREATE INDEX IF NOT EXISTS idx_memory_type ON memories(type)`); err != nil {
+		return fmt.Errorf("failed to create idx_memory_type index: %w", err)
+	}
+	// Backfill type from raw_memories where possible
+	_, _ = db.Exec(`UPDATE memories SET type = (SELECT raw_memories.type FROM raw_memories WHERE raw_memories.id = memories.raw_id) WHERE type IS NULL AND raw_id IS NOT NULL AND raw_id != ''`)
 
 	return nil
 }

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -348,11 +348,12 @@ func scanRawMemoryRows(rows *sql.Rows) ([]store.RawMemory, error) {
 }
 
 // memoryColumns is the standard column list for memory queries.
-const memoryColumns = `id, raw_id, timestamp, content, summary, concepts, embedding, salience, access_count, last_accessed, state, gist_of, episode_id, source, project, session_id, created_at, updated_at`
+const memoryColumns = `id, raw_id, timestamp, type, content, summary, concepts, embedding, salience, access_count, last_accessed, state, gist_of, episode_id, source, project, session_id, created_at, updated_at`
 
 // scanMemory scans a memory row from the database.
 func scanMemoryFrom(s scanner) (store.Memory, error) {
 	var mem store.Memory
+	var memType sql.NullString
 	var conceptsStr sql.NullString
 	var embeddingBlob []byte
 	var gistOfStr sql.NullString
@@ -365,6 +366,7 @@ func scanMemoryFrom(s scanner) (store.Memory, error) {
 		&mem.ID,
 		&mem.RawID,
 		&mem.Timestamp,
+		&memType,
 		&mem.Content,
 		&mem.Summary,
 		&conceptsStr,
@@ -413,6 +415,9 @@ func scanMemoryFrom(s scanner) (store.Memory, error) {
 	} else {
 		mem.GistOf = []string{}
 	}
+
+	// Decode type
+	mem.Type = memType.String
 
 	// Decode episode_id
 	mem.EpisodeID = episodeID.String
@@ -724,8 +729,8 @@ func (s *SQLiteStore) WriteMemory(ctx context.Context, mem store.Memory) error {
 
 	query := `
 	INSERT INTO memories
-	(id, raw_id, timestamp, content, summary, concepts, embedding, salience, access_count, last_accessed, state, gist_of, episode_id, source, project, session_id, created_at, updated_at)
-	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	(id, raw_id, timestamp, type, content, summary, concepts, embedding, salience, access_count, last_accessed, state, gist_of, episode_id, source, project, session_id, created_at, updated_at)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 
 	// Convert empty episode ID to nil so FK constraint allows NULL
@@ -738,6 +743,7 @@ func (s *SQLiteStore) WriteMemory(ctx context.Context, mem store.Memory) error {
 		mem.ID,
 		mem.RawID,
 		mem.Timestamp.Format(time.RFC3339),
+		nullableString(mem.Type),
 		mem.Content,
 		mem.Summary,
 		conceptsStr,
@@ -803,7 +809,7 @@ func (s *SQLiteStore) UpdateMemory(ctx context.Context, mem store.Memory) error 
 
 	query := `
 	UPDATE memories
-	SET raw_id = ?, timestamp = ?, content = ?, summary = ?, concepts = ?, embedding = ?,
+	SET raw_id = ?, timestamp = ?, type = ?, content = ?, summary = ?, concepts = ?, embedding = ?,
 	    salience = ?, access_count = ?, last_accessed = ?, state = ?, gist_of = ?,
 	    source = ?, project = ?, session_id = ?, updated_at = ?
 	WHERE id = ?
@@ -812,6 +818,7 @@ func (s *SQLiteStore) UpdateMemory(ctx context.Context, mem store.Memory) error 
 	result, err := s.db.ExecContext(ctx, query,
 		mem.RawID,
 		mem.Timestamp.Format(time.RFC3339),
+		nullableString(mem.Type),
 		mem.Content,
 		mem.Summary,
 		conceptsStr,
@@ -1329,8 +1336,8 @@ func (s *SQLiteStore) BatchMergeMemories(ctx context.Context, sourceIDs []string
 
 	writeQuery := `
 	INSERT INTO memories
-	(id, raw_id, timestamp, content, summary, concepts, embedding, salience, access_count, last_accessed, state, gist_of, episode_id, source, project, session_id, created_at, updated_at)
-	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	(id, raw_id, timestamp, type, content, summary, concepts, embedding, salience, access_count, last_accessed, state, gist_of, episode_id, source, project, session_id, created_at, updated_at)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 
 	// Convert empty episode ID to nil so FK constraint allows NULL
@@ -1343,6 +1350,7 @@ func (s *SQLiteStore) BatchMergeMemories(ctx context.Context, sourceIDs []string
 		gist.ID,
 		gist.RawID,
 		gist.Timestamp.Format(time.RFC3339),
+		nullableString(gist.Type),
 		gist.Content,
 		gist.Summary,
 		conceptsStr,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -46,9 +46,10 @@ type Memory struct {
 	ID           string    `json:"id"`
 	RawID        string    `json:"raw_id"`
 	Timestamp    time.Time `json:"timestamp"`
-	Content      string    `json:"content"`  // compressed/encoded form
-	Summary      string    `json:"summary"`  // one-liner
-	Concepts     []string  `json:"concepts"` // extracted concepts
+	Type         string    `json:"type,omitempty"` // "decision", "error", "insight", "learning", "general", etc.
+	Content      string    `json:"content"`        // compressed/encoded form
+	Summary      string    `json:"summary"`        // one-liner
+	Concepts     []string  `json:"concepts"`       // extracted concepts
 	Embedding    []float32 `json:"embedding,omitempty"`
 	Salience     float32   `json:"salience"`
 	AccessCount  int       `json:"access_count"`


### PR DESCRIPTION
## Summary
- The `Memory` struct had no `Type` field — the web dashboard's type filter buttons (decision, error, insight, learning) never worked because `m.type` was always `undefined` in the JSON response, so everything displayed as "general"
- Adds `type` column to the `memories` table (migration 008), backfills from `raw_memories.type`, and flows the type through encoding, all SQL read/write paths, and the API response
- No web UI changes needed — the existing JS already reads `m.type`, it just wasn't being served

## Test plan
- [x] `make test` — all tests pass
- [x] `make check` — go fmt + go vet clean
- [x] Build + restart daemon, verified `/api/v1/memories` returns `type` field
- [x] Confirmed 5 decisions, 4 insights, 1 learning now visible with correct types
- [x] Verify web UI timeline type filters work in browser

🤖 Generated with [Claude Code](https://claude.com/claude-code)