### PR TITLE
fix: strip FTS5 metacharacters from query sanitizer

### DIFF
--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -985,6 +985,8 @@ var ftsStopWords = map[string]bool{
 
 // sanitizeFTSQuery converts a raw query string into safe FTS5 syntax.
 // Uses prefix matching (word*) for stemming-like behavior and filters stop words.
+// Strips all non-alphanumeric characters to prevent FTS5 metacharacters
+// (colons, parentheses, etc.) from being interpreted as operators.
 func sanitizeFTSQuery(query string) string {
 	words := strings.Fields(query)
 	if len(words) == 0 {
@@ -992,12 +994,20 @@ func sanitizeFTSQuery(query string) string {
 	}
 	terms := make([]string, 0, len(words))
 	for _, w := range words {
-		w = strings.Trim(w, "\"'.,!?;:")
-		w = strings.ToLower(w)
-		if w == "" || len(w) < 2 || ftsStopWords[w] {
+		// Strip ALL non-alphanumeric chars — not just edges.
+		// FTS5 treats ":" as column filter, "+" / "^" / "-" / "()" as operators.
+		// Keeping only alphanumeric prevents any metacharacter injection.
+		cleaned := strings.Map(func(r rune) rune {
+			if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') {
+				return r
+			}
+			return -1
+		}, w)
+		cleaned = strings.ToLower(cleaned)
+		if cleaned == "" || len(cleaned) < 2 || ftsStopWords[cleaned] {
 			continue
 		}
-		terms = append(terms, w+"*")
+		terms = append(terms, cleaned+"*")
 	}
 	if len(terms) == 0 {
 		return ""

--- a/internal/store/sqlite/sqlite_test.go
+++ b/internal/store/sqlite/sqlite_test.go
@@ -937,3 +937,34 @@ func TestMarkRawProcessed(t *testing.T) {
 		t.Fatal("expected raw memory to be marked processed")
 	}
 }
+
+func TestSanitizeFTSQuery(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", ""},
+		{"single word", "mnemonic", "mnemonic*"},
+		{"multiple words", "memory search", "memory* OR search*"},
+		{"stop words filtered", "the memory is good", "memory* OR good*"},
+		{"short words filtered", "a x memory", "memory*"},
+		{"colon in middle stripped", "lm:studio", "lmstudio*"},
+		{"colon at edge stripped", "lm:", "lm*"},
+		{"hyphen stripped", "felix-lm", "felixlm*"},
+		{"parentheses stripped", "(memory)", "memory*"},
+		{"mixed punctuation", "hello! world? foo:bar", "hello* OR world* OR foobar*"},
+		{"all stop words", "the a an and or", ""},
+		{"all short words", "a x i", ""},
+		{"preserves digits", "v3 gpt4", "v3* OR gpt4*"},
+		{"FTS operators neutralized", "NOT NEAR memory", "not* OR near* OR memory*"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeFTSQuery(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeFTSQuery(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `sanitizeFTSQuery` only trimmed special chars from word edges (`strings.Trim`), so colons inside words (e.g., `lm:studio`) survived and FTS5 interpreted them as column filters, causing `no such column: lm` errors
- Replaced with `strings.Map` that strips **all** non-alphanumeric characters from each query term
- Added 14 table-driven test cases covering the bug and edge cases

## Test plan
- [x] `TestSanitizeFTSQuery` passes all 14 cases (colons, hyphens, parens, mixed punctuation, FTS operators)
- [x] `recall_project` MCP tool verified working after rebuild + daemon restart
- [x] `go fmt` / `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)