### PR TITLE
feat: checkpoint resume + HP sweep for pretraining

### DIFF
--- a/training/.gitignore
+++ b/training/.gitignore
@@ -18,6 +18,7 @@ __pycache__/
 *.safetensors
 *.gguf
 autoresearch_results.tsv
+sweep_results.tsv
 
 # Weights & Biases
 wandb/

--- a/training/scripts/preflight_batch.py
+++ b/training/scripts/preflight_batch.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+"""Find max batch size for mnemonic-LM configs via binary search.
+
+Adapted from felixlm/scripts/debug_nan.py. Runs forward+backward passes
+in-process with try/except torch.OutOfMemoryError — safe, no OOM killer risk.
+
+Usage:
+    source ~/Projects/felixlm/.venv/bin/activate
+    python training/scripts/preflight_batch.py
+    python training/scripts/preflight_batch.py --config v3_mnemonic_100m --max-try 32
+    python training/scripts/preflight_batch.py --steps 10 --safety-margin 0.75
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+import torch
+
+# Add mnemonic training scripts to path for CONFIGS
+TRAINING_DIR = Path(__file__).resolve().parent.parent
+sys.path.insert(0, str(TRAINING_DIR / "scripts"))
+
+from train_mnemonic_lm import CONFIGS
+
+
+def find_max_batch(config_name, max_try=32, steps=5, compile_model=False):
+    """Binary search for max batch size that fits in memory.
+
+    Runs `steps` forward+backward passes per candidate to catch delayed OOMs.
+    """
+    config = CONFIGS[config_name]()
+    lo, hi, best = 1, max_try, 0
+
+    while lo <= hi:
+        mid = (lo + hi) // 2
+        model = None
+        optimizer = None
+        try:
+            torch.cuda.empty_cache()
+            from felix_lm.v3.model import FelixLMv3
+
+            model = FelixLMv3(config).cuda()
+            if compile_model:
+                model = torch.compile(model)
+            optimizer = torch.optim.AdamW(model.parameters(), lr=6e-4)
+
+            for step in range(steps):
+                x = torch.randint(0, config.vocab_size, (mid, 2048)).cuda()
+                with torch.autocast("cuda", dtype=torch.bfloat16):
+                    result = model(x, x)
+                loss_val = result["loss"].item()
+                if step == 0 and loss_val != loss_val:  # NaN check
+                    raise ValueError("NaN loss on step 0!")
+                result["loss"].backward()
+                optimizer.step()
+                optimizer.zero_grad()
+                del x, result
+
+            del model, optimizer
+            torch.cuda.empty_cache()
+            model = None
+            optimizer = None
+            best = mid
+            print(f"  {config_name} bs={mid}: OK ({steps} steps)")
+            lo = mid + 1
+        except torch.OutOfMemoryError:
+            if model is not None:
+                del model
+            if optimizer is not None:
+                del optimizer
+            torch.cuda.empty_cache()
+            print(f"  {config_name} bs={mid}: OOM")
+            hi = mid - 1
+        except Exception as e:
+            if model is not None:
+                del model
+            if optimizer is not None:
+                del optimizer
+            torch.cuda.empty_cache()
+            print(f"  {config_name} bs={mid}: ERROR: {e}")
+            hi = mid - 1
+
+    return best
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Find max batch size for mnemonic-LM configs"
+    )
+    parser.add_argument(
+        "--config",
+        type=str,
+        default=None,
+        choices=list(CONFIGS.keys()),
+        help="Test a single config (default: all)",
+    )
+    parser.add_argument(
+        "--max-try", type=int, default=32, help="Upper bound for binary search"
+    )
+    parser.add_argument(
+        "--steps", type=int, default=5, help="Forward+backward steps per candidate"
+    )
+    parser.add_argument(
+        "--safety-margin",
+        type=float,
+        default=0.75,
+        help="Multiply max by this for safe batch size (default: 0.75)",
+    )
+    parser.add_argument("--compile", action="store_true", help="Test with torch.compile")
+    args = parser.parse_args()
+
+    configs = [args.config] if args.config else list(CONFIGS.keys())
+
+    print(f"GPU: {torch.cuda.get_device_name(0)}")
+    props = torch.cuda.get_device_properties(0)
+    vram = getattr(props, "total_memory", getattr(props, "total_mem", 0))
+    print(f"VRAM: {vram / 1e9:.0f} GB")
+    print(f"Testing {len(configs)} configs, {args.steps} steps each, max_try={args.max_try}")
+    print()
+
+    results = {}
+    for name in configs:
+        print(f"=== {name} ===")
+        max_bs = find_max_batch(
+            name, max_try=args.max_try, steps=args.steps, compile_model=args.compile
+        )
+        safe_bs = max(2, int(max_bs * args.safety_margin) & ~1)  # round down to even
+        results[name] = (max_bs, safe_bs)
+        print(f"  -> Max: {max_bs}, Safe ({args.safety_margin:.0%}): {safe_bs}\n")
+
+    print("=" * 50)
+    print("SUMMARY")
+    print("=" * 50)
+    for name, (max_bs, safe_bs) in results.items():
+        print(f"  {name}: max={max_bs}, safe={safe_bs}")
+        print(f"    Recommended: --batch-size {safe_bs} --grad-accum {max(1, 256 // safe_bs)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/training/scripts/sweep_hp.sh
+++ b/training/scripts/sweep_hp.sh
@@ -1,0 +1,319 @@
+#!/bin/bash
+# Hyperparameter sweep for mnemonic-lm v3 100M pretraining.
+#
+# Usage:
+#   ./training/scripts/sweep_hp.sh --phase 0        # Batch size test
+#   ./training/scripts/sweep_hp.sh --phase 1        # LR + WD sweep
+#   ./training/scripts/sweep_hp.sh --phase 2        # Beta2 sweep (reads Phase 1 results)
+#   ./training/scripts/sweep_hp.sh --phase 3        # Warmup sweep (reads Phase 2 results)
+#   ./training/scripts/sweep_hp.sh --dry-run --phase 1  # Preview commands
+#
+# Results written to training/sweep_results.tsv
+# All runs logged to wandb group "hp_sweep_v3_100m"
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
+cd "$REPO_ROOT"
+
+# --- Configuration ---
+VENV_ACTIVATE="source $HOME/Projects/felixlm/.venv/bin/activate"
+TRAIN_SCRIPT="training/scripts/train_mnemonic_lm.py"
+RESULTS_FILE="training/sweep_results.tsv"
+LOG_DIR="/tmp/mnemonic-lm-logs/sweep"
+WANDB_GROUP="hp_sweep_v3_100m"
+CONFIG="v3_mnemonic_100m"
+SWEEP_STEPS=4000          # micro-steps per sweep run (1000 optimizer steps at accum=4)
+SAVE_INTERVAL=2000        # checkpoint midway through sweep run
+COOLDOWN=30               # seconds between runs
+
+# Defaults (overridden per phase)
+BATCH=8
+ACCUM=4
+COMPILE="--compile"
+
+# --- Parse args ---
+PHASE=""
+DRY_RUN=false
+
+while [[ $# -gt 0 ]]; do
+    case $1 in
+        --phase) PHASE="$2"; shift 2 ;;
+        --dry-run) DRY_RUN=true; shift ;;
+        --batch) BATCH="$2"; shift 2 ;;
+        --steps) SWEEP_STEPS="$2"; shift 2 ;;
+        *) echo "Unknown arg: $1"; exit 1 ;;
+    esac
+done
+
+if [[ -z "$PHASE" ]]; then
+    echo "Usage: $0 --phase {0|1|2|3} [--dry-run] [--batch N] [--steps N]"
+    exit 1
+fi
+
+mkdir -p "$LOG_DIR"
+
+# --- Results file ---
+init_results() {
+    if [[ ! -f "$RESULTS_FILE" ]]; then
+        printf "run_name\tfinal_loss\tfinal_ppl\tlr\twd\tbeta2\twarmup\tbatch\taccum\tsteps\ttime_s\n" > "$RESULTS_FILE"
+    fi
+}
+
+# --- Run a single experiment ---
+run_experiment() {
+    local name="$1"; shift
+    local extra_args=("$@")
+
+    local cmd="PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True python -u $TRAIN_SCRIPT"
+    cmd+=" --config $CONFIG --device cuda"
+    cmd+=" --max-steps $SWEEP_STEPS --save-interval $SAVE_INTERVAL"
+    cmd+=" --run-name $name --wandb-group $WANDB_GROUP --wandb-tags sweep"
+    cmd+=" $COMPILE"
+    cmd+=" ${extra_args[*]}"
+
+    echo ""
+    echo "================================================================"
+    echo "  RUN: $name"
+    echo "  CMD: $cmd"
+    echo "================================================================"
+
+    if $DRY_RUN; then
+        echo "  [DRY RUN — skipped]"
+        return
+    fi
+
+    local log_file="$LOG_DIR/${name}.log"
+    local start_ts
+    start_ts=$(date +%s)
+
+    # Run training, capture output
+    eval "$VENV_ACTIVATE && $cmd" 2>&1 | tee "$log_file"
+    local exit_code=${PIPESTATUS[0]}
+
+    local end_ts
+    end_ts=$(date +%s)
+    local elapsed=$((end_ts - start_ts))
+
+    if [[ $exit_code -ne 0 ]]; then
+        echo "  FAILED (exit code $exit_code)"
+        printf "%s\tFAILED\tFAILED\t-\t-\t-\t-\t-\t-\t%s\t%s\n" \
+            "$name" "$SWEEP_STEPS" "$elapsed" >> "$RESULTS_FILE"
+        return
+    fi
+
+    # Parse results from training output
+    local final_loss final_ppl
+    final_loss=$(grep "Last 100 avg loss:" "$log_file" | tail -1 | grep -oP '[\d.]+$' || echo "N/A")
+    final_ppl=$(grep "Final PPL:" "$log_file" | tail -1 | grep -oP '[\d.]+$' || echo "N/A")
+
+    # Parse hyperparams from the run args
+    local lr wd beta2 warmup batch accum
+    lr=$(echo "${extra_args[*]}" | grep -oP '(?<=--lr )\S+' || echo "6e-4")
+    wd=$(echo "${extra_args[*]}" | grep -oP '(?<=--weight-decay )\S+' || echo "0.1")
+    beta2=$(echo "${extra_args[*]}" | grep -oP '(?<=--beta2 )\S+' || echo "0.95")
+    warmup=$(echo "${extra_args[*]}" | grep -oP '(?<=--warmup-steps )\S+' || echo "auto")
+    batch=$(echo "${extra_args[*]}" | grep -oP '(?<=--batch-size )\S+' || echo "$BATCH")
+    accum=$(echo "${extra_args[*]}" | grep -oP '(?<=--grad-accum )\S+' || echo "$ACCUM")
+
+    printf "%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n" \
+        "$name" "$final_loss" "$final_ppl" "$lr" "$wd" "$beta2" "$warmup" \
+        "$batch" "$accum" "$SWEEP_STEPS" "$elapsed" >> "$RESULTS_FILE"
+
+    echo ""
+    echo "  Result: loss=$final_loss  ppl=$final_ppl  time=${elapsed}s"
+    echo "  Log: $log_file"
+    echo "  Cooling down ${COOLDOWN}s..."
+    sleep "$COOLDOWN"
+}
+
+# --- Find best run from results ---
+best_from_results() {
+    local pattern="$1"
+    # Find run matching pattern with lowest loss (skip header, skip FAILED)
+    awk -F'\t' -v pat="$pattern" 'NR>1 && $1 ~ pat && $2 != "FAILED" {print $2, $1}' "$RESULTS_FILE" \
+        | sort -n | head -1 | awk '{print $2}'
+}
+
+best_loss_from_results() {
+    local pattern="$1"
+    awk -F'\t' -v pat="$pattern" 'NR>1 && $1 ~ pat && $2 != "FAILED" {print $2, $1}' "$RESULTS_FILE" \
+        | sort -n | head -1 | awk '{print $1}'
+}
+
+get_field() {
+    local run_name="$1" field_num="$2"
+    awk -F'\t' -v name="$run_name" 'NR>1 && $1 == name {print $'$field_num'}' "$RESULTS_FILE"
+}
+
+# --- Phase 0: Batch size preflight ---
+# Delegates to preflight_batch.py which does in-process binary search
+# with try/except torch.OutOfMemoryError — safe, no OOM killer risk.
+phase_0() {
+    echo "=== PHASE 0: Batch Size Preflight ==="
+    echo "In-process binary search (safe — catches OOM in Python, no system crash)"
+
+    local preflight_script
+    preflight_script="$(dirname "$TRAIN_SCRIPT")/preflight_batch.py"
+
+    local cmd="PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True python -u $preflight_script"
+    cmd+=" --config $CONFIG --steps 5 --max-try 24 --safety-margin 0.75"
+    if [[ -n "$COMPILE" ]]; then
+        cmd+=" --compile"
+    fi
+
+    if $DRY_RUN; then
+        echo "  CMD: $cmd"
+        echo "  [DRY RUN — skipped]"
+        echo ""
+        echo "Use --batch N for subsequent phases after running for real."
+        return
+    fi
+
+    echo ""
+    eval "$VENV_ACTIVATE && $cmd"
+    echo ""
+    echo "Use the safe batch size above: ./training/scripts/sweep_hp.sh --phase 1 --batch <safe>"
+}
+
+# --- Phase 1: LR + Weight Decay sweep ---
+phase_1() {
+    echo "=== PHASE 1: Learning Rate + Weight Decay Sweep ==="
+    echo "5 runs, $SWEEP_STEPS micro-steps each, batch=$BATCH accum=$ACCUM"
+    init_results
+
+    run_experiment "sweep_lr6e4_wd01" \
+        --lr 6e-4 --weight-decay 0.1 --beta2 0.95 \
+        --batch-size "$BATCH" --grad-accum "$ACCUM" --spoke-lr-mult 2.0
+
+    run_experiment "sweep_lr1e3_wd01" \
+        --lr 1e-3 --weight-decay 0.1 --beta2 0.95 \
+        --batch-size "$BATCH" --grad-accum "$ACCUM" --spoke-lr-mult 2.0
+
+    run_experiment "sweep_lr2e3_wd01" \
+        --lr 2e-3 --weight-decay 0.1 --beta2 0.95 \
+        --batch-size "$BATCH" --grad-accum "$ACCUM" --spoke-lr-mult 2.0
+
+    run_experiment "sweep_lr3e3_wd01" \
+        --lr 3e-3 --weight-decay 0.1 --beta2 0.95 \
+        --batch-size "$BATCH" --grad-accum "$ACCUM" --spoke-lr-mult 2.0
+
+    run_experiment "sweep_lr3e3_wd0" \
+        --lr 3e-3 --weight-decay 0.0 --beta2 0.95 \
+        --batch-size "$BATCH" --grad-accum "$ACCUM" --spoke-lr-mult 2.0
+
+    echo ""
+    echo "=== PHASE 1 RESULTS ==="
+    column -t -s$'\t' "$RESULTS_FILE"
+
+    local best
+    best=$(best_from_results "sweep_lr")
+    echo ""
+    echo "Best run: $best (loss=$(best_loss_from_results 'sweep_lr'))"
+    echo ""
+    echo "Next: review results, then run --phase 2 --batch $BATCH"
+}
+
+# --- Phase 2: Beta2 + LR interaction ---
+phase_2() {
+    echo "=== PHASE 2: Beta2 + LR Interaction ==="
+    init_results
+
+    # Find best LR from Phase 1
+    local best_run best_lr
+    best_run=$(best_from_results "sweep_lr")
+    if [[ -z "$best_run" ]]; then
+        echo "ERROR: No Phase 1 results found. Run --phase 1 first."
+        exit 1
+    fi
+    best_lr=$(get_field "$best_run" 4)
+    echo "Best LR from Phase 1: $best_lr (run: $best_run)"
+
+    # Compute 1.5x LR for interaction test
+    local higher_lr
+    higher_lr=$(python3 -c "print(f'{float('$best_lr') * 1.5:.1e}')")
+    echo "Higher LR for interaction test: $higher_lr"
+    echo "3 runs, $SWEEP_STEPS micro-steps each"
+
+    run_experiment "sweep_b2_99_lr${best_lr}" \
+        --lr "$best_lr" --weight-decay 0.1 --beta2 0.99 \
+        --batch-size "$BATCH" --grad-accum "$ACCUM" --spoke-lr-mult 2.0
+
+    run_experiment "sweep_b2_98_lr${best_lr}" \
+        --lr "$best_lr" --weight-decay 0.1 --beta2 0.98 \
+        --batch-size "$BATCH" --grad-accum "$ACCUM" --spoke-lr-mult 2.0
+
+    run_experiment "sweep_b2_99_lr${higher_lr}" \
+        --lr "$higher_lr" --weight-decay 0.1 --beta2 0.99 \
+        --batch-size "$BATCH" --grad-accum "$ACCUM" --spoke-lr-mult 2.0
+
+    echo ""
+    echo "=== PHASE 2 RESULTS ==="
+    column -t -s$'\t' "$RESULTS_FILE"
+
+    local best
+    best=$(best_from_results "sweep_b2")
+    echo ""
+    echo "Best beta2 run: $best (loss=$(best_loss_from_results 'sweep_b2'))"
+    echo "Compare against Phase 1 best: $best_run (loss=$(best_loss_from_results 'sweep_lr'))"
+    echo ""
+    echo "Next: review results, then run --phase 3 --batch $BATCH"
+}
+
+# --- Phase 3: Warmup validation ---
+phase_3() {
+    echo "=== PHASE 3: Warmup Validation ==="
+    init_results
+
+    # Find overall best from Phase 1+2
+    local best_run best_lr best_beta2
+    best_run=$(best_from_results "sweep_")
+    if [[ -z "$best_run" ]]; then
+        echo "ERROR: No prior results found."
+        exit 1
+    fi
+    best_lr=$(get_field "$best_run" 4)
+    best_beta2=$(get_field "$best_run" 6)
+    echo "Best config so far: LR=$best_lr, beta2=$best_beta2 (run: $best_run)"
+    echo "2 runs, $SWEEP_STEPS micro-steps each"
+
+    # Compute warmup values
+    local opt_steps=$((SWEEP_STEPS / ACCUM))
+    local warmup_5pct=$((opt_steps * 5 / 100))
+    local warmup_fixed=2000
+
+    # Note: these test different warmup; auto 10% is already tested in prior phases
+    run_experiment "sweep_warmup_5pct" \
+        --lr "$best_lr" --weight-decay 0.1 --beta2 "$best_beta2" \
+        --warmup-steps "$warmup_5pct" \
+        --batch-size "$BATCH" --grad-accum "$ACCUM" --spoke-lr-mult 2.0
+
+    run_experiment "sweep_warmup_2000" \
+        --lr "$best_lr" --weight-decay 0.1 --beta2 "$best_beta2" \
+        --warmup-steps "$warmup_fixed" \
+        --batch-size "$BATCH" --grad-accum "$ACCUM" --spoke-lr-mult 2.0
+
+    echo ""
+    echo "=== ALL RESULTS ==="
+    column -t -s$'\t' "$RESULTS_FILE"
+
+    local best
+    best=$(best_from_results "sweep_")
+    echo ""
+    echo "=== OVERALL WINNER ==="
+    echo "Run: $best"
+    echo "Loss: $(best_loss_from_results 'sweep_')"
+    echo "LR: $(get_field "$best" 4)  WD: $(get_field "$best" 5)  Beta2: $(get_field "$best" 6)  Warmup: $(get_field "$best" 7)"
+    echo ""
+    echo "Next: run confirmation at 20K steps with these hyperparameters."
+}
+
+# --- Dispatch ---
+case "$PHASE" in
+    0) phase_0 ;;
+    1) phase_1 ;;
+    2) phase_2 ;;
+    3) phase_3 ;;
+    *) echo "Unknown phase: $PHASE (use 0, 1, 2, or 3)"; exit 1 ;;
+esac

--- a/training/scripts/sweep_hp.sh
+++ b/training/scripts/sweep_hp.sh
@@ -42,13 +42,14 @@ while [[ $# -gt 0 ]]; do
         --phase) PHASE="$2"; shift 2 ;;
         --dry-run) DRY_RUN=true; shift ;;
         --batch) BATCH="$2"; shift 2 ;;
+        --accum) ACCUM="$2"; shift 2 ;;
         --steps) SWEEP_STEPS="$2"; shift 2 ;;
         *) echo "Unknown arg: $1"; exit 1 ;;
     esac
 done
 
 if [[ -z "$PHASE" ]]; then
-    echo "Usage: $0 --phase {0|1|2|3} [--dry-run] [--batch N] [--steps N]"
+    echo "Usage: $0 --phase {0|1|2|3} [--dry-run] [--batch N] [--accum N] [--steps N]"
     exit 1
 fi
 
@@ -69,6 +70,7 @@ run_experiment() {
     local cmd="PYTORCH_CUDA_ALLOC_CONF=expandable_segments:True python -u $TRAIN_SCRIPT"
     cmd+=" --config $CONFIG --device cuda"
     cmd+=" --max-steps $SWEEP_STEPS --save-interval $SAVE_INTERVAL"
+    cmd+=" --ckpt-dir checkpoints/$name"
     cmd+=" --run-name $name --wandb-group $WANDB_GROUP --wandb-tags sweep"
     cmd+=" $COMPILE"
     cmd+=" ${extra_args[*]}"
@@ -76,6 +78,28 @@ run_experiment() {
     echo ""
     echo "================================================================"
     echo "  RUN: $name"
+
+    # Skip if already completed (result in TSV)
+    if grep -qP "^${name}\t" "$RESULTS_FILE" 2>/dev/null; then
+        local prev_loss
+        prev_loss=$(awk -F'\t' -v n="$name" '$1 == n && $2 != "FAILED" {print $2}' "$RESULTS_FILE")
+        if [[ -n "$prev_loss" ]]; then
+            echo "  SKIPPED — already completed (loss=$prev_loss)"
+            echo "================================================================"
+            return
+        fi
+        # Previous run FAILED — remove entry and retry
+        echo "  Previous run FAILED, retrying..."
+        sed -i "/^${name}\t/d" "$RESULTS_FILE"
+    fi
+
+    # Auto-resume if checkpoint exists for THIS run (crashed mid-run)
+    local ckpt_dir="checkpoints/${name}"
+    if [[ -f "$ckpt_dir/last.pt" ]]; then
+        echo "  Found checkpoint — adding --resume last.pt"
+        cmd+=" --resume $ckpt_dir/last.pt"
+    fi
+
     echo "  CMD: $cmd"
     echo "================================================================"
 

--- a/training/scripts/train_mnemonic_lm.py
+++ b/training/scripts/train_mnemonic_lm.py
@@ -202,7 +202,7 @@ def train(config, args):
     print(f"  Warmup: {args.warmup_steps} optimizer steps")
 
     # Training loop
-    ckpt_dir = Path(f"checkpoints/{args.config}")
+    ckpt_dir = Path(args.ckpt_dir) if args.ckpt_dir else Path(f"checkpoints/{args.config}")
     ckpt_dir.mkdir(parents=True, exist_ok=True)
     global_step = 0
     lr = args.lr
@@ -267,6 +267,20 @@ def train(config, args):
 
     model.train()
     optimizer.zero_grad()
+
+    # Fast-forward dataloader if resuming (skip already-seen batches)
+    if global_step > 0:
+        print(f"  Fast-forwarding dataloader past {global_step} batches...")
+        skip_iter = iter(train_loader)
+        for i in range(global_step):
+            next(skip_iter, None)
+            if (i + 1) % 1000 == 0:
+                print(f"    Skipped {i + 1}/{global_step} batches")
+        print(f"  Fast-forward complete, resuming training at step {global_step}")
+        train_iter = skip_iter
+    else:
+        train_iter = iter(train_loader)
+
     start_time = time.time()
 
     try:
@@ -275,7 +289,7 @@ def train(config, args):
     except ImportError:
         pbar = None
 
-    for input_ids, targets in train_loader:
+    for input_ids, targets in train_iter:
         input_ids = input_ids.to(device)
         targets = targets.to(device)
 
@@ -405,6 +419,7 @@ def main():
     parser.add_argument("--compile", action="store_true")
     parser.add_argument("--spoke-lr-mult", type=float, default=2.0, help="Spoke LR multiplier")
     parser.add_argument("--tokenized-dir", type=str, default=None)
+    parser.add_argument("--ckpt-dir", type=str, default=None, help="Checkpoint directory (default: checkpoints/<config>)")
     parser.add_argument("--resume", type=str, default=None,
                         help="Resume from checkpoint (filename in ckpt dir, or absolute path). Use 'last.pt' to resume latest.")
     parser.add_argument("--run-name", type=str, default=None, help="wandb run name (default: config name)")

--- a/training/scripts/train_mnemonic_lm.py
+++ b/training/scripts/train_mnemonic_lm.py
@@ -125,6 +125,11 @@ def train(config, args):
 
     device = torch.device(args.device)
 
+    # Cap VRAM to 90% — OOM becomes a catchable PyTorch exception
+    # instead of triggering the Linux OOM killer and crashing the system
+    if device.type == "cuda":
+        torch.cuda.set_per_process_memory_fraction(0.9)
+
     model = FelixLMv3(config).to(device)
     if args.compile:
         print("Compiling model with torch.compile...")

--- a/training/scripts/train_mnemonic_lm.py
+++ b/training/scripts/train_mnemonic_lm.py
@@ -8,6 +8,7 @@ but imports Felix-LM's model and training utilities.
 Usage:
     python training/scripts/train_mnemonic_lm.py --config v3_mnemonic_500m --device cuda
     python training/scripts/train_mnemonic_lm.py --config v3_mnemonic_500m --device cuda --smoke-test
+    python training/scripts/train_mnemonic_lm.py --config v3_mnemonic_100m --device cuda --resume last.pt
 
 Requires:
     - Felix-LM installed/importable: pip install -e ~/Projects/felixlm
@@ -200,25 +201,6 @@ def train(config, args):
         args.warmup_steps = max(1, opt_steps // 10)
     print(f"  Warmup: {args.warmup_steps} optimizer steps")
 
-    # wandb
-    if not args.no_wandb:
-        import wandb
-        wandb.init(
-            project="mnemonic-lm",
-            name=args.config,
-            config={
-                "model_params": n_params,
-                "config": args.config,
-                "vocab_size": config.vocab_size,
-                "lr": args.lr,
-                "batch_size": args.batch_size,
-                "grad_accum": args.grad_accum,
-                "seq_len": args.seq_len,
-                "max_steps": max_steps,
-                "data": "mnemonic-curated-6.5B",
-            },
-        )
-
     # Training loop
     ckpt_dir = Path(f"checkpoints/{args.config}")
     ckpt_dir.mkdir(parents=True, exist_ok=True)
@@ -226,13 +208,70 @@ def train(config, args):
     lr = args.lr
     losses = []
 
+    # Resume from checkpoint
+    if args.resume:
+        resume_path = ckpt_dir / args.resume if not Path(args.resume).is_absolute() else Path(args.resume)
+        if resume_path.exists():
+            print(f"\nResuming from {resume_path}...")
+            ckpt = torch.load(resume_path, map_location=device, weights_only=False)
+            if "model_state_dict" in ckpt:
+                # Full checkpoint (model + optimizer + step)
+                raw_model = model._orig_mod if hasattr(model, "_orig_mod") else model
+                raw_model.load_state_dict(ckpt["model_state_dict"])
+                optimizer.load_state_dict(ckpt["optimizer_state_dict"])
+                global_step = ckpt["global_step"]
+                losses = ckpt.get("recent_losses", [])
+                if "rng_state" in ckpt:
+                    torch.set_rng_state(ckpt["rng_state"])
+                if "cuda_rng_state" in ckpt and device.type == "cuda":
+                    torch.cuda.set_rng_state(ckpt["cuda_rng_state"])
+                print(f"  Resumed at global_step={global_step} (opt_step={global_step // args.grad_accum})")
+            else:
+                # Legacy checkpoint (model weights only) — start optimizer fresh
+                raw_model = model._orig_mod if hasattr(model, "_orig_mod") else model
+                raw_model.load_state_dict(ckpt)
+                print("  Loaded model weights only (legacy checkpoint, optimizer reset)")
+        else:
+            print(f"WARNING: Resume path {resume_path} not found, training from scratch")
+
+    # wandb (after resume so we know the step count)
+    if not args.no_wandb:
+        import wandb
+        wandb_kwargs = {
+            "project": "mnemonic-lm",
+            "name": args.run_name or args.config,
+            "config": {
+                "model_params": n_params,
+                "config": args.config,
+                "vocab_size": config.vocab_size,
+                "lr": args.lr,
+                "weight_decay": args.weight_decay,
+                "beta2": args.beta2,
+                "batch_size": args.batch_size,
+                "grad_accum": args.grad_accum,
+                "seq_len": args.seq_len,
+                "max_steps": max_steps,
+                "spoke_lr_mult": args.spoke_lr_mult,
+                "warmup_steps": args.warmup_steps,
+                "data": "mnemonic-curated-6.5B",
+            },
+        }
+        if args.wandb_group:
+            wandb_kwargs["group"] = args.wandb_group
+        if args.wandb_tags:
+            wandb_kwargs["tags"] = [t.strip() for t in args.wandb_tags.split(",")]
+        if args.resume and global_step > 0:
+            wandb_kwargs["resume"] = "must"
+            print(f"  wandb: resuming run (step {global_step})")
+        wandb.init(**wandb_kwargs)
+
     model.train()
     optimizer.zero_grad()
     start_time = time.time()
 
     try:
         from tqdm import tqdm
-        pbar = tqdm(total=max_steps, desc="Training")
+        pbar = tqdm(total=max_steps, initial=global_step, desc="Training")
     except ImportError:
         pbar = None
 
@@ -280,9 +319,22 @@ def train(config, args):
                     log_dict[f"v3/gate_layer_{i}"] = gv.item()
             wandb.log(log_dict, step=global_step)
 
-        # Periodic checkpoint
+        # Periodic checkpoint (full state for resume)
         if global_step % args.save_interval == 0:
-            torch.save(model.state_dict(), ckpt_dir / f"step_{global_step}.pt")
+            raw_model = model._orig_mod if hasattr(model, "_orig_mod") else model
+            ckpt_data = {
+                "model_state_dict": raw_model.state_dict(),
+                "optimizer_state_dict": optimizer.state_dict(),
+                "global_step": global_step,
+                "recent_losses": losses[-1000:],
+                "rng_state": torch.get_rng_state(),
+                "args": vars(args),
+            }
+            if device.type == "cuda":
+                ckpt_data["cuda_rng_state"] = torch.cuda.get_rng_state()
+            torch.save(ckpt_data, ckpt_dir / f"step_{global_step}.pt")
+            # Also save as last.pt for easy resume
+            torch.save(ckpt_data, ckpt_dir / "last.pt")
             print(f"\n  Checkpoint saved at step {global_step}")
 
         if global_step % 5000 == 0 and global_step > 0:
@@ -318,7 +370,15 @@ def train(config, args):
     else:
         print("  FAIL: Loss did not decrease!")
 
-    torch.save(model.state_dict(), ckpt_dir / "last.pt")
+    raw_model = model._orig_mod if hasattr(model, "_orig_mod") else model
+    ckpt_data = {
+        "model_state_dict": raw_model.state_dict(),
+        "optimizer_state_dict": optimizer.state_dict(),
+        "global_step": global_step,
+        "recent_losses": losses[-1000:],
+        "args": vars(args),
+    }
+    torch.save(ckpt_data, ckpt_dir / "last.pt")
     print(f"  Checkpoint: {ckpt_dir}/last.pt")
 
     if not args.no_wandb:
@@ -345,6 +405,11 @@ def main():
     parser.add_argument("--compile", action="store_true")
     parser.add_argument("--spoke-lr-mult", type=float, default=2.0, help="Spoke LR multiplier")
     parser.add_argument("--tokenized-dir", type=str, default=None)
+    parser.add_argument("--resume", type=str, default=None,
+                        help="Resume from checkpoint (filename in ckpt dir, or absolute path). Use 'last.pt' to resume latest.")
+    parser.add_argument("--run-name", type=str, default=None, help="wandb run name (default: config name)")
+    parser.add_argument("--wandb-group", type=str, default=None, help="wandb group for sweep comparison")
+    parser.add_argument("--wandb-tags", type=str, default=None, help="Comma-separated wandb tags")
     parser.add_argument("--smoke-test", action="store_true", help="Run 1000 steps to verify pipeline")
     args = parser.parse_args()
 


### PR DESCRIPTION
## Summary
- Adds `--resume last.pt` crash recovery for multi-day pretraining runs (saves full model + optimizer + step + RNG state)
- Adds `--run-name`, `--wandb-group`, `--wandb-tags` CLI args for sweep orchestration
- Adds `sweep_hp.sh`: phased hyperparameter sweep script (Phase 0: batch size, Phase 1: LR+WD, Phase 2: beta2, Phase 3: warmup)
- Results tracked in `sweep_results.tsv` (gitignored), all runs grouped in wandb

Prerequisite for full 100M pretraining — autoresearch moved before pretrain in epic #149 Phase 2.

## Test plan
- [x] Resume round-trip verified: 20 steps → save → resume → 20 more steps, loss continued from ~8.7 (not reset to ~11)
- [x] Legacy model-only checkpoints load correctly (optimizer resets)
- [x] `sweep_hp.sh --dry-run --phase 1` previews correct commands
- [ ] Phase 0 batch size test
- [ ] Phase 1-3 sweep runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)