### PR TITLE
fix: add missing type column to SearchByFullText FTS query

### DIFF
--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1023,7 +1023,7 @@ func (s *SQLiteStore) SearchByFullText(ctx context.Context, query string, limit 
 	}
 
 	ftsQuery := `
-	SELECT m.id, m.raw_id, m.timestamp, m.content, m.summary, m.concepts, m.embedding,
+	SELECT m.id, m.raw_id, m.timestamp, m.type, m.content, m.summary, m.concepts, m.embedding,
 	       m.salience, m.access_count, m.last_accessed, m.state, m.gist_of, m.episode_id,
 	       m.source, m.project, m.session_id, m.created_at, m.updated_at
 	FROM memories m


### PR DESCRIPTION
## Summary

- `SearchByFullText` hardcoded its SELECT column list instead of using `memoryColumns`, missing the `type` column added in #169
- This caused `sql: expected 18 destination arguments in Scan, not 19` whenever FTS search ran through `scanMemoryFrom`
- Affected: benchmark-quality comparison mode, and any code path using `SearchByFullText` (retrieval agent FTS fallback, hybrid search)

## Fix

Added `m.type` to the FTS query's SELECT list, matching the 19-column order expected by `scanMemoryFrom`.

## Test plan

- [x] `make test` passes
- [x] `go run ./cmd/benchmark-quality/ -compare` runs clean (was crashing before)
- [x] `go run ./cmd/benchmark/` passes against live daemon

🤖 Generated with [Claude Code](https://claude.com/claude-code)