### PR TITLE
feat: implement --llm flag for benchmark-quality

### DIFF
--- a/cmd/benchmark-quality/comparison.go
+++ b/cmd/benchmark-quality/comparison.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/appsprout-dev/mnemonic/internal/agent/consolidation"
+	"github.com/appsprout-dev/mnemonic/internal/llm"
 	"github.com/appsprout-dev/mnemonic/internal/store"
 	"github.com/appsprout-dev/mnemonic/internal/store/sqlite"
 )
@@ -154,7 +155,10 @@ func runComparisonScenario(
 	}
 	defer func() { _ = s.Close() }()
 
-	stub := &semanticStubProvider{}
+	var p llm.Provider = &semanticStubProvider{}
+	if cfg.Provider != nil {
+		p = cfg.Provider
+	}
 
 	// Create dummy raw memory for FK constraint.
 	rawID := "compare-raw-" + sc.Name
@@ -188,7 +192,7 @@ func runComparisonScenario(
 	}
 
 	// Run consolidation cycles with salience decay.
-	consolAgent := consolidation.NewConsolidationAgent(s, stub, cfg.Consolidation, log)
+	consolAgent := consolidation.NewConsolidationAgent(s, p, cfg.Consolidation, log)
 	for i := 0; i < cycles; i++ {
 		allMems, listErr := s.ListMemories(ctx, "", 500, 0)
 		if listErr != nil {
@@ -217,10 +221,10 @@ func runComparisonScenario(
 
 	retrievers := []Retriever{
 		newFTSRetriever(s),
-		newVectorRetriever(s, stub),
-		newHybridRetriever(s, stub),
-		newMnemonicRetriever(s, stub, noSpreadCfg, log, "Mnemonic (no spread)"),
-		newMnemonicRetriever(s, stub, fullCfg, log, "Mnemonic (full)"),
+		newVectorRetriever(s, p),
+		newHybridRetriever(s, p),
+		newMnemonicRetriever(s, p, noSpreadCfg, log, "Mnemonic (no spread)"),
+		newMnemonicRetriever(s, p, fullCfg, log, "Mnemonic (full)"),
 	}
 
 	// Run each retriever against each query.

--- a/cmd/benchmark-quality/main.go
+++ b/cmd/benchmark-quality/main.go
@@ -16,6 +16,8 @@ import (
 	"github.com/appsprout-dev/mnemonic/internal/agent/encoding"
 	"github.com/appsprout-dev/mnemonic/internal/agent/episoding"
 	"github.com/appsprout-dev/mnemonic/internal/agent/retrieval"
+	"github.com/appsprout-dev/mnemonic/internal/config"
+	"github.com/appsprout-dev/mnemonic/internal/llm"
 	"github.com/appsprout-dev/mnemonic/internal/store"
 	"github.com/appsprout-dev/mnemonic/internal/store/sqlite"
 )
@@ -30,7 +32,8 @@ type benchConfig struct {
 	Dreaming      dreaming.DreamingConfig
 	Episoding     episoding.EpisodingConfig
 	Abstraction   abstraction.AbstractionConfig
-	BenchDecay    float32 // per-cycle salience decay (default 0.92)
+	BenchDecay    float32      // per-cycle salience decay (default 0.92)
+	Provider      llm.Provider // nil = use semantic stub
 }
 
 // defaultBenchConfig returns a benchConfig with sensible defaults.
@@ -62,34 +65,59 @@ func defaultBenchConfig() benchConfig {
 
 func main() {
 	var (
-		verbose   bool
-		cycles    int
-		report    string
-		llmMode   bool
-		sweepFile string
-		compare   bool
-		setFlags  setFlagList
+		verbose    bool
+		cycles     int
+		report     string
+		llmMode    bool
+		configPath string
+		sweepFile  string
+		compare    bool
+		setFlags   setFlagList
 	)
 
 	flag.BoolVar(&verbose, "verbose", false, "verbose output")
 	flag.IntVar(&cycles, "cycles", 5, "number of consolidation cycles")
 	flag.StringVar(&report, "report", "", "output format: 'markdown' writes benchmark-results.md")
-	flag.BoolVar(&llmMode, "llm", false, "use real LLM for embeddings (requires LM Studio)")
+	flag.BoolVar(&llmMode, "llm", false, "use real LLM provider (reads config.yaml + LLM_API_KEY env var)")
+	flag.StringVar(&configPath, "config", "config.yaml", "path to config.yaml (used with --llm)")
 	flag.StringVar(&sweepFile, "sweep", "", "path to sweep YAML file for parameter tuning")
 	flag.BoolVar(&compare, "compare", false, "run comparison benchmark: FTS vs Vector vs Hybrid vs Mnemonic")
 	flag.Var(&setFlags, "set", "override a config parameter (repeatable, format: key=value)")
 	flag.Parse()
-
-	if llmMode {
-		fmt.Fprintln(os.Stderr, "Error: --llm mode not yet implemented")
-		os.Exit(1)
-	}
 
 	logLevel := slog.LevelError
 	if verbose {
 		logLevel = slog.LevelDebug
 	}
 	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: logLevel}))
+
+	// Create LLM provider: real (from config) or stub.
+	var provider llm.Provider
+	llmLabel := "semantic-stub"
+	if llmMode {
+		cfg, cfgErr := config.Load(configPath)
+		if cfgErr != nil {
+			fmt.Fprintf(os.Stderr, "Error loading config: %v\n", cfgErr)
+			os.Exit(1)
+		}
+		if cfg.LLM.APIKey == "" {
+			fmt.Fprintln(os.Stderr, "Error: LLM_API_KEY environment variable is required for --llm mode")
+			os.Exit(1)
+		}
+		provider = llm.NewLMStudioProvider(
+			cfg.LLM.Endpoint,
+			cfg.LLM.ChatModel,
+			cfg.LLM.EmbeddingModel,
+			cfg.LLM.APIKey,
+			time.Duration(cfg.LLM.TimeoutSec)*time.Second,
+			cfg.LLM.MaxConcurrent,
+		)
+		if err := provider.Health(context.Background()); err != nil {
+			fmt.Fprintf(os.Stderr, "Error: LLM provider health check failed: %v\n", err)
+			os.Exit(1)
+		}
+		llmLabel = cfg.LLM.ChatModel
+	}
 
 	ctx := context.Background()
 	scenarios := allScenarios()
@@ -115,7 +143,7 @@ func main() {
 
 		fmt.Println()
 		fmt.Println("  Mnemonic Config Sweep")
-		fmt.Printf("  Version: %s  |  LLM: semantic-stub  |  Params: %d\n", Version, len(def.Sweeps))
+		fmt.Printf("  Version: %s  |  LLM: %s  |  Params: %d\n", Version, llmLabel, len(def.Sweeps))
 		fmt.Println()
 
 		sweepReport, sweepErr := runSweep(ctx, def, scenarios, cycles, verbose, log)
@@ -131,7 +159,7 @@ func main() {
 			if def.Cycles > 0 {
 				sweepCycles = def.Cycles
 			}
-			if writeErr := writeSweepMarkdownReport(sweepReport, sweepCycles); writeErr != nil {
+			if writeErr := writeSweepMarkdownReport(sweepReport, sweepCycles, llmLabel); writeErr != nil {
 				fmt.Fprintf(os.Stderr, "Error writing sweep report: %v\n", writeErr)
 			} else {
 				fmt.Println("  Sweep report written to sweep-results.md")
@@ -144,6 +172,7 @@ func main() {
 	// Comparison mode: run all approaches against all scenarios.
 	if compare {
 		cfg := defaultBenchConfig()
+		cfg.Provider = provider
 		if len(overrides) > 0 {
 			if overrideErr := applyOverrides(&cfg, overrides); overrideErr != nil {
 				fmt.Fprintf(os.Stderr, "Error: %v\n", overrideErr)
@@ -173,6 +202,7 @@ func main() {
 
 	// Standard mode: run all scenarios with optional -set overrides.
 	cfg := defaultBenchConfig()
+	cfg.Provider = provider
 	if len(overrides) > 0 {
 		if overrideErr := applyOverrides(&cfg, overrides); overrideErr != nil {
 			fmt.Fprintf(os.Stderr, "Error: %v\n", overrideErr)
@@ -182,7 +212,7 @@ func main() {
 
 	fmt.Println()
 	fmt.Println("  Mnemonic Memory Quality Benchmark")
-	fmt.Printf("  Version: %s  |  LLM: semantic-stub  |  Cycles: %d\n", Version, cycles)
+	fmt.Printf("  Version: %s  |  LLM: %s  |  Cycles: %d\n", Version, llmLabel, cycles)
 	fmt.Println()
 
 	var allResults []scenarioResult
@@ -232,7 +262,7 @@ func main() {
 	}
 
 	if report == "markdown" {
-		if writeErr := writeMarkdownReport(allResults, agg, cycles); writeErr != nil {
+		if writeErr := writeMarkdownReport(allResults, agg, cycles, llmLabel); writeErr != nil {
 			fmt.Fprintf(os.Stderr, "Error writing report: %v\n", writeErr)
 		} else {
 			fmt.Println("  Report written to benchmark-results.md")
@@ -275,9 +305,12 @@ func runScenario(
 	}
 	defer func() { _ = s.Close() }()
 
-	stub := &semanticStubProvider{}
-	retAgent := retrieval.NewRetrievalAgent(s, stub, cfg.Retrieval, log)
-	consolAgent := consolidation.NewConsolidationAgent(s, stub, cfg.Consolidation, log)
+	var p llm.Provider = &semanticStubProvider{}
+	if cfg.Provider != nil {
+		p = cfg.Provider
+	}
+	retAgent := retrieval.NewRetrievalAgent(s, p, cfg.Retrieval, log)
+	consolAgent := consolidation.NewConsolidationAgent(s, p, cfg.Consolidation, log)
 
 	// Phase 1: Create a dummy raw memory so FK constraints are satisfied,
 	// then ingest all benchmark memories referencing it.

--- a/cmd/benchmark-quality/pipeline.go
+++ b/cmd/benchmark-quality/pipeline.go
@@ -15,6 +15,7 @@ import (
 	"github.com/appsprout-dev/mnemonic/internal/agent/encoding"
 	"github.com/appsprout-dev/mnemonic/internal/agent/episoding"
 	"github.com/appsprout-dev/mnemonic/internal/agent/retrieval"
+	"github.com/appsprout-dev/mnemonic/internal/llm"
 	"github.com/appsprout-dev/mnemonic/internal/store/sqlite"
 )
 
@@ -44,15 +45,18 @@ func runPipelineScenario(
 	}
 	defer func() { _ = s.Close() }()
 
-	stub := &semanticStubProvider{}
+	var p llm.Provider = &semanticStubProvider{}
+	if cfg.Provider != nil {
+		p = cfg.Provider
+	}
 
 	// Create all agents with configs from benchConfig.
-	encAgent := encoding.NewEncodingAgentWithConfig(s, stub, log, cfg.Encoding)
-	epiAgent := episoding.NewEpisodingAgent(s, stub, log, cfg.Episoding)
-	dreamAgent := dreaming.NewDreamingAgent(s, stub, cfg.Dreaming, log)
-	consolAgent := consolidation.NewConsolidationAgent(s, stub, cfg.Consolidation, log)
-	absAgent := abstraction.NewAbstractionAgent(s, stub, cfg.Abstraction, log)
-	retAgent := retrieval.NewRetrievalAgent(s, stub, cfg.Retrieval, log)
+	encAgent := encoding.NewEncodingAgentWithConfig(s, p, log, cfg.Encoding)
+	epiAgent := episoding.NewEpisodingAgent(s, p, log, cfg.Episoding)
+	dreamAgent := dreaming.NewDreamingAgent(s, p, cfg.Dreaming, log)
+	consolAgent := consolidation.NewConsolidationAgent(s, p, cfg.Consolidation, log)
+	absAgent := abstraction.NewAbstractionAgent(s, p, cfg.Abstraction, log)
+	retAgent := retrieval.NewRetrievalAgent(s, p, cfg.Retrieval, log)
 
 	// Phase 1: Inject raw events.
 	for _, raw := range sc.RawEvents {

--- a/cmd/benchmark-quality/report.go
+++ b/cmd/benchmark-quality/report.go
@@ -144,11 +144,11 @@ func printAggregate(agg aggregateResult) {
 	fmt.Printf("\n    Overall: %s\n", agg.Overall)
 }
 
-func writeMarkdownReport(results []scenarioResult, agg aggregateResult, cycles int) error {
+func writeMarkdownReport(results []scenarioResult, agg aggregateResult, cycles int, llmLabel string) error {
 	var sb strings.Builder
 
 	sb.WriteString("# Mnemonic Memory Quality Benchmark\n\n")
-	fmt.Fprintf(&sb, "**Version:** %s | **LLM:** synthetic | **Cycles:** %d\n\n", Version, cycles)
+	fmt.Fprintf(&sb, "**Version:** %s | **LLM:** %s | **Cycles:** %d\n\n", Version, llmLabel, cycles)
 
 	for _, r := range results {
 		fmt.Fprintf(&sb, "## %s\n\n", r.Name)
@@ -195,11 +195,11 @@ func writeMarkdownReport(results []scenarioResult, agg aggregateResult, cycles i
 	return os.WriteFile("benchmark-results.md", []byte(sb.String()), 0644)
 }
 
-func writeSweepMarkdownReport(report SweepReport, cycles int) error {
+func writeSweepMarkdownReport(report SweepReport, cycles int, llmLabel string) error {
 	var sb strings.Builder
 
 	sb.WriteString("# Mnemonic Config Sweep Report\n\n")
-	fmt.Fprintf(&sb, "**Version:** %s | **LLM:** semantic-stub | **Cycles:** %d\n\n", Version, cycles)
+	fmt.Fprintf(&sb, "**Version:** %s | **LLM:** %s | **Cycles:** %d\n\n", Version, llmLabel, cycles)
 
 	sb.WriteString("## Baseline (All Defaults)\n\n")
 	sb.WriteString("| Metric | Score | Grade |\n|---|---|---|\n")

--- a/training/docs/experiment_registry.md
+++ b/training/docs/experiment_registry.md
@@ -57,6 +57,37 @@ Pre-registered experiments for Felix-LM v3 100M pretraining on mnemonic's curate
 
 - **Caveat:** This benchmark ran against a live database with 2061 pre-existing memories (mostly desktop noise from watcher). The 15 seed memories competed with real data. A clean-DB benchmark would likely show higher precision but would be less realistic. Both conditions should be tested when evaluating Felix-LM.
 
+### BASELINE-3: IR Quality Benchmark (Real Gemini Embeddings)
+
+- **Date:** 2026-03-17
+- **Status:** COMPLETED
+- **Purpose:** Run the IR quality benchmark with real Gemini embeddings instead of the deterministic stub. This isolates the effect of LLM embedding quality on retrieval, and establishes the quality floor for the pipeline scenarios (encoding, episoding, dreaming, consolidation, retrieval end-to-end).
+- **Command:** `./bin/benchmark-quality --llm --config config.yaml --cycles 5 --report markdown`
+- **Commit:** feat/gemini-benchmark-baseline (v0.17.0)
+- **Environment:** Linux x86_64, mnemonic v0.17.0, Gemini 3 Flash Preview (chat + gemini-embedding-2-preview), 6 direct scenarios + 3 pipeline scenarios, 5 consolidation cycles
+- **Results (Direct Scenarios — pre-ingested memories, Gemini used for query embeddings only):**
+
+| Metric | Stub | Gemini | Delta |
+|--------|------|--------|-------|
+| Precision@5 | 0.46 | 0.46 | 0% |
+| MRR | 0.84 | 0.84 | 0% |
+| nDCG | 0.85 | 0.85 | 0% |
+| Noise Suppression | 1.00 | 1.00 | 0% |
+| Signal Retention | 1.00 | 1.00 | 0% |
+
+- **Results (Pipeline Scenarios — Gemini does full encoding + all agents):**
+
+| Pipeline | Metric | Stub | Gemini | Delta |
+|----------|--------|------|--------|-------|
+| Full Day | Noise Suppr. | 0.73 | 0.95 | **+30%** |
+| Full Day | nDCG | 0.56 | 0.63 | +13% |
+| Cross-Pollination | Noise Suppr. | 0.62 | 0.92 | **+48%** |
+| Cross-Pollination | nDCG | 0.57 | 0.67 | +18% |
+| Noise Storm | Noise Suppr. | 0.85 | 0.91 | +7% |
+| Noise Storm | nDCG | 0.97 | 0.95 | -2% |
+
+- **Analysis:** Direct scenario results are identical between stub and Gemini because those scenarios use pre-ingested memories with stub-generated embeddings — Gemini only affects the query embedding, which goes through the same FTS+vector merge pipeline. The real differentiation shows in pipeline scenarios where Gemini handles the full encoding chain. Gemini's primary advantage is noise suppression: +30% on Full Day, +48% on Cross-Pollination. Gemini assigns more meaningful salience scores, letting consolidation's decay + threshold logic more effectively demote irrelevant memories. The nDCG improvement is modest (+13-18%) because FTS5 dominates retrieval in these scenarios (vector search returns 0 results since stub embeddings stored in the DB don't match Gemini query embeddings). A fair vector comparison would require re-embedding all stored memories with Gemini, which the current benchmark architecture doesn't support. The quality bar for Felix-LM: must achieve >= 0.90 noise suppression and >= 0.63 nDCG on pipeline scenarios.
+
 ---
 
 ## Phase 2: HP Sweep


### PR DESCRIPTION
## Summary
- Implements `--llm` and `--config` flags on `cmd/benchmark-quality/` to run benchmarks against real Gemini (or any LLM provider) instead of only the deterministic stub
- Threads the provider through all runner functions (standard, comparison, pipeline) via `benchConfig.Provider`
- Fixes markdown report writers to display the actual LLM label instead of hardcoded "synthetic"
- Documents BASELINE-3 results: Gemini shows +30-48% noise suppression improvement over stub in pipeline scenarios

## Test plan
- [x] `make benchmark-quality` builds clean
- [x] `go test ./cmd/benchmark-quality/...` passes
- [x] Stub mode (`./bin/benchmark-quality --cycles 1`) works unchanged
- [x] LLM mode (`./bin/benchmark-quality --llm --config config.yaml --cycles 5`) runs against Gemini
- [x] Report markdown shows correct LLM label

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)