### PR TITLE
feat: scaffold EmbeddedProvider for llama.cpp integration

### DIFF
--- a/cmd/mnemonic/main.go
+++ b/cmd/mnemonic/main.go
@@ -933,18 +933,7 @@ func diagnoseCommand(configPath string) {
 	}
 
 	// 4. LLM provider
-	timeout := time.Duration(cfg.LLM.TimeoutSec) * time.Second
-	if timeout == 0 {
-		timeout = 30 * time.Second
-	}
-	llmProvider := llm.NewLMStudioProvider(
-		cfg.LLM.Endpoint,
-		cfg.LLM.ChatModel,
-		cfg.LLM.EmbeddingModel,
-		cfg.LLM.APIKey,
-		timeout,
-		cfg.LLM.MaxConcurrent,
-	)
+	llmProvider := newLLMProvider(cfg)
 
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
@@ -1271,17 +1260,13 @@ func serveCommand(configPath string) {
 	}
 
 	// Create LLM provider
-	llmProvider := llm.NewLMStudioProvider(
-		cfg.LLM.Endpoint,
-		cfg.LLM.ChatModel,
-		cfg.LLM.EmbeddingModel,
-		cfg.LLM.APIKey,
-		time.Duration(cfg.LLM.TimeoutSec)*time.Second,
-		cfg.LLM.MaxConcurrent,
-	)
+	llmProvider := newLLMProvider(cfg)
 
 	// Check for embedding model drift
-	embModel := llmProvider.EmbeddingModelName()
+	embModel := cfg.LLM.EmbeddingModel
+	if cfg.LLM.Provider == "embedded" && cfg.LLM.Embedded.EmbedModelFile != "" {
+		embModel = cfg.LLM.Embedded.EmbedModelFile
+	}
 	if embModel != "" {
 		metaCtx, metaCancel := context.WithTimeout(context.Background(), 5*time.Second)
 		prevModel, _ := memStore.GetMeta(metaCtx, "embedding_model")
@@ -1764,14 +1749,7 @@ func initRuntime(configPath string) (*config.Config, *sqlite.SQLiteStore, llm.Pr
 		die(exitDatabase, fmt.Sprintf("opening database: %v", err), "mnemonic diagnose")
 	}
 
-	var provider llm.Provider = llm.NewLMStudioProvider(
-		cfg.LLM.Endpoint,
-		cfg.LLM.ChatModel,
-		cfg.LLM.EmbeddingModel,
-		cfg.LLM.APIKey,
-		time.Duration(cfg.LLM.TimeoutSec)*time.Second,
-		cfg.LLM.MaxConcurrent,
-	)
+	provider := newLLMProvider(cfg)
 
 	// Wrap with training data capture if enabled
 	if cfg.Training.CaptureEnabled && cfg.Training.CaptureDir != "" {
@@ -2752,4 +2730,42 @@ func autopilotCommand(configPath string) {
 	}
 
 	fmt.Println()
+}
+
+// newLLMProvider creates the appropriate LLM provider based on config.
+// For "api" (default), it creates an LMStudioProvider for OpenAI-compatible APIs.
+// For "embedded", it creates an EmbeddedProvider for in-process llama.cpp inference.
+func newLLMProvider(cfg *config.Config) llm.Provider {
+	switch cfg.LLM.Provider {
+	case "embedded":
+		ep := llm.NewEmbeddedProvider(llm.EmbeddedProviderConfig{
+			ModelsDir:      cfg.LLM.Embedded.ModelsDir,
+			ChatModelFile:  cfg.LLM.Embedded.ChatModelFile,
+			EmbedModelFile: cfg.LLM.Embedded.EmbedModelFile,
+			ContextSize:    cfg.LLM.Embedded.ContextSize,
+			GPULayers:      cfg.LLM.Embedded.GPULayers,
+			Threads:        cfg.LLM.Embedded.Threads,
+			BatchSize:      cfg.LLM.Embedded.BatchSize,
+			MaxTokens:      cfg.LLM.MaxTokens,
+			Temperature:    float32(cfg.LLM.Temperature),
+			MaxConcurrent:  cfg.LLM.MaxConcurrent,
+		})
+		// Note: LoadModels must be called with a backend factory before use.
+		// Until llama.cpp bindings are integrated, the provider will return
+		// ErrProviderUnavailable on all inference calls.
+		return ep
+	default: // "api" or ""
+		timeout := time.Duration(cfg.LLM.TimeoutSec) * time.Second
+		if timeout == 0 {
+			timeout = 30 * time.Second
+		}
+		return llm.NewLMStudioProvider(
+			cfg.LLM.Endpoint,
+			cfg.LLM.ChatModel,
+			cfg.LLM.EmbeddingModel,
+			cfg.LLM.APIKey,
+			timeout,
+			cfg.LLM.MaxConcurrent,
+		)
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -39,16 +39,29 @@ type Config struct {
 
 // LLMConfig holds LLM provider settings.
 type LLMConfig struct {
-	Endpoint             string  `yaml:"endpoint"`
-	ChatModel            string  `yaml:"chat_model"`
-	EmbeddingModel       string  `yaml:"embedding_model"`
-	APIKey               string  `yaml:"-"`                       // from LLM_API_KEY env var only (never serialized to config)
-	InputPricePerMToken  float64 `yaml:"input_price_per_mtoken"`  // custom input price (USD per 1M tokens), 0 = use built-in
-	OutputPricePerMToken float64 `yaml:"output_price_per_mtoken"` // custom output price (USD per 1M tokens), 0 = use built-in
-	MaxTokens            int     `yaml:"max_tokens"`
-	Temperature          float64 `yaml:"temperature"`
-	TimeoutSec           int     `yaml:"timeout_sec"`
-	MaxConcurrent        int     `yaml:"max_concurrent"` // max simultaneous LLM requests (0 = default 2)
+	Provider             string            `yaml:"provider"` // "api" (default) or "embedded" for in-process llama.cpp
+	Endpoint             string            `yaml:"endpoint"`
+	ChatModel            string            `yaml:"chat_model"`
+	EmbeddingModel       string            `yaml:"embedding_model"`
+	APIKey               string            `yaml:"-"`                       // from LLM_API_KEY env var only (never serialized to config)
+	InputPricePerMToken  float64           `yaml:"input_price_per_mtoken"`  // custom input price (USD per 1M tokens), 0 = use built-in
+	OutputPricePerMToken float64           `yaml:"output_price_per_mtoken"` // custom output price (USD per 1M tokens), 0 = use built-in
+	MaxTokens            int               `yaml:"max_tokens"`
+	Temperature          float64           `yaml:"temperature"`
+	TimeoutSec           int               `yaml:"timeout_sec"`
+	MaxConcurrent        int               `yaml:"max_concurrent"` // max simultaneous LLM requests (0 = default 2)
+	Embedded             EmbeddedLLMConfig `yaml:"embedded"`       // config for in-process llama.cpp provider
+}
+
+// EmbeddedLLMConfig holds settings for the in-process llama.cpp provider.
+type EmbeddedLLMConfig struct {
+	ModelsDir      string `yaml:"models_dir"`       // directory for GGUF model files (default: ~/.mnemonic/models)
+	ChatModelFile  string `yaml:"chat_model_file"`  // filename of the chat GGUF model within ModelsDir
+	EmbedModelFile string `yaml:"embed_model_file"` // filename of the embedding GGUF model within ModelsDir
+	ContextSize    int    `yaml:"context_size"`     // context window size in tokens (default: 2048)
+	GPULayers      int    `yaml:"gpu_layers"`       // number of layers to offload to GPU (-1 = all, 0 = none)
+	Threads        int    `yaml:"threads"`          // number of CPU threads for inference (0 = auto)
+	BatchSize      int    `yaml:"batch_size"`       // prompt processing batch size (default: 512)
 }
 
 // StoreConfig holds storage settings.
@@ -293,6 +306,7 @@ func Load(path string) (*Config, error) {
 func Default() *Config {
 	return &Config{
 		LLM: LLMConfig{
+			Provider:       "api",
 			Endpoint:       "http://localhost:1234/v1",
 			ChatModel:      "neural-chat",
 			EmbeddingModel: "text-embedding-embeddinggemma-300m-qat",
@@ -300,6 +314,12 @@ func Default() *Config {
 			Temperature:    0.3,
 			TimeoutSec:     120,
 			MaxConcurrent:  2,
+			Embedded: EmbeddedLLMConfig{
+				ModelsDir:   "~/.mnemonic/models",
+				ContextSize: 2048,
+				GPULayers:   -1,
+				BatchSize:   512,
+			},
 		},
 		Store: StoreConfig{
 			DBPath:        "~/.mnemonic/memory.db",
@@ -523,6 +543,14 @@ func (c *Config) process(configDir string) error {
 		return fmt.Errorf("expanding logging.file: %w", err)
 	}
 
+	// Expand Embedded LLM models dir
+	if c.LLM.Embedded.ModelsDir != "" {
+		c.LLM.Embedded.ModelsDir, err = resolvePath(c.LLM.Embedded.ModelsDir, configDir)
+		if err != nil {
+			return fmt.Errorf("expanding llm.embedded.models_dir: %w", err)
+		}
+	}
+
 	// Expand Project registry paths
 	for i := range c.Projects {
 		for j, p := range c.Projects[i].Paths {
@@ -607,14 +635,26 @@ func (c *Config) process(configDir string) error {
 
 // Validate checks that required fields are set.
 func (c *Config) Validate() error {
-	if c.LLM.Endpoint == "" {
-		return errors.New("llm.endpoint is required")
-	}
-	if c.LLM.ChatModel == "" {
-		return errors.New("llm.chat_model is required")
-	}
-	if c.LLM.EmbeddingModel == "" {
-		return errors.New("llm.embedding_model is required")
+	switch c.LLM.Provider {
+	case "", "api":
+		if c.LLM.Endpoint == "" {
+			return errors.New("llm.endpoint is required for api provider")
+		}
+		if c.LLM.ChatModel == "" {
+			return errors.New("llm.chat_model is required for api provider")
+		}
+		if c.LLM.EmbeddingModel == "" {
+			return errors.New("llm.embedding_model is required for api provider")
+		}
+	case "embedded":
+		if c.LLM.Embedded.ModelsDir == "" {
+			return errors.New("llm.embedded.models_dir is required for embedded provider")
+		}
+		if c.LLM.Embedded.ChatModelFile == "" {
+			return errors.New("llm.embedded.chat_model_file is required for embedded provider")
+		}
+	default:
+		return fmt.Errorf("llm.provider must be \"api\" or \"embedded\", got %q", c.LLM.Provider)
 	}
 	if c.Store.DBPath == "" {
 		return errors.New("store.db_path is required")

--- a/internal/llm/embedded.go
+++ b/internal/llm/embedded.go
@@ -1,0 +1,343 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+)
+
+// Backend is the interface for in-process LLM inference engines.
+// The llama.cpp CGo implementation will satisfy this interface.
+type Backend interface {
+	// LoadModel loads a GGUF model file into memory.
+	LoadModel(path string, opts BackendOptions) error
+
+	// Complete runs text generation on the loaded model.
+	Complete(ctx context.Context, req BackendCompletionRequest) (BackendCompletionResponse, error)
+
+	// Embed generates an embedding vector for the given text.
+	Embed(ctx context.Context, text string) ([]float32, error)
+
+	// BatchEmbed generates embedding vectors for multiple texts.
+	BatchEmbed(ctx context.Context, texts []string) ([][]float32, error)
+
+	// Close releases all resources held by the backend.
+	Close() error
+}
+
+// BackendOptions configures model loading for a Backend.
+type BackendOptions struct {
+	ContextSize int // context window size in tokens
+	GPULayers   int // layers to offload to GPU (-1 = all, 0 = CPU only)
+	Threads     int // CPU threads for inference (0 = auto-detect)
+	BatchSize   int // prompt processing batch size
+}
+
+// BackendCompletionRequest is the input for a backend completion call.
+type BackendCompletionRequest struct {
+	Prompt      string   // formatted prompt text
+	MaxTokens   int      // maximum tokens to generate
+	Temperature float32  // sampling temperature
+	TopP        float32  // nucleus sampling threshold
+	Stop        []string // stop sequences
+	Grammar     string   // GBNF grammar string for constrained decoding (empty = unconstrained)
+}
+
+// BackendCompletionResponse is the output of a backend completion call.
+type BackendCompletionResponse struct {
+	Text             string // generated text
+	PromptTokens     int    // tokens in the prompt
+	CompletionTokens int    // tokens generated
+}
+
+// EmbeddedProvider implements the Provider interface using in-process inference
+// via a Backend (llama.cpp CGo bindings). This allows mnemonic to run its own
+// GGUF models without an external API server.
+type EmbeddedProvider struct {
+	modelsDir      string
+	chatModelFile  string
+	embedModelFile string
+	opts           BackendOptions
+	maxTokens      int
+	temperature    float32
+
+	mu           sync.RWMutex
+	chatBackend  Backend
+	embedBackend Backend
+	sem          chan struct{}
+}
+
+// EmbeddedProviderConfig holds the configuration for creating an EmbeddedProvider.
+type EmbeddedProviderConfig struct {
+	ModelsDir      string
+	ChatModelFile  string
+	EmbedModelFile string
+	ContextSize    int
+	GPULayers      int
+	Threads        int
+	BatchSize      int
+	MaxTokens      int
+	Temperature    float32
+	MaxConcurrent  int
+}
+
+// NewEmbeddedProvider creates a new in-process inference provider.
+// The provider is created in an unloaded state — call LoadModels to load GGUF files.
+func NewEmbeddedProvider(cfg EmbeddedProviderConfig) *EmbeddedProvider {
+	if cfg.MaxConcurrent <= 0 {
+		cfg.MaxConcurrent = 1
+	}
+	if cfg.ContextSize <= 0 {
+		cfg.ContextSize = 2048
+	}
+	if cfg.BatchSize <= 0 {
+		cfg.BatchSize = 512
+	}
+	return &EmbeddedProvider{
+		modelsDir:      cfg.ModelsDir,
+		chatModelFile:  cfg.ChatModelFile,
+		embedModelFile: cfg.EmbedModelFile,
+		opts: BackendOptions{
+			ContextSize: cfg.ContextSize,
+			GPULayers:   cfg.GPULayers,
+			Threads:     cfg.Threads,
+			BatchSize:   cfg.BatchSize,
+		},
+		maxTokens:   cfg.MaxTokens,
+		temperature: cfg.Temperature,
+		sem:         make(chan struct{}, cfg.MaxConcurrent),
+	}
+}
+
+// LoadModels loads the configured GGUF model files using the given backend factory.
+// backendFactory creates a new Backend instance for each model.
+func (p *EmbeddedProvider) LoadModels(backendFactory func() Backend) error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	// Load chat model
+	chatPath := filepath.Join(p.modelsDir, p.chatModelFile)
+	if _, err := os.Stat(chatPath); err != nil {
+		return fmt.Errorf("chat model not found at %s: %w", chatPath, err)
+	}
+
+	chatBackend := backendFactory()
+	if err := chatBackend.LoadModel(chatPath, p.opts); err != nil {
+		return fmt.Errorf("loading chat model %s: %w", chatPath, err)
+	}
+	p.chatBackend = chatBackend
+	slog.Info("loaded embedded chat model", "path", chatPath)
+
+	// Load embedding model if configured
+	if p.embedModelFile != "" {
+		embedPath := filepath.Join(p.modelsDir, p.embedModelFile)
+		if _, err := os.Stat(embedPath); err != nil {
+			return fmt.Errorf("embedding model not found at %s: %w", embedPath, err)
+		}
+
+		embedBackend := backendFactory()
+		if err := embedBackend.LoadModel(embedPath, p.opts); err != nil {
+			return fmt.Errorf("loading embedding model %s: %w", embedPath, err)
+		}
+		p.embedBackend = embedBackend
+		slog.Info("loaded embedded embedding model", "path", embedPath)
+	}
+
+	return nil
+}
+
+// acquire blocks until a concurrency slot is available or ctx is cancelled.
+func (p *EmbeddedProvider) acquire(ctx context.Context) error {
+	select {
+	case p.sem <- struct{}{}:
+		return nil
+	case <-ctx.Done():
+		return ctx.Err()
+	}
+}
+
+// release frees a concurrency slot.
+func (p *EmbeddedProvider) release() {
+	<-p.sem
+}
+
+// formatPrompt converts a slice of Messages into a single prompt string
+// using the ChatML format that most GGUF models support.
+func formatPrompt(messages []Message) string {
+	var b strings.Builder
+	for _, msg := range messages {
+		b.WriteString("<|im_start|>")
+		b.WriteString(msg.Role)
+		b.WriteByte('\n')
+		b.WriteString(msg.Content)
+		b.WriteString("<|im_end|>\n")
+	}
+	b.WriteString("<|im_start|>assistant\n")
+	return b.String()
+}
+
+// Complete sends a completion request to the in-process backend.
+func (p *EmbeddedProvider) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	if err := p.acquire(ctx); err != nil {
+		return CompletionResponse{}, fmt.Errorf("embedded provider busy: %w", err)
+	}
+	defer p.release()
+
+	p.mu.RLock()
+	backend := p.chatBackend
+	p.mu.RUnlock()
+
+	if backend == nil {
+		return CompletionResponse{}, &ErrProviderUnavailable{
+			Endpoint: "embedded",
+			Cause:    fmt.Errorf("chat model not loaded — call LoadModels first"),
+		}
+	}
+
+	// Determine generation parameters
+	maxTokens := req.MaxTokens
+	if maxTokens == 0 {
+		maxTokens = p.maxTokens
+	}
+	temp := req.Temperature
+	if temp == 0 {
+		temp = p.temperature
+	}
+
+	// Convert response format to GBNF grammar if applicable
+	grammar := ""
+	if req.ResponseFormat != nil && req.ResponseFormat.Type == "json_object" {
+		grammar = GBNFJSONObject
+	}
+	if req.ResponseFormat != nil && req.ResponseFormat.Type == "json_schema" && req.ResponseFormat.JSONSchema != nil {
+		// For json_schema, we'd generate a GBNF grammar from the JSON schema.
+		// For now, fall back to generic JSON constraint.
+		grammar = GBNFJSONObject
+	}
+
+	backendReq := BackendCompletionRequest{
+		Prompt:      formatPrompt(req.Messages),
+		MaxTokens:   maxTokens,
+		Temperature: temp,
+		TopP:        req.TopP,
+		Stop:        req.Stop,
+		Grammar:     grammar,
+	}
+
+	backendResp, err := backend.Complete(ctx, backendReq)
+	if err != nil {
+		return CompletionResponse{}, fmt.Errorf("embedded completion: %w", err)
+	}
+
+	return CompletionResponse{
+		Content:          backendResp.Text,
+		StopReason:       "stop",
+		TokensUsed:       backendResp.PromptTokens + backendResp.CompletionTokens,
+		PromptTokens:     backendResp.PromptTokens,
+		CompletionTokens: backendResp.CompletionTokens,
+	}, nil
+}
+
+// Embed generates a single embedding for the given text.
+func (p *EmbeddedProvider) Embed(ctx context.Context, text string) ([]float32, error) {
+	embeddings, err := p.BatchEmbed(ctx, []string{text})
+	if err != nil {
+		return nil, err
+	}
+	if len(embeddings) == 0 {
+		return nil, fmt.Errorf("no embeddings returned")
+	}
+	return embeddings[0], nil
+}
+
+// BatchEmbed generates embeddings for multiple texts.
+func (p *EmbeddedProvider) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	if len(texts) == 0 {
+		return [][]float32{}, nil
+	}
+
+	if err := p.acquire(ctx); err != nil {
+		return nil, fmt.Errorf("embedded provider busy: %w", err)
+	}
+	defer p.release()
+
+	p.mu.RLock()
+	backend := p.embedBackend
+	// Fall back to chat backend for embeddings if no dedicated embedding model
+	if backend == nil {
+		backend = p.chatBackend
+	}
+	p.mu.RUnlock()
+
+	if backend == nil {
+		return nil, &ErrProviderUnavailable{
+			Endpoint: "embedded",
+			Cause:    fmt.Errorf("no model loaded for embeddings — call LoadModels first"),
+		}
+	}
+
+	return backend.BatchEmbed(ctx, texts)
+}
+
+// Health checks if the embedded models are loaded and ready.
+func (p *EmbeddedProvider) Health(ctx context.Context) error {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if p.chatBackend == nil {
+		return &ErrProviderUnavailable{
+			Endpoint: "embedded",
+			Cause:    fmt.Errorf("chat model not loaded"),
+		}
+	}
+	return nil
+}
+
+// ModelInfo returns metadata about the loaded embedded model.
+func (p *EmbeddedProvider) ModelInfo(ctx context.Context) (ModelMetadata, error) {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if p.chatBackend == nil {
+		return ModelMetadata{}, &ErrProviderUnavailable{
+			Endpoint: "embedded",
+			Cause:    fmt.Errorf("chat model not loaded"),
+		}
+	}
+
+	return ModelMetadata{
+		Name:              p.chatModelFile,
+		ContextWindow:     p.opts.ContextSize,
+		SupportsEmbedding: p.embedBackend != nil || p.embedModelFile == "",
+		MaxTokens:         p.maxTokens,
+	}, nil
+}
+
+// Close releases all backend resources.
+func (p *EmbeddedProvider) Close() error {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	var errs []error
+	if p.chatBackend != nil {
+		if err := p.chatBackend.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("closing chat backend: %w", err))
+		}
+		p.chatBackend = nil
+	}
+	if p.embedBackend != nil {
+		if err := p.embedBackend.Close(); err != nil {
+			errs = append(errs, fmt.Errorf("closing embed backend: %w", err))
+		}
+		p.embedBackend = nil
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("closing embedded provider: %v", errs)
+	}
+	return nil
+}

--- a/internal/llm/embedded_test.go
+++ b/internal/llm/embedded_test.go
@@ -1,0 +1,275 @@
+package llm
+
+import (
+	"context"
+	"os"
+	"testing"
+)
+
+// mockBackend is a test Backend implementation.
+type mockBackend struct {
+	loaded       bool
+	modelPath    string
+	opts         BackendOptions
+	completeFunc func(ctx context.Context, req BackendCompletionRequest) (BackendCompletionResponse, error)
+	embedFunc    func(ctx context.Context, text string) ([]float32, error)
+}
+
+func (m *mockBackend) LoadModel(path string, opts BackendOptions) error {
+	m.loaded = true
+	m.modelPath = path
+	m.opts = opts
+	return nil
+}
+
+func (m *mockBackend) Complete(ctx context.Context, req BackendCompletionRequest) (BackendCompletionResponse, error) {
+	if m.completeFunc != nil {
+		return m.completeFunc(ctx, req)
+	}
+	return BackendCompletionResponse{
+		Text:             `{"summary": "test"}`,
+		PromptTokens:     10,
+		CompletionTokens: 5,
+	}, nil
+}
+
+func (m *mockBackend) Embed(ctx context.Context, text string) ([]float32, error) {
+	if m.embedFunc != nil {
+		return m.embedFunc(ctx, text)
+	}
+	return []float32{0.1, 0.2, 0.3}, nil
+}
+
+func (m *mockBackend) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	result := make([][]float32, len(texts))
+	for i, t := range texts {
+		emb, err := m.Embed(ctx, t)
+		if err != nil {
+			return nil, err
+		}
+		result[i] = emb
+	}
+	return result, nil
+}
+
+func (m *mockBackend) Close() error {
+	m.loaded = false
+	return nil
+}
+
+func TestEmbeddedProviderUnloaded(t *testing.T) {
+	p := NewEmbeddedProvider(EmbeddedProviderConfig{
+		ModelsDir:     "/tmp/models",
+		ChatModelFile: "test.gguf",
+		MaxTokens:     256,
+		Temperature:   0.3,
+	})
+
+	ctx := context.Background()
+
+	// Health should fail when no model is loaded
+	if err := p.Health(ctx); err == nil {
+		t.Fatal("expected Health to fail when no model loaded")
+	}
+
+	// Complete should fail when no model is loaded
+	_, err := p.Complete(ctx, CompletionRequest{
+		Messages: []Message{{Role: "user", Content: "hello"}},
+	})
+	if err == nil {
+		t.Fatal("expected Complete to fail when no model loaded")
+	}
+
+	// Embed should fail when no model is loaded
+	_, err = p.Embed(ctx, "test")
+	if err == nil {
+		t.Fatal("expected Embed to fail when no model loaded")
+	}
+
+	// ModelInfo should fail when no model is loaded
+	_, err = p.ModelInfo(ctx)
+	if err == nil {
+		t.Fatal("expected ModelInfo to fail when no model loaded")
+	}
+}
+
+func TestEmbeddedProviderWithMockBackend(t *testing.T) {
+	// Create a temp dir with a fake GGUF file
+	dir := t.TempDir()
+	chatFile := "chat.gguf"
+	embedFile := "embed.gguf"
+
+	// Create fake model files
+	for _, f := range []string{chatFile, embedFile} {
+		if err := writeTestFile(dir, f); err != nil {
+			t.Fatalf("creating test file: %v", err)
+		}
+	}
+
+	p := NewEmbeddedProvider(EmbeddedProviderConfig{
+		ModelsDir:      dir,
+		ChatModelFile:  chatFile,
+		EmbedModelFile: embedFile,
+		ContextSize:    1024,
+		GPULayers:      0,
+		MaxTokens:      256,
+		Temperature:    0.3,
+		MaxConcurrent:  1,
+	})
+
+	// Load models with mock backend
+	err := p.LoadModels(func() Backend { return &mockBackend{} })
+	if err != nil {
+		t.Fatalf("LoadModels failed: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Health should pass
+	if err := p.Health(ctx); err != nil {
+		t.Fatalf("Health failed: %v", err)
+	}
+
+	// Complete should work
+	resp, err := p.Complete(ctx, CompletionRequest{
+		Messages: []Message{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete failed: %v", err)
+	}
+	if resp.Content != `{"summary": "test"}` {
+		t.Errorf("unexpected content: %s", resp.Content)
+	}
+	if resp.PromptTokens != 10 {
+		t.Errorf("expected 10 prompt tokens, got %d", resp.PromptTokens)
+	}
+	if resp.CompletionTokens != 5 {
+		t.Errorf("expected 5 completion tokens, got %d", resp.CompletionTokens)
+	}
+
+	// Embed should work
+	emb, err := p.Embed(ctx, "test")
+	if err != nil {
+		t.Fatalf("Embed failed: %v", err)
+	}
+	if len(emb) != 3 {
+		t.Errorf("expected 3-dim embedding, got %d", len(emb))
+	}
+
+	// BatchEmbed should work
+	embs, err := p.BatchEmbed(ctx, []string{"a", "b"})
+	if err != nil {
+		t.Fatalf("BatchEmbed failed: %v", err)
+	}
+	if len(embs) != 2 {
+		t.Errorf("expected 2 embeddings, got %d", len(embs))
+	}
+
+	// ModelInfo should work
+	info, err := p.ModelInfo(ctx)
+	if err != nil {
+		t.Fatalf("ModelInfo failed: %v", err)
+	}
+	if info.Name != chatFile {
+		t.Errorf("expected model name %s, got %s", chatFile, info.Name)
+	}
+	if info.ContextWindow != 1024 {
+		t.Errorf("expected context window 1024, got %d", info.ContextWindow)
+	}
+
+	// Close should work
+	if err := p.Close(); err != nil {
+		t.Fatalf("Close failed: %v", err)
+	}
+
+	// After close, health should fail
+	if err := p.Health(ctx); err == nil {
+		t.Fatal("expected Health to fail after Close")
+	}
+}
+
+func TestEmbeddedProviderGrammarRouting(t *testing.T) {
+	dir := t.TempDir()
+	chatFile := "chat.gguf"
+	if err := writeTestFile(dir, chatFile); err != nil {
+		t.Fatalf("creating test file: %v", err)
+	}
+
+	var capturedGrammar string
+	p := NewEmbeddedProvider(EmbeddedProviderConfig{
+		ModelsDir:     dir,
+		ChatModelFile: chatFile,
+		MaxTokens:     256,
+		Temperature:   0.3,
+		MaxConcurrent: 1,
+	})
+
+	err := p.LoadModels(func() Backend {
+		return &mockBackend{
+			completeFunc: func(_ context.Context, req BackendCompletionRequest) (BackendCompletionResponse, error) {
+				capturedGrammar = req.Grammar
+				return BackendCompletionResponse{Text: "{}", PromptTokens: 1, CompletionTokens: 1}, nil
+			},
+		}
+	})
+	if err != nil {
+		t.Fatalf("LoadModels failed: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// No response format — no grammar
+	_, err = p.Complete(ctx, CompletionRequest{
+		Messages: []Message{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete failed: %v", err)
+	}
+	if capturedGrammar != "" {
+		t.Errorf("expected no grammar for plain request, got %q", capturedGrammar)
+	}
+
+	// json_object format — should use GBNF grammar
+	_, err = p.Complete(ctx, CompletionRequest{
+		Messages:       []Message{{Role: "user", Content: "hello"}},
+		ResponseFormat: &ResponseFormat{Type: "json_object"},
+	})
+	if err != nil {
+		t.Fatalf("Complete failed: %v", err)
+	}
+	if capturedGrammar != GBNFJSONObject {
+		t.Errorf("expected GBNF JSON grammar for json_object request")
+	}
+}
+
+func TestFormatPrompt(t *testing.T) {
+	messages := []Message{
+		{Role: "system", Content: "You are helpful."},
+		{Role: "user", Content: "Hello"},
+	}
+	got := formatPrompt(messages)
+	expected := "<|im_start|>system\nYou are helpful.<|im_end|>\n<|im_start|>user\nHello<|im_end|>\n<|im_start|>assistant\n"
+	if got != expected {
+		t.Errorf("formatPrompt mismatch:\ngot:  %q\nwant: %q", got, expected)
+	}
+}
+
+func TestEmbeddedProviderBatchEmbedEmpty(t *testing.T) {
+	p := NewEmbeddedProvider(EmbeddedProviderConfig{
+		ModelsDir:     "/tmp/models",
+		ChatModelFile: "test.gguf",
+	})
+
+	ctx := context.Background()
+	result, err := p.BatchEmbed(ctx, []string{})
+	if err != nil {
+		t.Fatalf("BatchEmbed with empty input failed: %v", err)
+	}
+	if len(result) != 0 {
+		t.Errorf("expected empty result, got %d", len(result))
+	}
+}
+
+func writeTestFile(dir, name string) error {
+	return os.WriteFile(dir+"/"+name, []byte("fake gguf data"), 0600)
+}

--- a/internal/llm/grammar.go
+++ b/internal/llm/grammar.go
@@ -1,0 +1,58 @@
+package llm
+
+// GBNF (GGML BNF) grammars for constrained decoding with llama.cpp.
+// These grammars restrict model output to valid structures during sampling,
+// eliminating JSON parse failures without post-processing.
+//
+// Reference: https://github.com/ggerganov/llama.cpp/blob/master/grammars/README.md
+
+// GBNFJSONObject constrains output to a valid JSON object.
+// This is the fallback grammar for json_object response format.
+const GBNFJSONObject = `root   ::= object
+value  ::= object | array | string | number | "true" | "false" | "null"
+
+object ::=
+  "{" ws "}" |
+  "{" ws member ("," ws member)* ws "}"
+
+member ::= string ws ":" ws value
+
+array  ::=
+  "[" ws "]" |
+  "[" ws value ("," ws value)* ws "]"
+
+string ::=
+  "\"" (
+    [^\\"\x00-\x1f] |
+    "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F])
+  )* "\""
+
+number ::= "-"? ("0" | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [-+]? [0-9]+)?
+
+ws     ::= ([ \t\n] ws)?
+`
+
+// GBNFJSONArray constrains output to a valid JSON array.
+const GBNFJSONArray = `root   ::= array
+value  ::= object | array | string | number | "true" | "false" | "null"
+
+object ::=
+  "{" ws "}" |
+  "{" ws member ("," ws member)* ws "}"
+
+member ::= string ws ":" ws value
+
+array  ::=
+  "[" ws "]" |
+  "[" ws value ("," ws value)* ws "]"
+
+string ::=
+  "\"" (
+    [^\\"\x00-\x1f] |
+    "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F])
+  )* "\""
+
+number ::= "-"? ("0" | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [-+]? [0-9]+)?
+
+ws     ::= ([ \t\n] ws)?
+`

--- a/internal/llm/models.go
+++ b/internal/llm/models.go
@@ -1,0 +1,146 @@
+package llm
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+)
+
+// ModelManifest tracks installed GGUF models in the models directory.
+// Stored as models.json alongside the GGUF files.
+type ModelManifest struct {
+	Models []ModelEntry `json:"models"`
+}
+
+// ModelEntry describes a single installed GGUF model.
+type ModelEntry struct {
+	Filename    string    `json:"filename"`     // e.g. "mnemonic-lm-100m-q8_0.gguf"
+	Role        string    `json:"role"`         // "chat" or "embedding"
+	Version     string    `json:"version"`      // semantic version of the model weights
+	Quantize    string    `json:"quantize"`     // quantization type, e.g. "Q8_0", "Q4_K_M"
+	SizeBytes   int64     `json:"size_bytes"`   // file size
+	SHA256      string    `json:"sha256"`       // integrity hash
+	InstalledAt time.Time `json:"installed_at"` // when the model was added
+}
+
+// manifestPath returns the path to models.json in the given models directory.
+func manifestPath(modelsDir string) string {
+	return filepath.Join(modelsDir, "models.json")
+}
+
+// LoadManifest reads the model manifest from the models directory.
+// Returns an empty manifest if the file does not exist.
+func LoadManifest(modelsDir string) (*ModelManifest, error) {
+	path := manifestPath(modelsDir)
+	data, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return &ModelManifest{}, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading model manifest: %w", err)
+	}
+
+	var m ModelManifest
+	if err := json.Unmarshal(data, &m); err != nil {
+		return nil, fmt.Errorf("parsing model manifest: %w", err)
+	}
+	return &m, nil
+}
+
+// SaveManifest writes the model manifest to the models directory.
+func SaveManifest(modelsDir string, m *ModelManifest) error {
+	if err := os.MkdirAll(modelsDir, 0700); err != nil {
+		return fmt.Errorf("creating models directory: %w", err)
+	}
+
+	data, err := json.MarshalIndent(m, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling model manifest: %w", err)
+	}
+
+	path := manifestPath(modelsDir)
+	if err := os.WriteFile(path, data, 0600); err != nil {
+		return fmt.Errorf("writing model manifest: %w", err)
+	}
+	return nil
+}
+
+// FindModel looks up a model entry by filename.
+func (m *ModelManifest) FindModel(filename string) *ModelEntry {
+	for i := range m.Models {
+		if m.Models[i].Filename == filename {
+			return &m.Models[i]
+		}
+	}
+	return nil
+}
+
+// FindByRole returns the first model entry with the given role.
+func (m *ModelManifest) FindByRole(role string) *ModelEntry {
+	for i := range m.Models {
+		if m.Models[i].Role == role {
+			return &m.Models[i]
+		}
+	}
+	return nil
+}
+
+// AddModel adds or updates a model entry in the manifest.
+func (m *ModelManifest) AddModel(entry ModelEntry) {
+	for i := range m.Models {
+		if m.Models[i].Filename == entry.Filename {
+			m.Models[i] = entry
+			return
+		}
+	}
+	m.Models = append(m.Models, entry)
+}
+
+// DiscoverModels scans the models directory for .gguf files and returns
+// any that are not yet in the manifest. This helps detect manually placed models.
+func DiscoverModels(modelsDir string) ([]string, error) {
+	entries, err := os.ReadDir(modelsDir)
+	if os.IsNotExist(err) {
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("reading models directory: %w", err)
+	}
+
+	var found []string
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if filepath.Ext(e.Name()) == ".gguf" {
+			found = append(found, e.Name())
+		}
+	}
+	return found, nil
+}
+
+// EnsureModelsDir creates the models directory if it doesn't exist.
+func EnsureModelsDir(modelsDir string) error {
+	if err := os.MkdirAll(modelsDir, 0700); err != nil {
+		return fmt.Errorf("creating models directory %s: %w", modelsDir, err)
+	}
+	return nil
+}
+
+// ValidateModelFile checks that a GGUF file exists and is readable.
+func ValidateModelFile(modelsDir, filename string) error {
+	path := filepath.Join(modelsDir, filename)
+	info, err := os.Stat(path)
+	if err != nil {
+		return fmt.Errorf("model file %s: %w", path, err)
+	}
+	if info.IsDir() {
+		return fmt.Errorf("model file %s is a directory", path)
+	}
+	if info.Size() == 0 {
+		return fmt.Errorf("model file %s is empty", path)
+	}
+	return nil
+}

--- a/internal/llm/models_test.go
+++ b/internal/llm/models_test.go
@@ -1,0 +1,167 @@
+package llm
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestManifestRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	manifest := &ModelManifest{
+		Models: []ModelEntry{
+			{
+				Filename:    "mnemonic-100m-q8.gguf",
+				Role:        "chat",
+				Version:     "0.1.0",
+				Quantize:    "Q8_0",
+				SizeBytes:   100_000_000,
+				SHA256:      "abc123",
+				InstalledAt: time.Date(2026, 3, 17, 0, 0, 0, 0, time.UTC),
+			},
+		},
+	}
+
+	if err := SaveManifest(dir, manifest); err != nil {
+		t.Fatalf("SaveManifest: %v", err)
+	}
+
+	loaded, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("LoadManifest: %v", err)
+	}
+
+	if len(loaded.Models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(loaded.Models))
+	}
+	if loaded.Models[0].Filename != "mnemonic-100m-q8.gguf" {
+		t.Errorf("unexpected filename: %s", loaded.Models[0].Filename)
+	}
+	if loaded.Models[0].Role != "chat" {
+		t.Errorf("unexpected role: %s", loaded.Models[0].Role)
+	}
+}
+
+func TestManifestMissing(t *testing.T) {
+	dir := t.TempDir()
+
+	manifest, err := LoadManifest(dir)
+	if err != nil {
+		t.Fatalf("LoadManifest on empty dir: %v", err)
+	}
+	if len(manifest.Models) != 0 {
+		t.Errorf("expected empty manifest, got %d models", len(manifest.Models))
+	}
+}
+
+func TestManifestFindModel(t *testing.T) {
+	m := &ModelManifest{
+		Models: []ModelEntry{
+			{Filename: "a.gguf", Role: "chat"},
+			{Filename: "b.gguf", Role: "embedding"},
+		},
+	}
+
+	if got := m.FindModel("a.gguf"); got == nil {
+		t.Error("expected to find a.gguf")
+	}
+	if got := m.FindModel("c.gguf"); got != nil {
+		t.Error("expected nil for missing model")
+	}
+}
+
+func TestManifestFindByRole(t *testing.T) {
+	m := &ModelManifest{
+		Models: []ModelEntry{
+			{Filename: "a.gguf", Role: "chat"},
+			{Filename: "b.gguf", Role: "embedding"},
+		},
+	}
+
+	if got := m.FindByRole("embedding"); got == nil || got.Filename != "b.gguf" {
+		t.Error("expected to find embedding model b.gguf")
+	}
+	if got := m.FindByRole("other"); got != nil {
+		t.Error("expected nil for missing role")
+	}
+}
+
+func TestManifestAddModel(t *testing.T) {
+	m := &ModelManifest{}
+
+	m.AddModel(ModelEntry{Filename: "a.gguf", Role: "chat", Version: "1.0"})
+	if len(m.Models) != 1 {
+		t.Fatalf("expected 1 model, got %d", len(m.Models))
+	}
+
+	// Update existing
+	m.AddModel(ModelEntry{Filename: "a.gguf", Role: "chat", Version: "2.0"})
+	if len(m.Models) != 1 {
+		t.Fatalf("expected 1 model after update, got %d", len(m.Models))
+	}
+	if m.Models[0].Version != "2.0" {
+		t.Errorf("expected version 2.0, got %s", m.Models[0].Version)
+	}
+
+	// Add new
+	m.AddModel(ModelEntry{Filename: "b.gguf", Role: "embedding"})
+	if len(m.Models) != 2 {
+		t.Fatalf("expected 2 models, got %d", len(m.Models))
+	}
+}
+
+func TestDiscoverModels(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create some files
+	for _, name := range []string{"model.gguf", "other.gguf", "readme.txt"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("data"), 0600); err != nil {
+			t.Fatalf("creating file: %v", err)
+		}
+	}
+
+	found, err := DiscoverModels(dir)
+	if err != nil {
+		t.Fatalf("DiscoverModels: %v", err)
+	}
+	if len(found) != 2 {
+		t.Errorf("expected 2 gguf files, got %d: %v", len(found), found)
+	}
+}
+
+func TestDiscoverModelsMissingDir(t *testing.T) {
+	found, err := DiscoverModels("/nonexistent/dir")
+	if err != nil {
+		t.Fatalf("DiscoverModels on missing dir: %v", err)
+	}
+	if found != nil {
+		t.Errorf("expected nil, got %v", found)
+	}
+}
+
+func TestValidateModelFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Missing file
+	if err := ValidateModelFile(dir, "missing.gguf"); err == nil {
+		t.Error("expected error for missing file")
+	}
+
+	// Empty file
+	if err := os.WriteFile(filepath.Join(dir, "empty.gguf"), nil, 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateModelFile(dir, "empty.gguf"); err == nil {
+		t.Error("expected error for empty file")
+	}
+
+	// Valid file
+	if err := os.WriteFile(filepath.Join(dir, "valid.gguf"), []byte("data"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	if err := ValidateModelFile(dir, "valid.gguf"); err != nil {
+		t.Errorf("unexpected error for valid file: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Implements `EmbeddedProvider` satisfying `llm.Provider` for in-process GGUF model inference via a pluggable `Backend` interface (llama.cpp CGo bindings will implement this)
- Adds model file management: `ModelManifest` (models.json), `.gguf` discovery, validation, role-based lookup in `~/.mnemonic/models/`
- Adds GBNF grammar constants for constrained decoding (JSON object/array) — routes `json_object`/`json_schema` response formats to grammar sampling
- Adds `llm.provider` config field (`"api"` or `"embedded"`) with `llm.embedded` sub-config for model paths, GPU layers, context size, threads
- Refactors provider creation into `newLLMProvider()` factory, replacing 3 direct `NewLMStudioProvider` calls in main.go

Closes #174

## Test plan

- [x] 13 new unit tests covering: unloaded provider errors, mock backend completion/embedding, grammar routing, prompt formatting, manifest CRUD, model discovery, file validation
- [x] `make build` passes
- [x] `make check` (go fmt + go vet) clean
- [x] `golangci-lint run` clean
- [x] Full `go test ./...` passes — no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)