### PR TITLE
fix: suppress filesystem events during git operations

### DIFF
--- a/internal/agent/perception/agent.go
+++ b/internal/agent/perception/agent.go
@@ -61,6 +61,10 @@ type PerceptionAgent struct {
 	// watcher emits multiple events for the same file with identical content.
 	recentContentMu sync.Mutex
 	recentContent   map[string]time.Time // hash(source+path+content) → timestamp
+
+	// Git-operation suppression: prevents encoding filesystem events that are
+	// side-effects of git operations (pull, checkout, merge, rebase).
+	gitOpCooldown time.Duration // how long after a git op to suppress fs events (default: 10s)
 }
 
 // NewPerceptionAgent creates a new perception agent with the given dependencies.
@@ -72,12 +76,13 @@ func NewPerceptionAgent(
 	log *slog.Logger,
 ) *PerceptionAgent {
 	return &PerceptionAgent{
-		name:        "perception",
-		watchers:    watchers,
-		store:       s,
-		llmProvider: llmProv,
-		cfg:         cfg,
-		log:         log,
+		name:          "perception",
+		watchers:      watchers,
+		store:         s,
+		llmProvider:   llmProv,
+		cfg:           cfg,
+		log:           log,
+		gitOpCooldown: 10 * time.Second,
 	}
 }
 
@@ -290,6 +295,15 @@ func (pa *PerceptionAgent) processEvent(ctx context.Context, event Event) {
 		}
 		pa.recentContent[hash] = time.Now()
 		pa.recentContentMu.Unlock()
+	}
+
+	// 0b. Git-operation suppression: if this filesystem event is inside a git repo
+	// that had a recent git operation (pull, checkout, merge, rebase), suppress it.
+	// The git watcher will handle it as a single "repo_changed" event instead.
+	if event.Source == "filesystem" && pa.isRecentGitOp(event.Path) {
+		pa.log.Debug("suppressed filesystem event during git operation",
+			"path", event.Path, "type", event.Type)
+		return
 	}
 
 	// 1. Run heuristic filter
@@ -511,6 +525,56 @@ func (pa *PerceptionAgent) mergeMetadata(
 	merged["heuristic_score"] = heuristicScore
 
 	return merged
+}
+
+// isRecentGitOp checks if the given file path is inside a git repo that had
+// a recent git operation (pull, checkout, merge, rebase). It does this by
+// walking up the directory tree to find .git/, then checking if sentinel files
+// (.git/FETCH_HEAD, .git/HEAD, .git/ORIG_HEAD) were modified recently.
+//
+// This is lightweight (a few stat calls) and avoids encoding filesystem events
+// that are side-effects of git operations — the git watcher handles those as
+// a single "repo_changed" event instead.
+func (pa *PerceptionAgent) isRecentGitOp(filePath string) bool {
+	gitDir := findGitDir(filePath)
+	if gitDir == "" {
+		return false
+	}
+
+	cutoff := time.Now().Add(-pa.gitOpCooldown)
+
+	// Check sentinel files that git updates during operations.
+	// FETCH_HEAD: updated by git fetch/pull
+	// ORIG_HEAD: updated by git merge/rebase/reset
+	// HEAD: updated by git checkout/switch
+	sentinels := []string{"FETCH_HEAD", "ORIG_HEAD", "HEAD"}
+	for _, s := range sentinels {
+		info, err := os.Stat(filepath.Join(gitDir, s))
+		if err != nil {
+			continue
+		}
+		if info.ModTime().After(cutoff) {
+			return true
+		}
+	}
+	return false
+}
+
+// findGitDir walks up from the given path to find the nearest .git directory.
+// Returns the .git directory path, or empty string if not found.
+func findGitDir(path string) string {
+	dir := filepath.Dir(path)
+	for {
+		candidate := filepath.Join(dir, ".git")
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "" // reached filesystem root
+		}
+		dir = parent
+	}
 }
 
 // knownProjectParents are directory names that typically contain project directories.

--- a/internal/agent/perception/git_suppression_test.go
+++ b/internal/agent/perception/git_suppression_test.go
@@ -1,0 +1,98 @@
+package perception
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestFindGitDir(t *testing.T) {
+	// Create a temp directory structure with .git
+	tmp := t.TempDir()
+	gitDir := filepath.Join(tmp, ".git")
+	if err := os.Mkdir(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	subDir := filepath.Join(tmp, "src", "pkg")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name string
+		path string
+		want string
+	}{
+		{"file in repo root", filepath.Join(tmp, "README.md"), gitDir},
+		{"file in nested dir", filepath.Join(subDir, "main.go"), gitDir},
+		{"file outside any repo", "/tmp/random/file.txt", ""},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := findGitDir(tt.path)
+			if got != tt.want {
+				t.Errorf("findGitDir(%q) = %q, want %q", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsRecentGitOp(t *testing.T) {
+	// Create a temp repo with .git and sentinel files
+	tmp := t.TempDir()
+	gitDir := filepath.Join(tmp, ".git")
+	if err := os.Mkdir(gitDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	pa := &PerceptionAgent{
+		gitOpCooldown: 10 * time.Second,
+	}
+
+	filePath := filepath.Join(tmp, "CHANGELOG.md")
+
+	// No sentinel files exist yet — should not suppress
+	if pa.isRecentGitOp(filePath) {
+		t.Error("expected false when no sentinel files exist")
+	}
+
+	// Create FETCH_HEAD with current mtime — should suppress
+	fetchHead := filepath.Join(gitDir, "FETCH_HEAD")
+	if err := os.WriteFile(fetchHead, []byte("abc123\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !pa.isRecentGitOp(filePath) {
+		t.Error("expected true when FETCH_HEAD was just modified")
+	}
+
+	// Set FETCH_HEAD mtime to 30 seconds ago — should not suppress
+	old := time.Now().Add(-30 * time.Second)
+	if err := os.Chtimes(fetchHead, old, old); err != nil {
+		t.Fatal(err)
+	}
+	if pa.isRecentGitOp(filePath) {
+		t.Error("expected false when FETCH_HEAD is old")
+	}
+
+	// Create ORIG_HEAD with current mtime (simulates merge/rebase) — should suppress
+	origHead := filepath.Join(gitDir, "ORIG_HEAD")
+	if err := os.WriteFile(origHead, []byte("def456\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !pa.isRecentGitOp(filePath) {
+		t.Error("expected true when ORIG_HEAD was just modified")
+	}
+}
+
+func TestIsRecentGitOp_NotInRepo(t *testing.T) {
+	pa := &PerceptionAgent{
+		gitOpCooldown: 10 * time.Second,
+	}
+
+	// A path that's definitely not in a git repo
+	if pa.isRecentGitOp("/tmp/not-a-repo/somefile.txt") {
+		t.Error("expected false for path outside any git repo")
+	}
+}


### PR DESCRIPTION
## Summary

- After a git pull/checkout/merge/rebase, the filesystem watcher would detect every changed file individually, creating noisy raw memories (e.g., "Mnemonic v0.17.0 released" from CHANGELOG.md changes after `git pull`)
- The fix checks `.git` sentinel file mtimes (FETCH_HEAD, ORIG_HEAD, HEAD) when a filesystem event arrives — if any were modified within the last 10s, the event is suppressed
- The git watcher already handles these as a single "repo_changed" event, so no information is lost

## How it works

1. Filesystem event arrives in perception agent's `processEvent()`
2. New step 0b: `isRecentGitOp()` walks up to find `.git/`, stats sentinel files
3. If any sentinel was modified in the last 10 seconds, the event is suppressed
4. Lightweight: a few `os.Stat` calls, no new goroutines or watchers

## Test plan

- [x] `TestFindGitDir` — finds `.git` from nested paths, returns empty outside repos
- [x] `TestIsRecentGitOp` — suppresses when FETCH_HEAD/ORIG_HEAD are fresh, allows when old
- [x] `TestIsRecentGitOp_NotInRepo` — no false positives outside git repos
- [x] Full test suite passes (`make test`)
- [ ] Manual: rebuild daemon, run `git pull`, verify no CHANGELOG/Makefile memories created

🤖 Generated with [Claude Code](https://claude.com/claude-code)