### PR TITLE
feat: store access snapshot in retrieval feedback

### DIFF
--- a/internal/api/routes/feedback.go
+++ b/internal/api/routes/feedback.go
@@ -158,15 +158,27 @@ func HandleFeedback(s store.Store, log *slog.Logger) http.HandlerFunc {
 }
 
 // SaveRetrievalFeedback saves traversal data for a query so feedback can adjust strengths later.
+// It also snapshots the access count of each retrieved memory so implicit feedback can detect re-access.
 func SaveRetrievalFeedback(ctx context.Context, s store.Store, log *slog.Logger, queryID string, queryText string, retrievedIDs []string, traversedAssocs []store.TraversedAssoc) {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
+
+	// Snapshot access counts at query time for implicit feedback detection
+	snapshot := make(map[string]int, len(retrievedIDs))
+	for _, memID := range retrievedIDs {
+		mem, err := s.GetMemory(ctx, memID)
+		if err != nil {
+			continue
+		}
+		snapshot[memID] = mem.AccessCount
+	}
 
 	fb := store.RetrievalFeedback{
 		QueryID:         queryID,
 		QueryText:       queryText,
 		RetrievedIDs:    retrievedIDs,
 		TraversedAssocs: traversedAssocs,
+		AccessSnapshot:  snapshot,
 		CreatedAt:       time.Now(),
 	}
 	if err := s.WriteRetrievalFeedback(ctx, fb); err != nil {

--- a/internal/store/sqlite/schema.go
+++ b/internal/store/sqlite/schema.go
@@ -101,6 +101,7 @@ CREATE TABLE IF NOT EXISTS retrieval_feedback (
     query_text TEXT NOT NULL,
     retrieved_memory_ids JSON,
     traversed_assocs JSON,
+    access_snapshot JSON,
     feedback TEXT,
     notes TEXT,
     created_at DATETIME DEFAULT (datetime('now'))
@@ -386,6 +387,12 @@ func InitSchema(db *sql.DB) error {
 	}
 	// Backfill type from raw_memories where possible
 	_, _ = db.Exec(`UPDATE memories SET type = (SELECT raw_memories.type FROM raw_memories WHERE raw_memories.id = memories.raw_id) WHERE type IS NULL AND raw_id IS NOT NULL AND raw_id != ''`)
+
+	// Migration 009: Add access_snapshot column to retrieval_feedback
+	_, err = db.Exec(`ALTER TABLE retrieval_feedback ADD COLUMN access_snapshot JSON`)
+	if err != nil && !isAlterTableDuplicateColumn(err) {
+		return fmt.Errorf("failed to add retrieval_feedback.access_snapshot column: %w", err)
+	}
 
 	return nil
 }

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1786,11 +1786,15 @@ func (s *SQLiteStore) WriteRetrievalFeedback(ctx context.Context, fb store.Retri
 	if err != nil {
 		return fmt.Errorf("failed to marshal traversed assocs: %w", err)
 	}
+	snapshotJSON, err := json.Marshal(fb.AccessSnapshot)
+	if err != nil {
+		return fmt.Errorf("failed to marshal access snapshot: %w", err)
+	}
 
 	_, err = s.db.ExecContext(ctx,
-		`INSERT OR REPLACE INTO retrieval_feedback (query_id, query_text, retrieved_memory_ids, traversed_assocs, feedback, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?)`,
-		fb.QueryID, fb.QueryText, string(retrievedJSON), string(traversedJSON), fb.Feedback, fb.CreatedAt.Format(time.RFC3339))
+		`INSERT OR REPLACE INTO retrieval_feedback (query_id, query_text, retrieved_memory_ids, traversed_assocs, access_snapshot, feedback, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		fb.QueryID, fb.QueryText, string(retrievedJSON), string(traversedJSON), string(snapshotJSON), fb.Feedback, fb.CreatedAt.Format(time.RFC3339))
 	if err != nil {
 		return fmt.Errorf("failed to write retrieval feedback: %w", err)
 	}
@@ -1800,12 +1804,12 @@ func (s *SQLiteStore) WriteRetrievalFeedback(ctx context.Context, fb store.Retri
 // GetRetrievalFeedback retrieves a feedback record by query ID.
 func (s *SQLiteStore) GetRetrievalFeedback(ctx context.Context, queryID string) (store.RetrievalFeedback, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT query_id, query_text, retrieved_memory_ids, COALESCE(traversed_assocs, '[]'), COALESCE(feedback, ''), created_at
+		`SELECT query_id, query_text, retrieved_memory_ids, COALESCE(traversed_assocs, '[]'), COALESCE(access_snapshot, '{}'), COALESCE(feedback, ''), created_at
 		 FROM retrieval_feedback WHERE query_id = ?`, queryID)
 
 	var fb store.RetrievalFeedback
-	var retrievedJSON, traversedJSON, createdAtStr string
-	err := row.Scan(&fb.QueryID, &fb.QueryText, &retrievedJSON, &traversedJSON, &fb.Feedback, &createdAtStr)
+	var retrievedJSON, traversedJSON, snapshotJSON, createdAtStr string
+	err := row.Scan(&fb.QueryID, &fb.QueryText, &retrievedJSON, &traversedJSON, &snapshotJSON, &fb.Feedback, &createdAtStr)
 	if err != nil {
 		return store.RetrievalFeedback{}, fmt.Errorf("failed to get retrieval feedback: %w", err)
 	}
@@ -1815,6 +1819,9 @@ func (s *SQLiteStore) GetRetrievalFeedback(ctx context.Context, queryID string) 
 	}
 	if err := json.Unmarshal([]byte(traversedJSON), &fb.TraversedAssocs); err != nil {
 		fb.TraversedAssocs = nil
+	}
+	if err := json.Unmarshal([]byte(snapshotJSON), &fb.AccessSnapshot); err != nil {
+		fb.AccessSnapshot = nil
 	}
 	fb.CreatedAt, _ = time.Parse(time.RFC3339, createdAtStr)
 

--- a/internal/store/sqlite/sqlite_test.go
+++ b/internal/store/sqlite/sqlite_test.go
@@ -968,3 +968,69 @@ func TestSanitizeFTSQuery(t *testing.T) {
 		})
 	}
 }
+
+func TestRetrievalFeedbackAccessSnapshot(t *testing.T) {
+	s := createTestStore(t)
+	defer func() { _ = s.Close() }()
+
+	ctx := context.Background()
+
+	t.Run("round-trip with access snapshot", func(t *testing.T) {
+		fb := store.RetrievalFeedback{
+			QueryID:      "q-1",
+			QueryText:    "test query",
+			RetrievedIDs: []string{"mem-1", "mem-2"},
+			TraversedAssocs: []store.TraversedAssoc{
+				{SourceID: "mem-1", TargetID: "mem-2"},
+			},
+			AccessSnapshot: map[string]int{
+				"mem-1": 5,
+				"mem-2": 12,
+			},
+			CreatedAt: time.Now(),
+		}
+
+		if err := s.WriteRetrievalFeedback(ctx, fb); err != nil {
+			t.Fatalf("WriteRetrievalFeedback: %v", err)
+		}
+
+		got, err := s.GetRetrievalFeedback(ctx, "q-1")
+		if err != nil {
+			t.Fatalf("GetRetrievalFeedback: %v", err)
+		}
+
+		if len(got.AccessSnapshot) != 2 {
+			t.Fatalf("expected 2 snapshot entries, got %d", len(got.AccessSnapshot))
+		}
+		if got.AccessSnapshot["mem-1"] != 5 {
+			t.Errorf("expected mem-1 access count 5, got %d", got.AccessSnapshot["mem-1"])
+		}
+		if got.AccessSnapshot["mem-2"] != 12 {
+			t.Errorf("expected mem-2 access count 12, got %d", got.AccessSnapshot["mem-2"])
+		}
+	})
+
+	t.Run("backward compat with nil snapshot", func(t *testing.T) {
+		// Write a record without a snapshot (simulates old data)
+		fb := store.RetrievalFeedback{
+			QueryID:      "q-old",
+			QueryText:    "old query",
+			RetrievedIDs: []string{"mem-3"},
+			CreatedAt:    time.Now(),
+		}
+
+		if err := s.WriteRetrievalFeedback(ctx, fb); err != nil {
+			t.Fatalf("WriteRetrievalFeedback: %v", err)
+		}
+
+		got, err := s.GetRetrievalFeedback(ctx, "q-old")
+		if err != nil {
+			t.Fatalf("GetRetrievalFeedback: %v", err)
+		}
+
+		// nil snapshot should deserialize as empty/nil map without error
+		if got.AccessSnapshot != nil && len(got.AccessSnapshot) != 0 {
+			t.Errorf("expected nil or empty snapshot for old record, got %v", got.AccessSnapshot)
+		}
+	})
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -291,6 +291,7 @@ type RetrievalFeedback struct {
 	QueryText       string           `json:"query_text"`
 	RetrievedIDs    []string         `json:"retrieved_ids"`
 	TraversedAssocs []TraversedAssoc `json:"traversed_assocs"`
+	AccessSnapshot  map[string]int   `json:"access_snapshot,omitempty"` // memory_id -> access_count at query time
 	Feedback        string           `json:"feedback"`
 	CreatedAt       time.Time        `json:"created_at"`
 }


### PR DESCRIPTION
## Summary
- Adds `AccessSnapshot` field to `RetrievalFeedback` struct — captures each retrieved memory's `access_count` at query time
- `SaveRetrievalFeedback` now snapshots access counts for all retrieved memories
- Includes idempotent schema migration (`access_snapshot JSON` column) and backward-compatible deserialization
- Prerequisite for implicit positive feedback (#185)

## Test plan
- [x] New `TestRetrievalFeedbackAccessSnapshot` verifies round-trip with snapshot data
- [x] Backward compat subtest: old records with nil snapshot deserialize cleanly
- [x] `make check` passes (go fmt + go vet)
- [x] `golangci-lint run` — 0 issues
- [x] Full test suite passes

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)