### PR TITLE
feat: store access snapshot in retrieval feedback

### DIFF
--- a/internal/api/routes/feedback.go
+++ b/internal/api/routes/feedback.go
@@ -158,15 +158,28 @@ func HandleFeedback(s store.Store, log *slog.Logger) http.HandlerFunc {
 }
 
 // SaveRetrievalFeedback saves traversal data for a query so feedback can adjust strengths later.
-func SaveRetrievalFeedback(ctx context.Context, s store.Store, log *slog.Logger, queryID string, queryText string, retrievedIDs []string, traversedAssocs []store.TraversedAssoc) {
+// It captures a ranked access snapshot of the returned memories for metacognition analysis.
+func SaveRetrievalFeedback(ctx context.Context, s store.Store, log *slog.Logger, queryID string, queryText string, results []store.RetrievalResult, traversedAssocs []store.TraversedAssoc) {
 	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
 	defer cancel()
+
+	var retrievedIDs []string
+	var snapshot []store.AccessSnapshotEntry
+	for i, r := range results {
+		retrievedIDs = append(retrievedIDs, r.Memory.ID)
+		snapshot = append(snapshot, store.AccessSnapshotEntry{
+			MemoryID: r.Memory.ID,
+			Rank:     i + 1,
+			Score:    r.Score,
+		})
+	}
 
 	fb := store.RetrievalFeedback{
 		QueryID:         queryID,
 		QueryText:       queryText,
 		RetrievedIDs:    retrievedIDs,
 		TraversedAssocs: traversedAssocs,
+		AccessSnapshot:  snapshot,
 		CreatedAt:       time.Now(),
 	}
 	if err := s.WriteRetrievalFeedback(ctx, fb); err != nil {

--- a/internal/api/routes/query.go
+++ b/internal/api/routes/query.go
@@ -81,12 +81,8 @@ func HandleQuery(retriever *retrieval.RetrievalAgent, bus events.Bus, s store.St
 			"results", len(queryResp.Memories),
 			"took_ms", queryResp.TookMs)
 
-		// Save traversal data for feedback loop
-		var retrievedIDs []string
-		for _, mem := range queryResp.Memories {
-			retrievedIDs = append(retrievedIDs, mem.Memory.ID)
-		}
-		SaveRetrievalFeedback(ctx, s, log, queryResp.QueryID, reqBody.Query, retrievedIDs, queryResp.TraversedAssocs)
+		// Save traversal data and access snapshot for feedback loop
+		SaveRetrievalFeedback(ctx, s, log, queryResp.QueryID, reqBody.Query, queryResp.Memories, queryResp.TraversedAssocs)
 
 		// Publish query executed event
 		queryEvt := events.QueryExecuted{

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -398,16 +398,23 @@ func (srv *MCPServer) handleRecall(ctx context.Context, args map[string]interfac
 		return nil, fmt.Errorf("retrieval failed: %w", err)
 	}
 
-	// Save traversal data for feedback loop
+	// Save traversal data and access snapshot for feedback loop
 	var retrievedIDs []string
-	for _, mem := range result.Memories {
+	var snapshot []store.AccessSnapshotEntry
+	for i, mem := range result.Memories {
 		retrievedIDs = append(retrievedIDs, mem.Memory.ID)
+		snapshot = append(snapshot, store.AccessSnapshotEntry{
+			MemoryID: mem.Memory.ID,
+			Rank:     i + 1,
+			Score:    mem.Score,
+		})
 	}
 	fb := store.RetrievalFeedback{
 		QueryID:         result.QueryID,
 		QueryText:       query,
 		RetrievedIDs:    retrievedIDs,
 		TraversedAssocs: result.TraversedAssocs,
+		AccessSnapshot:  snapshot,
 		CreatedAt:       time.Now(),
 	}
 	if err := srv.store.WriteRetrievalFeedback(ctx, fb); err != nil {

--- a/internal/store/sqlite/schema.go
+++ b/internal/store/sqlite/schema.go
@@ -101,6 +101,7 @@ CREATE TABLE IF NOT EXISTS retrieval_feedback (
     query_text TEXT NOT NULL,
     retrieved_memory_ids JSON,
     traversed_assocs JSON,
+    access_snapshot JSON,
     feedback TEXT,
     notes TEXT,
     created_at DATETIME DEFAULT (datetime('now'))
@@ -386,6 +387,12 @@ func InitSchema(db *sql.DB) error {
 	}
 	// Backfill type from raw_memories where possible
 	_, _ = db.Exec(`UPDATE memories SET type = (SELECT raw_memories.type FROM raw_memories WHERE raw_memories.id = memories.raw_id) WHERE type IS NULL AND raw_id IS NOT NULL AND raw_id != ''`)
+
+	// Migration 009: Add access_snapshot column to retrieval_feedback
+	_, err = db.Exec(`ALTER TABLE retrieval_feedback ADD COLUMN access_snapshot JSON`)
+	if err != nil && !isAlterTableDuplicateColumn(err) {
+		return fmt.Errorf("failed to add retrieval_feedback.access_snapshot column: %w", err)
+	}
 
 	return nil
 }

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1786,11 +1786,15 @@ func (s *SQLiteStore) WriteRetrievalFeedback(ctx context.Context, fb store.Retri
 	if err != nil {
 		return fmt.Errorf("failed to marshal traversed assocs: %w", err)
 	}
+	snapshotJSON, err := json.Marshal(fb.AccessSnapshot)
+	if err != nil {
+		return fmt.Errorf("failed to marshal access snapshot: %w", err)
+	}
 
 	_, err = s.db.ExecContext(ctx,
-		`INSERT OR REPLACE INTO retrieval_feedback (query_id, query_text, retrieved_memory_ids, traversed_assocs, feedback, created_at)
-		 VALUES (?, ?, ?, ?, ?, ?)`,
-		fb.QueryID, fb.QueryText, string(retrievedJSON), string(traversedJSON), fb.Feedback, fb.CreatedAt.Format(time.RFC3339))
+		`INSERT OR REPLACE INTO retrieval_feedback (query_id, query_text, retrieved_memory_ids, traversed_assocs, access_snapshot, feedback, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?)`,
+		fb.QueryID, fb.QueryText, string(retrievedJSON), string(traversedJSON), string(snapshotJSON), fb.Feedback, fb.CreatedAt.Format(time.RFC3339))
 	if err != nil {
 		return fmt.Errorf("failed to write retrieval feedback: %w", err)
 	}
@@ -1800,12 +1804,12 @@ func (s *SQLiteStore) WriteRetrievalFeedback(ctx context.Context, fb store.Retri
 // GetRetrievalFeedback retrieves a feedback record by query ID.
 func (s *SQLiteStore) GetRetrievalFeedback(ctx context.Context, queryID string) (store.RetrievalFeedback, error) {
 	row := s.db.QueryRowContext(ctx,
-		`SELECT query_id, query_text, retrieved_memory_ids, COALESCE(traversed_assocs, '[]'), COALESCE(feedback, ''), created_at
+		`SELECT query_id, query_text, retrieved_memory_ids, COALESCE(traversed_assocs, '[]'), COALESCE(access_snapshot, '[]'), COALESCE(feedback, ''), created_at
 		 FROM retrieval_feedback WHERE query_id = ?`, queryID)
 
 	var fb store.RetrievalFeedback
-	var retrievedJSON, traversedJSON, createdAtStr string
-	err := row.Scan(&fb.QueryID, &fb.QueryText, &retrievedJSON, &traversedJSON, &fb.Feedback, &createdAtStr)
+	var retrievedJSON, traversedJSON, snapshotJSON, createdAtStr string
+	err := row.Scan(&fb.QueryID, &fb.QueryText, &retrievedJSON, &traversedJSON, &snapshotJSON, &fb.Feedback, &createdAtStr)
 	if err != nil {
 		return store.RetrievalFeedback{}, fmt.Errorf("failed to get retrieval feedback: %w", err)
 	}
@@ -1815,6 +1819,9 @@ func (s *SQLiteStore) GetRetrievalFeedback(ctx context.Context, queryID string) 
 	}
 	if err := json.Unmarshal([]byte(traversedJSON), &fb.TraversedAssocs); err != nil {
 		fb.TraversedAssocs = nil
+	}
+	if err := json.Unmarshal([]byte(snapshotJSON), &fb.AccessSnapshot); err != nil {
+		fb.AccessSnapshot = nil
 	}
 	fb.CreatedAt, _ = time.Parse(time.RFC3339, createdAtStr)
 

--- a/internal/store/sqlite/sqlite_test.go
+++ b/internal/store/sqlite/sqlite_test.go
@@ -968,3 +968,104 @@ func TestSanitizeFTSQuery(t *testing.T) {
 		})
 	}
 }
+
+func TestRetrievalFeedbackAccessSnapshot(t *testing.T) {
+	s := createTestStore(t)
+	defer func() { _ = s.Close() }()
+
+	ctx := context.Background()
+
+	t.Run("round-trip with access snapshot", func(t *testing.T) {
+		fb := store.RetrievalFeedback{
+			QueryID:      "q-snap-1",
+			QueryText:    "test query",
+			RetrievedIDs: []string{"mem-1", "mem-2", "mem-3"},
+			TraversedAssocs: []store.TraversedAssoc{
+				{SourceID: "mem-1", TargetID: "mem-2"},
+			},
+			AccessSnapshot: []store.AccessSnapshotEntry{
+				{MemoryID: "mem-1", Rank: 1, Score: 0.95},
+				{MemoryID: "mem-2", Rank: 2, Score: 0.72},
+				{MemoryID: "mem-3", Rank: 3, Score: 0.41},
+			},
+			CreatedAt: time.Now(),
+		}
+
+		if err := s.WriteRetrievalFeedback(ctx, fb); err != nil {
+			t.Fatalf("WriteRetrievalFeedback: %v", err)
+		}
+
+		got, err := s.GetRetrievalFeedback(ctx, "q-snap-1")
+		if err != nil {
+			t.Fatalf("GetRetrievalFeedback: %v", err)
+		}
+
+		if len(got.AccessSnapshot) != 3 {
+			t.Fatalf("expected 3 snapshot entries, got %d", len(got.AccessSnapshot))
+		}
+		if got.AccessSnapshot[0].MemoryID != "mem-1" || got.AccessSnapshot[0].Rank != 1 {
+			t.Errorf("snapshot[0] = %+v, want mem-1 rank 1", got.AccessSnapshot[0])
+		}
+		if got.AccessSnapshot[1].Score != 0.72 {
+			t.Errorf("snapshot[1].Score = %f, want 0.72", got.AccessSnapshot[1].Score)
+		}
+		if got.AccessSnapshot[2].Rank != 3 {
+			t.Errorf("snapshot[2].Rank = %d, want 3", got.AccessSnapshot[2].Rank)
+		}
+	})
+
+	t.Run("backward compat with nil snapshot", func(t *testing.T) {
+		fb := store.RetrievalFeedback{
+			QueryID:      "q-old",
+			QueryText:    "old query",
+			RetrievedIDs: []string{"mem-3"},
+			CreatedAt:    time.Now(),
+		}
+
+		if err := s.WriteRetrievalFeedback(ctx, fb); err != nil {
+			t.Fatalf("WriteRetrievalFeedback: %v", err)
+		}
+
+		got, err := s.GetRetrievalFeedback(ctx, "q-old")
+		if err != nil {
+			t.Fatalf("GetRetrievalFeedback: %v", err)
+		}
+
+		if got.AccessSnapshot != nil && len(got.AccessSnapshot) != 0 {
+			t.Errorf("expected nil or empty snapshot for old record, got %v", got.AccessSnapshot)
+		}
+	})
+
+	t.Run("update preserves snapshot", func(t *testing.T) {
+		// Write initial record with snapshot
+		fb := store.RetrievalFeedback{
+			QueryID:      "q-update",
+			QueryText:    "update test",
+			RetrievedIDs: []string{"mem-4"},
+			AccessSnapshot: []store.AccessSnapshotEntry{
+				{MemoryID: "mem-4", Rank: 1, Score: 0.88},
+			},
+			CreatedAt: time.Now(),
+		}
+		if err := s.WriteRetrievalFeedback(ctx, fb); err != nil {
+			t.Fatalf("WriteRetrievalFeedback: %v", err)
+		}
+
+		// Simulate feedback update (re-write with quality set)
+		fb.Feedback = "helpful"
+		if err := s.WriteRetrievalFeedback(ctx, fb); err != nil {
+			t.Fatalf("WriteRetrievalFeedback (update): %v", err)
+		}
+
+		got, err := s.GetRetrievalFeedback(ctx, "q-update")
+		if err != nil {
+			t.Fatalf("GetRetrievalFeedback: %v", err)
+		}
+		if got.Feedback != "helpful" {
+			t.Errorf("expected feedback 'helpful', got %q", got.Feedback)
+		}
+		if len(got.AccessSnapshot) != 1 || got.AccessSnapshot[0].Score != 0.88 {
+			t.Errorf("snapshot not preserved after update: %+v", got.AccessSnapshot)
+		}
+	})
+}

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -285,14 +285,22 @@ type TraversedAssoc struct {
 	TargetID string `json:"target_id"`
 }
 
+// AccessSnapshotEntry records a single memory's rank and score at retrieval time.
+type AccessSnapshotEntry struct {
+	MemoryID string  `json:"memory_id"`
+	Rank     int     `json:"rank"`
+	Score    float32 `json:"score"`
+}
+
 // RetrievalFeedback records a query's traversal path for feedback processing.
 type RetrievalFeedback struct {
-	QueryID         string           `json:"query_id"`
-	QueryText       string           `json:"query_text"`
-	RetrievedIDs    []string         `json:"retrieved_ids"`
-	TraversedAssocs []TraversedAssoc `json:"traversed_assocs"`
-	Feedback        string           `json:"feedback"`
-	CreatedAt       time.Time        `json:"created_at"`
+	QueryID         string                `json:"query_id"`
+	QueryText       string                `json:"query_text"`
+	RetrievedIDs    []string              `json:"retrieved_ids"`
+	TraversedAssocs []TraversedAssoc      `json:"traversed_assocs"`
+	AccessSnapshot  []AccessSnapshotEntry `json:"access_snapshot,omitempty"` // ranked memories at query time
+	Feedback        string                `json:"feedback"`
+	CreatedAt       time.Time             `json:"created_at"`
 }
 
 // Store is the abstraction for persistent memory.


### PR DESCRIPTION
## Summary
- Adds `AccessSnapshotEntry` struct (memory_id, rank, score) and `AccessSnapshot` field to `RetrievalFeedback`
- Both MCP `recall` and REST API `/query` now capture the ranked snapshot when saving feedback records
- New `access_snapshot` JSON column in `retrieval_feedback` table with idempotent migration for existing DBs
- 3 new tests covering round-trip, backward compat, and update-preserves-snapshot

## Test plan
- [x] `make build` compiles clean
- [x] `make test` — all tests pass including new `TestRetrievalFeedbackAccessSnapshot`
- [x] `make check` (go fmt + go vet) clean
- [x] `golangci-lint run` — 0 issues

Closes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)