### PR TITLE
feat: externalize perception and encoding tunables to config

### DIFF
--- a/cmd/mnemonic/main.go
+++ b/cmd/mnemonic/main.go
@@ -1349,18 +1349,7 @@ func serveCommand(configPath string) {
 	// --- Start encoding agent ---
 	var encoder *encoding.EncodingAgent
 	if cfg.Encoding.Enabled {
-		encoder = encoding.NewEncodingAgentWithConfig(memStore, wrap("encoding"), log, encoding.EncodingConfig{
-			PollingInterval:         5 * time.Second,
-			SimilarityThreshold:     0.3,
-			MaxSimilarSearchResults: cfg.Encoding.FindSimilarLimit,
-			CompletionMaxTokens:     cfg.Encoding.CompletionMaxTokens,
-			CompletionTemperature:   float32(cfg.LLM.Temperature),
-			MaxConcurrentEncodings:  cfg.Encoding.MaxConcurrentEncodings,
-			EnableLLMClassification: cfg.Encoding.EnableLLMClassification,
-			CoachingFile:            cfg.Coaching.CoachingFile,
-			ExcludePatterns:         cfg.Perception.Filesystem.ExcludePatterns,
-			ConceptVocabulary:       cfg.Encoding.ConceptVocabulary,
-		})
+		encoder = encoding.NewEncodingAgentWithConfig(memStore, wrap("encoding"), log, buildEncodingConfig(cfg))
 		if err := encoder.Start(rootCtx, bus); err != nil {
 			log.Error("failed to start encoding agent", "error", err)
 		} else {
@@ -1455,10 +1444,23 @@ func serveCommand(configPath string) {
 						MaxContentLength:   cfg.Perception.Heuristics.MaxContentLength,
 						FrequencyThreshold: cfg.Perception.Heuristics.FrequencyThreshold,
 						FrequencyWindowMin: cfg.Perception.Heuristics.FrequencyWindowMin,
+						PassScore:          float32(cfg.Perception.HeuristicPassScore),
+						BatchEditWindowSec: cfg.Perception.BatchEditWindowSec,
+						BatchEditThreshold: cfg.Perception.BatchEditThreshold,
+						RecallBoostMax:     float32(cfg.Perception.RecallBoostMax),
+						RecallBoostMinutes: cfg.Perception.RecallBoostWindowMin,
 					},
 					LLMGatingEnabled:      cfg.Perception.LLMGatingEnabled,
 					LearnedExclusionsPath: cfg.Perception.LearnedExclusionsPath,
 					ProjectResolver:       projectResolver,
+					ContentDedupTTLSec:    cfg.Perception.ContentDedupTTLSec,
+					GitOpCooldownSec:      cfg.Perception.GitOpCooldownSec,
+					MaxRawContentLen:      cfg.Perception.MaxRawContentLen,
+					LLMGateSnippetLen:     cfg.Perception.LLMGateSnippetLen,
+					LLMGateTimeoutSec:     cfg.Perception.LLMGateTimeoutSec,
+					RejectionThreshold:    cfg.Perception.RejectionThreshold,
+					RejectionWindowMin:    cfg.Perception.RejectionWindowMin,
+					RejectionMaxPromoted:  cfg.Perception.RejectionMaxPromoted,
 				},
 				log,
 			)
@@ -1811,18 +1813,7 @@ func rememberCommand(configPath, text string) {
 	bus := events.NewInMemoryBus(100)
 	defer func() { _ = bus.Close() }()
 
-	encoder := encoding.NewEncodingAgentWithConfig(db, llmProvider, log, encoding.EncodingConfig{
-		PollingInterval:         5 * time.Second,
-		SimilarityThreshold:     0.3,
-		MaxSimilarSearchResults: cfg.Encoding.FindSimilarLimit,
-		CompletionMaxTokens:     cfg.Encoding.CompletionMaxTokens,
-		CompletionTemperature:   float32(cfg.LLM.Temperature),
-		MaxConcurrentEncodings:  cfg.Encoding.MaxConcurrentEncodings,
-		EnableLLMClassification: cfg.Encoding.EnableLLMClassification,
-		CoachingFile:            cfg.Coaching.CoachingFile,
-		ExcludePatterns:         cfg.Perception.Filesystem.ExcludePatterns,
-		ConceptVocabulary:       cfg.Encoding.ConceptVocabulary,
-	})
+	encoder := encoding.NewEncodingAgentWithConfig(db, llmProvider, log, buildEncodingConfig(cfg))
 	if err := encoder.Start(encodeCtx, bus); err != nil {
 		fmt.Fprintf(os.Stderr, "Error starting encoder: %v\n", err)
 		os.Exit(1)
@@ -2503,18 +2494,7 @@ func mcpCommand(configPath string) {
 	defer func() { _ = bus.Close() }()
 
 	// Create encoding agent so remembered memories get encoded
-	encoder := encoding.NewEncodingAgentWithConfig(db, llmProvider, log, encoding.EncodingConfig{
-		PollingInterval:         5 * time.Second,
-		SimilarityThreshold:     0.3,
-		MaxSimilarSearchResults: cfg.Encoding.FindSimilarLimit,
-		CompletionMaxTokens:     cfg.Encoding.CompletionMaxTokens,
-		CompletionTemperature:   float32(cfg.LLM.Temperature),
-		MaxConcurrentEncodings:  cfg.Encoding.MaxConcurrentEncodings,
-		EnableLLMClassification: cfg.Encoding.EnableLLMClassification,
-		CoachingFile:            cfg.Coaching.CoachingFile,
-		ExcludePatterns:         cfg.Perception.Filesystem.ExcludePatterns,
-		ConceptVocabulary:       cfg.Encoding.ConceptVocabulary,
-	})
+	encoder := encoding.NewEncodingAgentWithConfig(db, llmProvider, log, buildEncodingConfig(cfg))
 	if err := encoder.Start(ctx, bus); err != nil {
 		log.Error("failed to start encoding agent for MCP", "error", err)
 	}
@@ -2730,6 +2710,39 @@ func autopilotCommand(configPath string) {
 	}
 
 	fmt.Println()
+}
+
+// buildEncodingConfig translates central config into the encoding agent's config struct.
+func buildEncodingConfig(cfg *config.Config) encoding.EncodingConfig {
+	pollingInterval := time.Duration(cfg.Encoding.PollingIntervalSec) * time.Second
+	if pollingInterval <= 0 {
+		pollingInterval = 5 * time.Second
+	}
+	simThreshold := float32(cfg.Encoding.SimilarityThreshold)
+	if simThreshold <= 0 {
+		simThreshold = 0.3
+	}
+	return encoding.EncodingConfig{
+		PollingInterval:         pollingInterval,
+		SimilarityThreshold:     simThreshold,
+		MaxSimilarSearchResults: cfg.Encoding.FindSimilarLimit,
+		CompletionMaxTokens:     cfg.Encoding.CompletionMaxTokens,
+		CompletionTemperature:   float32(cfg.LLM.Temperature),
+		MaxConcurrentEncodings:  cfg.Encoding.MaxConcurrentEncodings,
+		EnableLLMClassification: cfg.Encoding.EnableLLMClassification,
+		CoachingFile:            cfg.Coaching.CoachingFile,
+		ExcludePatterns:         cfg.Perception.Filesystem.ExcludePatterns,
+		ConceptVocabulary:       cfg.Encoding.ConceptVocabulary,
+		MaxRetries:              cfg.Encoding.MaxRetries,
+		MaxLLMContentChars:      cfg.Encoding.MaxLLMContentChars,
+		MaxEmbeddingChars:       cfg.Encoding.MaxEmbeddingChars,
+		TemporalWindowMin:       cfg.Encoding.TemporalWindowMin,
+		BackoffThreshold:        cfg.Encoding.BackoffThreshold,
+		BackoffBaseSec:          cfg.Encoding.BackoffBaseSec,
+		BackoffMaxSec:           cfg.Encoding.BackoffMaxSec,
+		BatchSizeEvent:          cfg.Encoding.BatchSizeEvent,
+		BatchSizePoll:           cfg.Encoding.BatchSizePoll,
+	}
 }
 
 // newLLMProvider creates the appropriate LLM provider based on config.

--- a/internal/agent/encoding/agent.go
+++ b/internal/agent/encoding/agent.go
@@ -20,8 +20,8 @@ import (
 	"github.com/appsprout-dev/mnemonic/internal/watcher/filesystem"
 )
 
-// maxRetries is the number of encoding attempts before a raw memory is skipped.
-const maxRetries = 3
+// defaultMaxRetries is the default number of encoding attempts before a raw memory is skipped.
+const defaultMaxRetries = 3
 
 // EncodingAgent transforms raw memories into encoded, searchable memory units.
 // It performs compression, concept extraction, embedding generation, and association creation.
@@ -61,6 +61,15 @@ type EncodingConfig struct {
 	CoachingFile            string   // path to coaching.yaml; empty = no coaching
 	ExcludePatterns         []string // paths matching these patterns are skipped (defense-in-depth)
 	ConceptVocabulary       []string // controlled vocabulary for concept extraction; empty = free-form
+	MaxRetries              int      // encoding attempts before skipping (default: 3)
+	MaxLLMContentChars      int      // max chars sent to LLM for compression (default: 8000)
+	MaxEmbeddingChars       int      // max chars sent to embedding model (default: 4000)
+	TemporalWindowMin       int      // minutes for temporal relationship detection (default: 5)
+	BackoffThreshold        int      // consecutive failures before backoff (default: 3)
+	BackoffBaseSec          int      // base backoff per failure in seconds (default: 30)
+	BackoffMaxSec           int      // maximum backoff in seconds (default: 300)
+	BatchSizeEvent          int      // batch size for EncodeAllPending (default: 50)
+	BatchSizePoll           int      // batch size for polling loop (default: 10)
 }
 
 // DefaultConceptVocabulary is the default controlled vocabulary for concept extraction.
@@ -95,6 +104,15 @@ func DefaultConfig() EncodingConfig {
 		MaxConcurrentEncodings:  1,
 		EnableLLMClassification: false,
 		ConceptVocabulary:       DefaultConceptVocabulary,
+		MaxRetries:              3,
+		MaxLLMContentChars:      8000,
+		MaxEmbeddingChars:       4000,
+		TemporalWindowMin:       5,
+		BackoffThreshold:        3,
+		BackoffBaseSec:          30,
+		BackoffMaxSec:           300,
+		BatchSizeEvent:          50,
+		BatchSizePoll:           10,
 	}
 }
 
@@ -216,6 +234,80 @@ func NewEncodingAgentWithConfig(s store.Store, llmProv llm.Provider, log *slog.L
 	return ea
 }
 
+// maxRetries returns the configured max retries, falling back to the default.
+func (ea *EncodingAgent) maxRetries() int {
+	if ea.config.MaxRetries > 0 {
+		return ea.config.MaxRetries
+	}
+	return defaultMaxRetries
+}
+
+// maxLLMContent returns the configured max LLM content chars, falling back to the default.
+func (ea *EncodingAgent) maxLLMContent() int {
+	if ea.config.MaxLLMContentChars > 0 {
+		return ea.config.MaxLLMContentChars
+	}
+	return defaultMaxLLMContentChars
+}
+
+// maxEmbedding returns the configured max embedding chars, falling back to the default.
+func (ea *EncodingAgent) maxEmbedding() int {
+	if ea.config.MaxEmbeddingChars > 0 {
+		return ea.config.MaxEmbeddingChars
+	}
+	return defaultMaxEmbeddingChars
+}
+
+// temporalWindow returns the configured temporal relationship window.
+func (ea *EncodingAgent) temporalWindow() time.Duration {
+	if ea.config.TemporalWindowMin > 0 {
+		return time.Duration(ea.config.TemporalWindowMin) * time.Minute
+	}
+	return 5 * time.Minute
+}
+
+// backoffThreshold returns the configured consecutive failure threshold for backoff.
+func (ea *EncodingAgent) backoffThreshold() int {
+	if ea.config.BackoffThreshold > 0 {
+		return ea.config.BackoffThreshold
+	}
+	return 3
+}
+
+// backoffDuration calculates the backoff duration for a given number of consecutive failures.
+func (ea *EncodingAgent) backoffDuration(consecutiveFailures int) time.Duration {
+	baseSec := ea.config.BackoffBaseSec
+	if baseSec <= 0 {
+		baseSec = 30
+	}
+	maxSec := ea.config.BackoffMaxSec
+	if maxSec <= 0 {
+		maxSec = 300
+	}
+	backoff := time.Duration(consecutiveFailures) * time.Duration(baseSec) * time.Second
+	maxBackoff := time.Duration(maxSec) * time.Second
+	if backoff > maxBackoff {
+		backoff = maxBackoff
+	}
+	return backoff
+}
+
+// batchSizeEvent returns the configured batch size for EncodeAllPending.
+func (ea *EncodingAgent) batchSizeEvent() int {
+	if ea.config.BatchSizeEvent > 0 {
+		return ea.config.BatchSizeEvent
+	}
+	return 50
+}
+
+// batchSizePoll returns the configured batch size for the polling loop.
+func (ea *EncodingAgent) batchSizePoll() int {
+	if ea.config.BatchSizePoll > 0 {
+		return ea.config.BatchSizePoll
+	}
+	return 10
+}
+
 // Name returns the agent's identifier.
 func (ea *EncodingAgent) Name() string {
 	return ea.name
@@ -279,7 +371,7 @@ func (ea *EncodingAgent) Stop() error {
 func (ea *EncodingAgent) EncodeAllPending(ctx context.Context) (int, error) {
 	encoded := 0
 	for {
-		unprocessed, err := ea.store.ListRawUnprocessed(ctx, 50)
+		unprocessed, err := ea.store.ListRawUnprocessed(ctx, ea.batchSizeEvent())
 		if err != nil {
 			return encoded, fmt.Errorf("listing unprocessed: %w", err)
 		}
@@ -361,7 +453,7 @@ func (ea *EncodingAgent) handleRawMemoryCreated(ctx context.Context, event event
 			count := ea.failureCounts[e.ID]
 			ea.processingMutex.Unlock()
 
-			if count >= maxRetries {
+			if count >= ea.maxRetries() {
 				ea.log.Warn("encoding permanently failed from event, marking as processed",
 					"raw_id", e.ID, "attempts", count, "error", err)
 				_ = ea.store.MarkRawProcessed(ea.ctx, e.ID)
@@ -422,7 +514,7 @@ func (ea *EncodingAgent) pollAndProcessRawMemories(ctx context.Context) error {
 	ea.backoffUntil = time.Time{} // clear backoff
 	ea.processingMutex.Unlock()
 
-	unprocessed, err := ea.store.ListRawUnprocessed(ctx, 10)
+	unprocessed, err := ea.store.ListRawUnprocessed(ctx, ea.batchSizePoll())
 	if err != nil {
 		return fmt.Errorf("failed to list unprocessed raw memories: %w", err)
 	}
@@ -452,7 +544,7 @@ func (ea *EncodingAgent) pollAndProcessRawMemories(ctx context.Context) error {
 		// Skip memories that have exceeded max retries
 		ea.processingMutex.Lock()
 		retries := ea.failureCounts[raw.ID]
-		if retries >= maxRetries {
+		if retries >= ea.maxRetries() {
 			delete(ea.failureCounts, raw.ID) // clean up stale entry
 			ea.processingMutex.Unlock()
 			continue
@@ -476,7 +568,7 @@ func (ea *EncodingAgent) pollAndProcessRawMemories(ctx context.Context) error {
 
 			consecutiveFailures++
 
-			if count >= maxRetries {
+			if count >= ea.maxRetries() {
 				ea.log.Warn("encoding permanently failed, marking as processed",
 					"raw_id", raw.ID, "attempts", count, "error", err)
 				// Mark as processed so it stops retrying
@@ -487,16 +579,13 @@ func (ea *EncodingAgent) pollAndProcessRawMemories(ctx context.Context) error {
 				ea.processingMutex.Unlock()
 			} else {
 				ea.log.Warn("encoding failed, will retry later",
-					"raw_id", raw.ID, "attempt", count, "max", maxRetries, "error", err)
+					"raw_id", raw.ID, "attempt", count, "max", ea.maxRetries(), "error", err)
 			}
 
 			// If all attempts in this batch are failing, the LLM is probably
 			// down — apply backoff to avoid hammering it
-			if consecutiveFailures >= 3 {
-				backoff := time.Duration(consecutiveFailures) * 30 * time.Second
-				if backoff > 5*time.Minute {
-					backoff = 5 * time.Minute
-				}
+			if consecutiveFailures >= ea.backoffThreshold() {
+				backoff := ea.backoffDuration(consecutiveFailures)
 				ea.processingMutex.Lock()
 				ea.backoffUntil = time.Now().Add(backoff)
 				ea.processingMutex.Unlock()
@@ -553,7 +642,7 @@ func (ea *EncodingAgent) encodeMemory(ctx context.Context, rawID string) error {
 	ea.log.Debug("compression completed", "raw_id", raw.ID, "summary_length", len(compression.Summary))
 
 	// Step 3: Generate embedding (truncate to avoid exceeding model context)
-	embeddingText := agentutil.Truncate(compression.Summary+" "+compression.Content, maxEmbeddingChars)
+	embeddingText := agentutil.Truncate(compression.Summary+" "+compression.Content, ea.maxEmbedding())
 	embedding, err := ea.llmProvider.Embed(ctx, embeddingText)
 	if err != nil {
 		ea.log.Warn("failed to generate embedding", "raw_id", raw.ID, "error", err)
@@ -733,13 +822,11 @@ func (ea *EncodingAgent) encodeMemory(ctx context.Context, rawID string) error {
 	return nil
 }
 
-// maxLLMContentChars is the maximum characters of raw content to send to the LLM for compression.
-// This keeps the prompt well within typical small-model context windows.
-const maxLLMContentChars = 8000
+// defaultMaxLLMContentChars is the default maximum characters of raw content to send to the LLM for compression.
+const defaultMaxLLMContentChars = 8000
 
-// maxEmbeddingChars is the maximum characters to send to the embedding model.
-// Roughly ~500 tokens, well under the 2048 token limit of small embedding models.
-const maxEmbeddingChars = 4000
+// defaultMaxEmbeddingChars is the default maximum characters to send to the embedding model.
+const defaultMaxEmbeddingChars = 4000
 
 // stripHTMLTags removes HTML/XML tags and collapses whitespace to extract readable text.
 // This lets the LLM focus on actual content rather than markup.
@@ -807,7 +894,7 @@ func (ea *EncodingAgent) compressAndExtractConcepts(ctx context.Context, raw sto
 		}
 	}
 
-	truncatedContent := agentutil.Truncate(processedContent, maxLLMContentChars)
+	truncatedContent := agentutil.Truncate(processedContent, ea.maxLLMContent())
 
 	// Gather contextual information for richer encoding
 	episodeCtx := ea.getEpisodeContext(ctx, raw)
@@ -1012,7 +1099,7 @@ func (ea *EncodingAgent) fallbackCompression(raw store.RawMemory) *compressionRe
 	return &compressionResponse{
 		Gist:               truncateString(summary, 60),
 		Summary:            summary,
-		Content:            agentutil.Truncate(raw.Content, maxLLMContentChars),
+		Content:            agentutil.Truncate(raw.Content, ea.maxLLMContent()),
 		Narrative:          "",
 		Concepts:           concepts,
 		StructuredConcepts: nil,
@@ -1153,7 +1240,7 @@ var validRelationTypes = map[string]bool{
 // It uses heuristics only (no LLM calls) for efficiency.
 func (ea *EncodingAgent) classifyRelationship(ctx context.Context, compression *compressionResponse, existing store.Memory, raw store.RawMemory) string {
 	// Heuristic 1: Temporal relationship — same source, close timestamps
-	if isTemporalRelationship(raw, existing) {
+	if isTemporalRelationship(raw, existing, ea.temporalWindow()) {
 		ea.log.Debug("temporal relationship detected", "raw_source", raw.Source, "existing_id", existing.ID)
 		return "temporal"
 	}
@@ -1173,13 +1260,13 @@ func (ea *EncodingAgent) classifyRelationship(ctx context.Context, compression *
 }
 
 // isTemporalRelationship detects if two memories are temporally adjacent.
-func isTemporalRelationship(raw store.RawMemory, existing store.Memory) bool {
+func isTemporalRelationship(raw store.RawMemory, existing store.Memory, window time.Duration) bool {
 	timeDiff := raw.Timestamp.Sub(existing.Timestamp)
 	if timeDiff < 0 {
 		timeDiff = -timeDiff
 	}
-	// Same source and within 5 minutes
-	return raw.Source != "" && timeDiff > 0 && timeDiff < 5*time.Minute
+	// Same source and within the configured temporal window
+	return raw.Source != "" && timeDiff > 0 && timeDiff < window
 }
 
 // hasOverlappingConcepts checks if two concept lists share at least minOverlap concepts.

--- a/internal/agent/encoding/agent_test.go
+++ b/internal/agent/encoding/agent_test.go
@@ -621,7 +621,7 @@ func TestIsTemporalRelationship(t *testing.T) {
 		raw := store.RawMemory{Source: "terminal", Timestamp: now}
 		existing := store.Memory{Timestamp: now.Add(-2 * time.Minute)}
 
-		if !isTemporalRelationship(raw, existing) {
+		if !isTemporalRelationship(raw, existing, 5*time.Minute) {
 			t.Error("expected temporal relationship for same source within 5 min")
 		}
 	})
@@ -630,7 +630,7 @@ func TestIsTemporalRelationship(t *testing.T) {
 		raw := store.RawMemory{Source: "terminal", Timestamp: now}
 		existing := store.Memory{Timestamp: now.Add(-10 * time.Minute)}
 
-		if isTemporalRelationship(raw, existing) {
+		if isTemporalRelationship(raw, existing, 5*time.Minute) {
 			t.Error("did not expect temporal relationship for > 5 min apart")
 		}
 	})
@@ -639,7 +639,7 @@ func TestIsTemporalRelationship(t *testing.T) {
 		raw := store.RawMemory{Source: "terminal", Timestamp: now}
 		existing := store.Memory{Timestamp: now}
 
-		if isTemporalRelationship(raw, existing) {
+		if isTemporalRelationship(raw, existing, 5*time.Minute) {
 			t.Error("did not expect temporal relationship for zero time diff")
 		}
 	})
@@ -648,7 +648,7 @@ func TestIsTemporalRelationship(t *testing.T) {
 		raw := store.RawMemory{Source: "", Timestamp: now}
 		existing := store.Memory{Timestamp: now.Add(-1 * time.Minute)}
 
-		if isTemporalRelationship(raw, existing) {
+		if isTemporalRelationship(raw, existing, 5*time.Minute) {
 			t.Error("did not expect temporal relationship for empty source")
 		}
 	})
@@ -657,7 +657,7 @@ func TestIsTemporalRelationship(t *testing.T) {
 		raw := store.RawMemory{Source: "terminal", Timestamp: now}
 		existing := store.Memory{Timestamp: now.Add(2 * time.Minute)}
 
-		if !isTemporalRelationship(raw, existing) {
+		if !isTemporalRelationship(raw, existing, 5*time.Minute) {
 			t.Error("expected temporal relationship regardless of order")
 		}
 	})

--- a/internal/agent/perception/agent.go
+++ b/internal/agent/perception/agent.go
@@ -32,13 +32,23 @@ type PerceptionConfig struct {
 	LLMGatingEnabled      bool            // if false, skip LLM and use heuristic score as salience
 	LearnedExclusionsPath string          // file path for persisting learned watcher exclusions
 	ProjectResolver       ProjectResolver // optional: maps paths to canonical project names
+	ContentDedupTTLSec    int             // how long to remember content hashes for dedup (default: 5)
+	GitOpCooldownSec      int             // suppress fs events after git ops for this many seconds (default: 10)
+	MaxRawContentLen      int             // max chars stored per raw memory (default: 10000)
+	LLMGateSnippetLen     int             // max chars sent to LLM gate (default: 500)
+	LLMGateTimeoutSec     int             // timeout for LLM gating call in seconds (default: 10)
+	HeuristicPassScore    float32         // minimum heuristic score to pass (default: 0.2)
+	BatchEditWindowSec    int             // seconds window for batch edit detection (default: 5)
+	BatchEditThreshold    int             // edits in window to count as batch (default: 3)
+	RecallBoostWindowMin  int             // minutes recall boost decays over (default: 30)
+	RecallBoostMax        float32         // max recall salience boost (default: 0.2)
+	RejectionThreshold    int             // rejections before auto-exclusion (default: 50)
+	RejectionWindowMin    int             // window in minutes for rejection tracking (default: 60)
+	RejectionMaxPromoted  int             // cap on auto-exclusions per session (default: 20)
 }
 
-// recentContentTTL is how long to remember content hashes for dedup.
-// This prevents duplicate raw memories when the filesystem watcher emits
-// multiple events for the same file content within a short window
-// (e.g., atomic saves producing Created+Renamed then Modified events).
-const recentContentTTL = 5 * time.Second
+// defaultContentDedupTTL is the default duration for content-hash dedup.
+const defaultContentDedupTTL = 5 * time.Second
 
 // PerceptionAgent orchestrates the perception pipeline: watchers → heuristic → LLM → memory.
 type PerceptionAgent struct {
@@ -75,6 +85,10 @@ func NewPerceptionAgent(
 	cfg PerceptionConfig,
 	log *slog.Logger,
 ) *PerceptionAgent {
+	gitCooldown := time.Duration(cfg.GitOpCooldownSec) * time.Second
+	if gitCooldown <= 0 {
+		gitCooldown = 10 * time.Second
+	}
 	return &PerceptionAgent{
 		name:          "perception",
 		watchers:      watchers,
@@ -82,7 +96,7 @@ func NewPerceptionAgent(
 		llmProvider:   llmProv,
 		cfg:           cfg,
 		log:           log,
-		gitOpCooldown: 10 * time.Second,
+		gitOpCooldown: gitCooldown,
 	}
 }
 
@@ -108,6 +122,9 @@ func (pa *PerceptionAgent) Start(ctx context.Context, bus events.Bus) error {
 	pa.heuristicFilter = NewHeuristicFilter(pa.cfg.HeuristicConfig, pa.log)
 	pa.rejectionTracker = newRejectionTracker(
 		rejectionTrackerConfig{
+			Threshold:   pa.cfg.RejectionThreshold,
+			Window:      time.Duration(pa.cfg.RejectionWindowMin) * time.Minute,
+			MaxPromoted: pa.cfg.RejectionMaxPromoted,
 			PersistPath: pa.cfg.LearnedExclusionsPath,
 		},
 		pa.log,
@@ -256,11 +273,28 @@ func contentHash(source, path, content string) string {
 	return hex.EncodeToString(h.Sum(nil)[:16]) // 128 bits is plenty for dedup
 }
 
+// contentDedupTTL returns the configured content dedup TTL, falling back to the default.
+func (pa *PerceptionAgent) contentDedupTTL() time.Duration {
+	if pa.cfg.ContentDedupTTLSec > 0 {
+		return time.Duration(pa.cfg.ContentDedupTTLSec) * time.Second
+	}
+	return defaultContentDedupTTL
+}
+
+// maxRawContentLen returns the configured max raw content length, falling back to 10000.
+func (pa *PerceptionAgent) maxRawContentLen() int {
+	if pa.cfg.MaxRawContentLen > 0 {
+		return pa.cfg.MaxRawContentLen
+	}
+	return 10000
+}
+
 // cleanupRecentContent periodically evicts expired entries from the dedup map.
 func (pa *PerceptionAgent) cleanupRecentContent(ctx context.Context) {
 	defer pa.processingWg.Done()
 	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
+	ttl := pa.contentDedupTTL()
 	for {
 		select {
 		case <-ctx.Done():
@@ -269,7 +303,7 @@ func (pa *PerceptionAgent) cleanupRecentContent(ctx context.Context) {
 			now := time.Now()
 			pa.recentContentMu.Lock()
 			for k, ts := range pa.recentContent {
-				if now.Sub(ts) > recentContentTTL {
+				if now.Sub(ts) > ttl {
 					delete(pa.recentContent, k)
 				}
 			}
@@ -353,7 +387,7 @@ func (pa *PerceptionAgent) processEvent(ctx context.Context, event Event) {
 		ID:              uuid.New().String(),
 		Source:          event.Source,
 		Type:            event.Type,
-		Content:         pa.truncateContent(event.Content, 10000),
+		Content:         pa.truncateContent(event.Content, pa.maxRawContentLen()),
 		Timestamp:       event.Timestamp,
 		CreatedAt:       time.Now(),
 		Metadata:        pa.mergeMetadata(event.Metadata, event.Path, heuristicResult.Score),
@@ -407,9 +441,13 @@ func (pa *PerceptionAgent) callLLMGate(
 	heuristicScore float32,
 ) (*llmGateResult, error) {
 	// Build the prompt
+	snippetLen := pa.cfg.LLMGateSnippetLen
+	if snippetLen <= 0 {
+		snippetLen = 500
+	}
 	contentSnippet := event.Content
-	if len(contentSnippet) > 500 {
-		contentSnippet = contentSnippet[:500]
+	if len(contentSnippet) > snippetLen {
+		contentSnippet = contentSnippet[:snippetLen]
 	}
 
 	prompt := fmt.Sprintf(`You are a memory perception system. Evaluate if this observation is worth remembering.
@@ -446,7 +484,11 @@ Salience 0.0-1.0: Higher for errors, decisions, insights, creative work. Lower f
 	}
 
 	// Call LLM with context timeout
-	llmCtx, cancel := context.WithTimeout(ctx, 10*time.Second)
+	gateTimeout := time.Duration(pa.cfg.LLMGateTimeoutSec) * time.Second
+	if gateTimeout <= 0 {
+		gateTimeout = 10 * time.Second
+	}
+	llmCtx, cancel := context.WithTimeout(ctx, gateTimeout)
 	defer cancel()
 
 	resp, err := pa.llmProvider.Complete(llmCtx, req)

--- a/internal/agent/perception/heuristic.go
+++ b/internal/agent/perception/heuristic.go
@@ -11,10 +11,15 @@ import (
 
 // HeuristicConfig defines the configuration for the heuristic pre-filter.
 type HeuristicConfig struct {
-	MinContentLength   int // minimum content length to pass
-	MaxContentLength   int // maximum content length to pass
-	FrequencyThreshold int // skip if seen >N times in window
-	FrequencyWindowMin int // window size in minutes
+	MinContentLength   int     // minimum content length to pass
+	MaxContentLength   int     // maximum content length to pass
+	FrequencyThreshold int     // skip if seen >N times in window
+	FrequencyWindowMin int     // window size in minutes
+	PassScore          float32 // minimum score to pass filter (default: 0.2)
+	BatchEditWindowSec int     // seconds window for batch edit detection (default: 5)
+	BatchEditThreshold int     // edits in window to count as batch (default: 3)
+	RecallBoostMax     float32 // max recall salience boost (default: 0.2)
+	RecallBoostMinutes int     // minutes recall boost decays over (default: 30)
 }
 
 // HeuristicResult represents the outcome of a heuristic evaluation.
@@ -181,13 +186,17 @@ func (h *HeuristicFilter) Evaluate(event Event) HeuristicResult {
 		score = 0.0
 	}
 
-	// 7. Pass threshold check (>= 0.2)
+	// 7. Pass threshold check
+	passScore := h.cfg.PassScore
+	if passScore <= 0 {
+		passScore = 0.2
+	}
 	rationale := sourceRationale
 	if keywordMatches > 0 {
 		rationale += fmt.Sprintf("; found %d high-signal keywords", keywordMatches)
 	}
 
-	passed := score >= 0.2
+	passed := score >= passScore
 	return HeuristicResult{
 		Pass:      passed,
 		Score:     score,
@@ -475,8 +484,12 @@ func (h *HeuristicFilter) IsBatchEdit(path string, timestamp time.Time) (bool, i
 	h.editMu.Lock()
 	defer h.editMu.Unlock()
 
-	// Batch window: edits within 5 seconds are considered a batch
-	batchWindow := 5 * time.Second
+	// Batch window: edits within the configured window are considered a batch
+	windowSec := h.cfg.BatchEditWindowSec
+	if windowSec <= 0 {
+		windowSec = 5
+	}
+	batchWindow := time.Duration(windowSec) * time.Second
 	cutoff := timestamp.Add(-batchWindow)
 
 	// Clean old entries and count recent edits
@@ -491,8 +504,11 @@ func (h *HeuristicFilter) IsBatchEdit(path string, timestamp time.Time) (bool, i
 	recent = append(recent, recentEdit{path: path, timestamp: timestamp})
 	h.recentEdits = recent
 
-	// If 3+ edits in the window, it's a batch
-	batchThreshold := 3
+	// If edits meet the threshold, it's a batch
+	batchThreshold := h.cfg.BatchEditThreshold
+	if batchThreshold <= 0 {
+		batchThreshold = 3
+	}
 	if len(recent) >= batchThreshold {
 		return true, len(recent)
 	}
@@ -524,14 +540,23 @@ func (h *HeuristicFilter) GetRecallBoost(path string) float32 {
 		return 0
 	}
 
-	// Boost decays over 30 minutes
+	// Boost decays over the configured window
+	boostMinutes := h.cfg.RecallBoostMinutes
+	if boostMinutes <= 0 {
+		boostMinutes = 30
+	}
+	boostWindow := time.Duration(boostMinutes) * time.Minute
 	elapsed := time.Since(recallTime)
-	if elapsed > 30*time.Minute {
+	if elapsed > boostWindow {
 		return 0
 	}
 
-	// Linear decay: 0.2 → 0 over 30 minutes
-	boost := float32(0.2) * float32(1.0-elapsed.Seconds()/(30*60))
+	// Linear decay: max → 0 over window
+	maxBoost := h.cfg.RecallBoostMax
+	if maxBoost <= 0 {
+		maxBoost = 0.2
+	}
+	boost := maxBoost * float32(1.0-elapsed.Seconds()/boostWindow.Seconds())
 	return boost
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -87,6 +87,19 @@ type PerceptionConfig struct {
 	Terminal              TerminalPerceptionConfig   `yaml:"terminal"`
 	Clipboard             ClipboardPerceptionConfig  `yaml:"clipboard"`
 	Heuristics            HeuristicsConfig           `yaml:"heuristics"`
+	ContentDedupTTLSec    int                        `yaml:"content_dedup_ttl_sec"`    // how long to remember content hashes for dedup (default: 5)
+	GitOpCooldownSec      int                        `yaml:"git_op_cooldown_sec"`      // suppress fs events after git ops for this many seconds (default: 10)
+	MaxRawContentLen      int                        `yaml:"max_raw_content_len"`      // max chars stored per raw memory (default: 10000)
+	LLMGateSnippetLen     int                        `yaml:"llm_gate_snippet_len"`     // max chars sent to LLM gate (default: 500)
+	LLMGateTimeoutSec     int                        `yaml:"llm_gate_timeout_sec"`     // timeout for LLM gating call (default: 10)
+	HeuristicPassScore    float64                    `yaml:"heuristic_pass_score"`     // minimum heuristic score to pass (default: 0.2)
+	BatchEditWindowSec    int                        `yaml:"batch_edit_window_sec"`    // seconds window for batch edit detection (default: 5)
+	BatchEditThreshold    int                        `yaml:"batch_edit_threshold"`     // edits in window to count as batch (default: 3)
+	RecallBoostWindowMin  int                        `yaml:"recall_boost_window_min"`  // minutes recall boost decays over (default: 30)
+	RecallBoostMax        float64                    `yaml:"recall_boost_max"`         // max recall salience boost (default: 0.2)
+	RejectionThreshold    int                        `yaml:"rejection_threshold"`      // rejections before auto-exclusion (default: 50)
+	RejectionWindowMin    int                        `yaml:"rejection_window_min"`     // window in minutes for rejection tracking (default: 60)
+	RejectionMaxPromoted  int                        `yaml:"rejection_max_promoted"`   // cap on auto-exclusions per session (default: 20)
 }
 
 // FilesystemPerceptionConfig holds filesystem perception settings.
@@ -147,6 +160,17 @@ type EncodingConfig struct {
 	EnableLLMClassification  bool     `yaml:"enable_llm_classification"`
 	CompletionMaxTokens      int      `yaml:"completion_max_tokens"`
 	ConceptVocabulary        []string `yaml:"concept_vocabulary"`
+	SimilarityThreshold      float64  `yaml:"similarity_threshold"`       // min cosine similarity for associations (default: 0.3)
+	PollingIntervalSec       int      `yaml:"polling_interval_sec"`       // seconds between unprocessed-memory polls (default: 5)
+	MaxRetries               int      `yaml:"max_retries"`                // encoding attempts before skipping (default: 3)
+	MaxLLMContentChars       int      `yaml:"max_llm_content_chars"`      // max chars sent to LLM for compression (default: 8000)
+	MaxEmbeddingChars        int      `yaml:"max_embedding_chars"`        // max chars sent to embedding model (default: 4000)
+	TemporalWindowMin        int      `yaml:"temporal_window_min"`        // minutes for temporal relationship detection (default: 5)
+	BackoffThreshold         int      `yaml:"backoff_threshold"`          // consecutive failures before backoff (default: 3)
+	BackoffBaseSec           int      `yaml:"backoff_base_sec"`           // base backoff per failure in seconds (default: 30)
+	BackoffMaxSec            int      `yaml:"backoff_max_sec"`            // maximum backoff in seconds (default: 300)
+	BatchSizeEvent           int      `yaml:"batch_size_event"`           // batch size for EncodeAllPending (default: 50)
+	BatchSizePoll            int      `yaml:"batch_size_poll"`            // batch size for polling loop (default: 10)
 }
 
 // ConsolidationConfig holds consolidation settings.
@@ -334,6 +358,19 @@ func Default() *Config {
 			Enabled:               true,
 			LLMGatingEnabled:      false,
 			LearnedExclusionsPath: "~/.mnemonic/learned-exclusions.txt",
+			ContentDedupTTLSec:    5,
+			GitOpCooldownSec:      10,
+			MaxRawContentLen:      10000,
+			LLMGateSnippetLen:     500,
+			LLMGateTimeoutSec:     10,
+			HeuristicPassScore:    0.2,
+			BatchEditWindowSec:    5,
+			BatchEditThreshold:    3,
+			RecallBoostWindowMin:  30,
+			RecallBoostMax:        0.2,
+			RejectionThreshold:    50,
+			RejectionWindowMin:    60,
+			RejectionMaxPromoted:  20,
 			Filesystem: FilesystemPerceptionConfig{
 				Enabled: true,
 				WatchDirs: []string{
@@ -419,6 +456,17 @@ func Default() *Config {
 			MaxConcurrentEncodings:   1,
 			EnableLLMClassification:  false,
 			CompletionMaxTokens:      1024,
+			SimilarityThreshold:      0.3,
+			PollingIntervalSec:       5,
+			MaxRetries:               3,
+			MaxLLMContentChars:       8000,
+			MaxEmbeddingChars:        4000,
+			TemporalWindowMin:        5,
+			BackoffThreshold:         3,
+			BackoffBaseSec:           30,
+			BackoffMaxSec:            300,
+			BatchSizeEvent:           50,
+			BatchSizePoll:            10,
 		},
 		Consolidation: ConsolidationConfig{
 			Enabled:             true,


### PR DESCRIPTION
## Summary
- **Perception** (13 tunables): dedup TTL, git cooldown, content truncation, LLM gate snippet/timeout, rejection tracker limits, heuristic pass score, batch edit window/threshold, recall boost window/max
- **Encoding** (9 tunables): max retries, LLM/embedding char limits, temporal window, backoff threshold/base/max, batch sizes
- All fields have zero-value fallbacks — no behavioral change for existing users
- Adds `buildEncodingConfig()` helper in main.go to deduplicate config mapping

## Test plan
- [x] `make build` compiles clean
- [x] `make test` — all tests pass (encoding test updated for new parameter)
- [x] `make check` (go fmt + go vet) clean
- [x] `golangci-lint run` — 0 issues

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)