### PR TITLE
feat: add implicit positive feedback from memory re-access

### DIFF
--- a/cmd/mnemonic/main.go
+++ b/cmd/mnemonic/main.go
@@ -1507,8 +1507,17 @@ func serveCommand(configPath string) {
 	// --- Start metacognition agent ---
 	var metaAgent *metacognition.MetacognitionAgent
 	if cfg.Metacognition.Enabled {
+		implicitWindow := 24 * time.Hour
+		if cfg.Metacognition.ImplicitFeedbackWindow != "" {
+			if d, err := time.ParseDuration(cfg.Metacognition.ImplicitFeedbackWindow); err == nil {
+				implicitWindow = d
+			}
+		}
 		metaAgent = metacognition.NewMetacognitionAgent(memStore, wrap("metacognition"), metacognition.MetacognitionConfig{
-			Interval: cfg.Metacognition.Interval,
+			Interval:                cfg.Metacognition.Interval,
+			ImplicitFeedbackEnabled: cfg.Metacognition.ImplicitFeedbackEnabled,
+			ImplicitFeedbackWindow:  implicitWindow,
+			ImplicitFeedbackScale:   cfg.Metacognition.ImplicitFeedbackScale,
 		}, log)
 
 		if err := metaAgent.Start(rootCtx, bus); err != nil {

--- a/internal/agent/metacognition/agent.go
+++ b/internal/agent/metacognition/agent.go
@@ -7,6 +7,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/appsprout-dev/mnemonic/internal/api/routes"
 	"github.com/appsprout-dev/mnemonic/internal/events"
 	"github.com/appsprout-dev/mnemonic/internal/llm"
 	"github.com/appsprout-dev/mnemonic/internal/store"
@@ -14,7 +15,10 @@ import (
 )
 
 type MetacognitionConfig struct {
-	Interval time.Duration
+	Interval                time.Duration
+	ImplicitFeedbackEnabled bool
+	ImplicitFeedbackWindow  time.Duration // how far back to look for unrated feedback (default 24h)
+	ImplicitFeedbackScale   float64       // magnitude multiplier vs explicit (default 0.5)
 }
 
 type MetacognitionAgent struct {
@@ -158,8 +162,11 @@ func (ma *MetacognitionAgent) runCycle(ctx context.Context) (*CycleReport, error
 	// --- Feedback processing phase: adjust associations and salience based on feedback ---
 	feedbackActions := ma.processFeedback(ctx)
 
+	// --- Implicit feedback: detect re-access of recalled memories ---
+	implicitActions := ma.processImplicitFeedback(ctx)
+
 	// --- Action phase: act on observations ---
-	actionsPerformed := ma.actOnObservations(ctx, observations) + feedbackActions
+	actionsPerformed := ma.actOnObservations(ctx, observations) + feedbackActions + implicitActions
 
 	if ma.bus != nil {
 		_ = ma.bus.Publish(ctx, events.MetaCycleCompleted{
@@ -626,6 +633,71 @@ func (ma *MetacognitionAgent) processFeedback(ctx context.Context) int {
 		ma.log.Info("feedback processing completed", "adjustments", actions)
 	}
 
+	return actions
+}
+
+// processImplicitFeedback finds unrated recall feedback records and checks if any
+// returned memories were re-accessed since the query. Re-access is treated as implicit
+// positive feedback at a reduced scale.
+func (ma *MetacognitionAgent) processImplicitFeedback(ctx context.Context) int {
+	if !ma.config.ImplicitFeedbackEnabled {
+		return 0
+	}
+
+	window := ma.config.ImplicitFeedbackWindow
+	if window == 0 {
+		window = 24 * time.Hour
+	}
+	scale := ma.config.ImplicitFeedbackScale
+	if scale == 0 {
+		scale = 0.5
+	}
+
+	// Look for unrated feedback between 1h and window-duration old
+	feedbacks, err := ma.store.ListUnratedFeedback(ctx, 1*time.Hour, window, 20)
+	if err != nil {
+		ma.log.Warn("failed to list unrated feedback for implicit processing", "error", err)
+		return 0
+	}
+
+	actions := 0
+	for _, fb := range feedbacks {
+		if len(fb.AccessSnapshot) == 0 {
+			continue
+		}
+
+		// Check if any memory from the snapshot was re-accessed since the query
+		reAccessed := false
+		for _, snap := range fb.AccessSnapshot {
+			mem, err := ma.store.GetMemory(ctx, snap.MemoryID)
+			if err != nil {
+				continue
+			}
+			// If the memory's last access is after the query time, it was re-accessed
+			if mem.LastAccessed.After(fb.CreatedAt) {
+				reAccessed = true
+				break
+			}
+		}
+
+		if !reAccessed {
+			continue
+		}
+
+		// Apply positive feedback at reduced scale
+		adj := routes.ApplyFeedbackAdjustments(ctx, ma.store, ma.log, fb, "helpful", scale)
+		actions += adj
+
+		// Mark the feedback record so we don't process it again
+		fb.Feedback = "implicit_helpful"
+		if err := ma.store.WriteRetrievalFeedback(ctx, fb); err != nil {
+			ma.log.Warn("failed to mark implicit feedback", "query_id", fb.QueryID, "error", err)
+		}
+	}
+
+	if actions > 0 {
+		ma.log.Info("implicit feedback processing completed", "adjustments", actions, "records_processed", len(feedbacks))
+	}
 	return actions
 }
 

--- a/internal/api/routes/feedback.go
+++ b/internal/api/routes/feedback.go
@@ -87,63 +87,7 @@ func HandleFeedback(s store.Store, log *slog.Logger) http.HandlerFunc {
 		fb.Feedback = req.Quality
 		_ = s.WriteRetrievalFeedback(ctx, fb)
 
-		switch req.Quality {
-		case "helpful":
-			// Strengthen traversed associations and boost returned memory salience
-			for _, ta := range fb.TraversedAssocs {
-				assocs, err := s.GetAssociations(ctx, ta.SourceID)
-				if err != nil {
-					continue
-				}
-				for _, a := range assocs {
-					if a.TargetID == ta.TargetID {
-						newStrength := a.Strength + feedbackStrengthDelta
-						if newStrength > 1.0 {
-							newStrength = 1.0
-						}
-						if err := s.UpdateAssociationStrength(ctx, ta.SourceID, ta.TargetID, newStrength); err == nil {
-							adjustments++
-						}
-						break
-					}
-				}
-			}
-			// Boost salience of returned memories
-			for _, memID := range fb.RetrievedIDs {
-				mem, err := s.GetMemory(ctx, memID)
-				if err != nil {
-					continue
-				}
-				newSalience := mem.Salience + feedbackSalienceBoost
-				if newSalience > 1.0 {
-					newSalience = 1.0
-				}
-				if err := s.UpdateSalience(ctx, memID, newSalience); err != nil {
-					log.Warn("failed to update salience", "memory_id", memID, "error", err)
-				}
-			}
-
-		case "irrelevant":
-			// Weaken traversed associations
-			for _, ta := range fb.TraversedAssocs {
-				assocs, err := s.GetAssociations(ctx, ta.SourceID)
-				if err != nil {
-					continue
-				}
-				for _, a := range assocs {
-					if a.TargetID == ta.TargetID {
-						newStrength := a.Strength - feedbackStrengthDelta
-						if newStrength < 0.05 {
-							newStrength = 0.05
-						}
-						if err := s.UpdateAssociationStrength(ctx, ta.SourceID, ta.TargetID, newStrength); err == nil {
-							adjustments++
-						}
-						break
-					}
-				}
-			}
-		}
+		adjustments = ApplyFeedbackAdjustments(ctx, s, log, fb, req.Quality, 1.0)
 
 		log.Info("feedback recorded",
 			"query_id", req.QueryID,
@@ -187,4 +131,69 @@ func SaveRetrievalFeedback(ctx context.Context, s store.Store, log *slog.Logger,
 	} else {
 		log.Debug("saved retrieval feedback record", "query_id", queryID, "retrieved", len(retrievedIDs), "traversed", len(traversedAssocs))
 	}
+}
+
+// ApplyFeedbackAdjustments applies association strength and salience adjustments
+// based on a quality rating. scaleFactor controls the magnitude (1.0 for explicit,
+// <1.0 for implicit feedback).
+func ApplyFeedbackAdjustments(ctx context.Context, s store.Store, log *slog.Logger, fb store.RetrievalFeedback, quality string, scaleFactor float64) int {
+	adjustments := 0
+	strengthDelta := float32(float64(feedbackStrengthDelta) * scaleFactor)
+	salienceBoost := float32(float64(feedbackSalienceBoost) * scaleFactor)
+
+	switch quality {
+	case "helpful":
+		for _, ta := range fb.TraversedAssocs {
+			assocs, err := s.GetAssociations(ctx, ta.SourceID)
+			if err != nil {
+				continue
+			}
+			for _, a := range assocs {
+				if a.TargetID == ta.TargetID {
+					newStrength := a.Strength + strengthDelta
+					if newStrength > 1.0 {
+						newStrength = 1.0
+					}
+					if err := s.UpdateAssociationStrength(ctx, ta.SourceID, ta.TargetID, newStrength); err == nil {
+						adjustments++
+					}
+					break
+				}
+			}
+		}
+		for _, memID := range fb.RetrievedIDs {
+			mem, err := s.GetMemory(ctx, memID)
+			if err != nil {
+				continue
+			}
+			newSalience := mem.Salience + salienceBoost
+			if newSalience > 1.0 {
+				newSalience = 1.0
+			}
+			if err := s.UpdateSalience(ctx, memID, newSalience); err != nil {
+				log.Warn("failed to update salience", "memory_id", memID, "error", err)
+			}
+		}
+
+	case "irrelevant":
+		for _, ta := range fb.TraversedAssocs {
+			assocs, err := s.GetAssociations(ctx, ta.SourceID)
+			if err != nil {
+				continue
+			}
+			for _, a := range assocs {
+				if a.TargetID == ta.TargetID {
+					newStrength := a.Strength - strengthDelta
+					if newStrength < 0.05 {
+						newStrength = 0.05
+					}
+					if err := s.UpdateAssociationStrength(ctx, ta.SourceID, ta.TargetID, newStrength); err == nil {
+						adjustments++
+					}
+					break
+				}
+			}
+		}
+	}
+	return adjustments
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -178,9 +178,12 @@ type RetrievalConfig struct {
 
 // MetacognitionConfig holds metacognition settings.
 type MetacognitionConfig struct {
-	Enabled     bool          `yaml:"enabled"`
-	IntervalRaw string        `yaml:"interval"`
-	Interval    time.Duration `yaml:"-"`
+	Enabled                 bool          `yaml:"enabled"`
+	IntervalRaw             string        `yaml:"interval"`
+	Interval                time.Duration `yaml:"-"`
+	ImplicitFeedbackEnabled bool          `yaml:"implicit_feedback_enabled"`
+	ImplicitFeedbackWindow  string        `yaml:"implicit_feedback_window"`
+	ImplicitFeedbackScale   float64       `yaml:"implicit_feedback_scale"`
 }
 
 // DreamingConfig holds dreaming (memory replay) agent settings.
@@ -444,9 +447,12 @@ func Default() *Config {
 			DualHitBonus:        0.15,
 		},
 		Metacognition: MetacognitionConfig{
-			Enabled:     true,
-			IntervalRaw: "24h",
-			Interval:    24 * time.Hour,
+			Enabled:                 true,
+			IntervalRaw:             "24h",
+			Interval:                24 * time.Hour,
+			ImplicitFeedbackEnabled: true,
+			ImplicitFeedbackWindow:  "24h",
+			ImplicitFeedbackScale:   0.5,
 		},
 		Dreaming: DreamingConfig{
 			Enabled:                true,

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1828,6 +1828,43 @@ func (s *SQLiteStore) GetRetrievalFeedback(ctx context.Context, queryID string) 
 	return fb, nil
 }
 
+// ListUnratedFeedback returns feedback records with no explicit rating, created between newerThan and olderThan ago.
+func (s *SQLiteStore) ListUnratedFeedback(ctx context.Context, olderThan, newerThan time.Duration, limit int) ([]store.RetrievalFeedback, error) {
+	now := time.Now()
+	oldest := now.Add(-newerThan).Format(time.RFC3339)
+	newest := now.Add(-olderThan).Format(time.RFC3339)
+
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT query_id, query_text, retrieved_memory_ids, COALESCE(traversed_assocs, '[]'), COALESCE(access_snapshot, '[]'), COALESCE(feedback, ''), created_at
+		 FROM retrieval_feedback
+		 WHERE (feedback = '' OR feedback IS NULL)
+		   AND created_at >= ? AND created_at <= ?
+		 ORDER BY created_at DESC LIMIT ?`,
+		oldest, newest, limit)
+	if err != nil {
+		return nil, fmt.Errorf("listing unrated feedback: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	var results []store.RetrievalFeedback
+	for rows.Next() {
+		var fb store.RetrievalFeedback
+		var retrievedJSON, traversedJSON, snapshotJSON, createdAtStr string
+		if err := rows.Scan(&fb.QueryID, &fb.QueryText, &retrievedJSON, &traversedJSON, &snapshotJSON, &fb.Feedback, &createdAtStr); err != nil {
+			return nil, fmt.Errorf("scanning unrated feedback: %w", err)
+		}
+		_ = json.Unmarshal([]byte(retrievedJSON), &fb.RetrievedIDs)
+		_ = json.Unmarshal([]byte(traversedJSON), &fb.TraversedAssocs)
+		_ = json.Unmarshal([]byte(snapshotJSON), &fb.AccessSnapshot)
+		fb.CreatedAt, _ = time.Parse(time.RFC3339, createdAtStr)
+		results = append(results, fb)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating unrated feedback: %w", err)
+	}
+	return results, nil
+}
+
 // ListMetaObservations retrieves observations, optionally filtered by type.
 func (s *SQLiteStore) ListMetaObservations(ctx context.Context, observationType string, limit int) ([]store.MetaObservation, error) {
 	var rows *sql.Rows

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -377,6 +377,7 @@ type Store interface {
 	// --- Retrieval feedback operations ---
 	WriteRetrievalFeedback(ctx context.Context, fb RetrievalFeedback) error
 	GetRetrievalFeedback(ctx context.Context, queryID string) (RetrievalFeedback, error)
+	ListUnratedFeedback(ctx context.Context, olderThan, newerThan time.Duration, limit int) ([]RetrievalFeedback, error)
 
 	// --- Episode operations ---
 	CreateEpisode(ctx context.Context, ep Episode) error

--- a/internal/store/storetest/mock.go
+++ b/internal/store/storetest/mock.go
@@ -154,6 +154,9 @@ func (MockStore) WriteRetrievalFeedback(context.Context, store.RetrievalFeedback
 func (MockStore) GetRetrievalFeedback(context.Context, string) (store.RetrievalFeedback, error) {
 	return store.RetrievalFeedback{}, nil
 }
+func (MockStore) ListUnratedFeedback(context.Context, time.Duration, time.Duration, int) ([]store.RetrievalFeedback, error) {
+	return nil, nil
+}
 
 // --- Episode operations ---
 


### PR DESCRIPTION
## Summary
- Adds `ListUnratedFeedback` to Store interface — finds recall records with no explicit rating within a time window
- Extracts `ApplyFeedbackAdjustments()` from the HTTP handler into a shared function reusable by both explicit and implicit paths
- Metacognition agent now runs `processImplicitFeedback()` each cycle: finds unrated queries 1-24h old, checks if any returned memory was re-accessed, applies positive feedback at reduced scale (default 50%)
- New config fields: `implicit_feedback_enabled`, `implicit_feedback_window`, `implicit_feedback_scale`

## Test plan
- [x] `make build` compiles clean
- [x] `make check` (go fmt + go vet) clean
- [x] `golangci-lint run` — 0 issues
- [x] `make test` — all packages pass including routes and sqlite
- [ ] Deploy and verify implicit feedback triggers after recall + re-access

**Stacked on #200** (access snapshot in feedback)

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)