### PR TITLE
feat: add dreaming quality gate and event bus test determinism

### DIFF
--- a/internal/agent/dreaming/agent.go
+++ b/internal/agent/dreaming/agent.go
@@ -393,6 +393,11 @@ func (da *DreamingAgent) crossProjectLink(ctx context.Context, replayed []store.
 				continue
 			}
 
+			// Require at least 1 shared concept to avoid spurious embedding-only links
+			if countSharedConcepts(mem.Concepts, result.Memory.Concepts) < 1 {
+				continue
+			}
+
 			newAssoc := store.Association{
 				SourceID:      mem.ID,
 				TargetID:      result.Memory.ID,
@@ -437,6 +442,11 @@ func (da *DreamingAgent) linkToPatterns(ctx context.Context, replayed []store.Me
 				}
 			}
 			if alreadyEvidence {
+				continue
+			}
+
+			// Require at least 1 shared concept to validate pattern relevance
+			if countSharedConcepts(mem.Concepts, pattern.Concepts) < 1 {
 				continue
 			}
 

--- a/internal/agent/dreaming/agent_test.go
+++ b/internal/agent/dreaming/agent_test.go
@@ -1,10 +1,12 @@
 package dreaming
 
 import (
+	"context"
 	"log/slog"
 	"testing"
 	"time"
 
+	"github.com/appsprout-dev/mnemonic/internal/store"
 	"github.com/appsprout-dev/mnemonic/internal/store/storetest"
 )
 
@@ -211,7 +213,180 @@ func TestDreamingAgentName(t *testing.T) {
 	}
 }
 
+// TestCrossProjectLinkRequiresConceptOverlap verifies that crossProjectLink
+// does not create an association when two memories have high embedding similarity
+// but zero shared concepts.
+func TestCrossProjectLinkRequiresConceptOverlap(t *testing.T) {
+	ms := &crossProjectMockStore{}
+	logger := slog.New(slog.NewTextHandler(nil, nil))
+	config := DreamingConfig{
+		Interval:               3 * time.Hour,
+		BatchSize:              20,
+		SalienceThreshold:      0.3,
+		AssociationBoostFactor: 1.15,
+		NoisePruneThreshold:    0.15,
+	}
+	agent := NewDreamingAgent(ms, nil, config, logger)
+
+	// Memory from project A with concepts ["golang", "testing"]
+	memA := store.Memory{
+		ID:        "mem-a",
+		Project:   "project-alpha",
+		Concepts:  []string{"golang", "testing"},
+		Embedding: []float32{0.9, 0.1, 0.0},
+	}
+
+	// Memory from project B with completely different concepts but high embedding similarity
+	memB := store.Memory{
+		ID:        "mem-b",
+		Project:   "project-beta",
+		Concepts:  []string{"python", "deployment"},
+		Embedding: []float32{0.89, 0.11, 0.01},
+	}
+
+	// Configure mock: SearchByEmbedding returns memB with score > 0.75
+	ms.embeddingResults = []store.RetrievalResult{
+		{Memory: memB, Score: 0.85},
+	}
+
+	report := &DreamReport{}
+	err := agent.crossProjectLink(context.Background(), []store.Memory{memA}, report)
+	if err != nil {
+		t.Fatalf("crossProjectLink failed: %v", err)
+	}
+
+	// No association should have been created — zero concept overlap
+	if report.CrossProjectLinks != 0 {
+		t.Fatalf("expected 0 cross-project links (no concept overlap), got %d", report.CrossProjectLinks)
+	}
+	if ms.associationsCreated != 0 {
+		t.Fatalf("expected 0 associations created, got %d", ms.associationsCreated)
+	}
+}
+
+// TestCrossProjectLinkCreatesWithConceptOverlap verifies that crossProjectLink
+// creates an association when memories share at least 1 concept.
+func TestCrossProjectLinkCreatesWithConceptOverlap(t *testing.T) {
+	ms := &crossProjectMockStore{}
+	logger := slog.New(slog.NewTextHandler(nil, nil))
+	config := DreamingConfig{
+		Interval:               3 * time.Hour,
+		BatchSize:              20,
+		SalienceThreshold:      0.3,
+		AssociationBoostFactor: 1.15,
+		NoisePruneThreshold:    0.15,
+	}
+	agent := NewDreamingAgent(ms, nil, config, logger)
+
+	memA := store.Memory{
+		ID:        "mem-a",
+		Project:   "project-alpha",
+		Concepts:  []string{"golang", "testing", "sqlite"},
+		Embedding: []float32{0.9, 0.1, 0.0},
+	}
+
+	memB := store.Memory{
+		ID:        "mem-b",
+		Project:   "project-beta",
+		Concepts:  []string{"sqlite", "deployment"},
+		Embedding: []float32{0.89, 0.11, 0.01},
+	}
+
+	ms.embeddingResults = []store.RetrievalResult{
+		{Memory: memB, Score: 0.85},
+	}
+
+	report := &DreamReport{}
+	err := agent.crossProjectLink(context.Background(), []store.Memory{memA}, report)
+	if err != nil {
+		t.Fatalf("crossProjectLink failed: %v", err)
+	}
+
+	if report.CrossProjectLinks != 1 {
+		t.Fatalf("expected 1 cross-project link (shared concept 'sqlite'), got %d", report.CrossProjectLinks)
+	}
+	if ms.associationsCreated != 1 {
+		t.Fatalf("expected 1 association created, got %d", ms.associationsCreated)
+	}
+}
+
+// TestLinkToPatternsRequiresConceptOverlap verifies that linkToPatterns
+// does not boost a pattern when the memory shares no concepts with it.
+func TestLinkToPatternsRequiresConceptOverlap(t *testing.T) {
+	ms := &patternLinkMockStore{}
+	logger := slog.New(slog.NewTextHandler(nil, nil))
+	config := DreamingConfig{
+		Interval:               3 * time.Hour,
+		BatchSize:              20,
+		SalienceThreshold:      0.3,
+		AssociationBoostFactor: 1.15,
+		NoisePruneThreshold:    0.15,
+	}
+	agent := NewDreamingAgent(ms, nil, config, logger)
+
+	mem := store.Memory{
+		ID:        "mem-1",
+		Concepts:  []string{"golang", "testing"},
+		Embedding: []float32{0.9, 0.1, 0.0},
+	}
+
+	// Pattern with completely different concepts
+	ms.patternResults = []store.Pattern{
+		{
+			ID:          "pat-1",
+			Concepts:    []string{"python", "deployment"},
+			EvidenceIDs: []string{},
+			Strength:    0.5,
+		},
+	}
+
+	report := &DreamReport{}
+	err := agent.linkToPatterns(context.Background(), []store.Memory{mem}, report)
+	if err != nil {
+		t.Fatalf("linkToPatterns failed: %v", err)
+	}
+
+	if report.PatternLinks != 0 {
+		t.Fatalf("expected 0 pattern links (no concept overlap), got %d", report.PatternLinks)
+	}
+	if ms.patternsUpdated != 0 {
+		t.Fatalf("expected 0 patterns updated, got %d", ms.patternsUpdated)
+	}
+}
+
 // mockStore embeds the shared base mock and has no overrides.
 type mockStore struct {
 	storetest.MockStore
+}
+
+// crossProjectMockStore tracks associations created and returns configured embedding results.
+type crossProjectMockStore struct {
+	storetest.MockStore
+	embeddingResults    []store.RetrievalResult
+	associationsCreated int
+}
+
+func (m *crossProjectMockStore) SearchByEmbedding(_ context.Context, _ []float32, _ int) ([]store.RetrievalResult, error) {
+	return m.embeddingResults, nil
+}
+
+func (m *crossProjectMockStore) CreateAssociation(_ context.Context, _ store.Association) error {
+	m.associationsCreated++
+	return nil
+}
+
+// patternLinkMockStore tracks pattern updates and returns configured pattern results.
+type patternLinkMockStore struct {
+	storetest.MockStore
+	patternResults  []store.Pattern
+	patternsUpdated int
+}
+
+func (m *patternLinkMockStore) SearchPatternsByEmbedding(_ context.Context, _ []float32, _ int) ([]store.Pattern, error) {
+	return m.patternResults, nil
+}
+
+func (m *patternLinkMockStore) UpdatePattern(_ context.Context, _ store.Pattern) error {
+	m.patternsUpdated++
+	return nil
 }

--- a/internal/events/inmemory_test.go
+++ b/internal/events/inmemory_test.go
@@ -8,6 +8,22 @@ import (
 	"time"
 )
 
+// waitWithTimeout converts a WaitGroup into a channel-based wait with timeout.
+// Returns true if the WaitGroup completed, false if it timed out.
+func waitWithTimeout(wg *sync.WaitGroup, timeout time.Duration) bool {
+	done := make(chan struct{})
+	go func() {
+		wg.Wait()
+		close(done)
+	}()
+	select {
+	case <-done:
+		return true
+	case <-time.After(timeout):
+		return false
+	}
+}
+
 // TestSubscribePublish tests the basic subscribe and publish flow.
 func TestSubscribePublish(t *testing.T) {
 	bus := NewInMemoryBus(10)
@@ -15,11 +31,14 @@ func TestSubscribePublish(t *testing.T) {
 
 	received := make([]Event, 0)
 	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(1)
 
 	subID := bus.Subscribe(TypeRawMemoryCreated, func(ctx context.Context, event Event) error {
 		mu.Lock()
 		received = append(received, event)
 		mu.Unlock()
+		wg.Done()
 		return nil
 	})
 
@@ -35,12 +54,13 @@ func TestSubscribePublish(t *testing.T) {
 		Ts:             time.Now(),
 	}
 
-	// Give the async dispatch a moment to process
 	if err := bus.Publish(context.Background(), event); err != nil {
 		t.Fatalf("publish failed: %v", err)
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	if !waitWithTimeout(&wg, 2*time.Second) {
+		t.Fatal("timed out waiting for event handler")
+	}
 
 	mu.Lock()
 	if len(received) != 1 {
@@ -58,11 +78,15 @@ func TestMultipleSubscribers(t *testing.T) {
 	count2 := 0
 	count3 := 0
 	var mu sync.Mutex
+	var wg sync.WaitGroup
+	// 3 subscribers x 3 publishes = 9 handler calls
+	wg.Add(9)
 
 	bus.Subscribe(TypeMemoryEncoded, func(ctx context.Context, event Event) error {
 		mu.Lock()
 		count1++
 		mu.Unlock()
+		wg.Done()
 		return nil
 	})
 
@@ -70,6 +94,7 @@ func TestMultipleSubscribers(t *testing.T) {
 		mu.Lock()
 		count2++
 		mu.Unlock()
+		wg.Done()
 		return nil
 	})
 
@@ -77,6 +102,7 @@ func TestMultipleSubscribers(t *testing.T) {
 		mu.Lock()
 		count3++
 		mu.Unlock()
+		wg.Done()
 		return nil
 	})
 
@@ -94,7 +120,9 @@ func TestMultipleSubscribers(t *testing.T) {
 		}
 	}
 
-	time.Sleep(200 * time.Millisecond)
+	if !waitWithTimeout(&wg, 2*time.Second) {
+		t.Fatal("timed out waiting for event handlers")
+	}
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -118,18 +146,34 @@ func TestUnsubscribe(t *testing.T) {
 	count1 := 0
 	count2 := 0
 	var mu sync.Mutex
+	var wg1 sync.WaitGroup
+	var wg2 sync.WaitGroup
+
+	// First publish: both handlers fire (wg1 tracks both)
+	wg1.Add(2)
+	// Second publish: only handler 2 fires (wg2 tracks it)
+	wg2.Add(1)
+
+	firstPublishDone := false
 
 	subID1 := bus.Subscribe(TypeQueryExecuted, func(ctx context.Context, event Event) error {
 		mu.Lock()
 		count1++
 		mu.Unlock()
+		wg1.Done()
 		return nil
 	})
 
 	subID2 := bus.Subscribe(TypeQueryExecuted, func(ctx context.Context, event Event) error {
 		mu.Lock()
 		count2++
+		isFirst := !firstPublishDone
 		mu.Unlock()
+		if isFirst {
+			wg1.Done()
+		} else {
+			wg2.Done()
+		}
 		return nil
 	})
 
@@ -146,7 +190,13 @@ func TestUnsubscribe(t *testing.T) {
 		t.Fatalf("publish failed: %v", err)
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	if !waitWithTimeout(&wg1, 2*time.Second) {
+		t.Fatal("timed out waiting for first publish handlers")
+	}
+
+	mu.Lock()
+	firstPublishDone = true
+	mu.Unlock()
 
 	// Unsubscribe the first subscriber
 	bus.Unsubscribe(subID1)
@@ -156,7 +206,9 @@ func TestUnsubscribe(t *testing.T) {
 		t.Fatalf("publish failed: %v", err)
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	if !waitWithTimeout(&wg2, 2*time.Second) {
+		t.Fatal("timed out waiting for second publish handler")
+	}
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -200,7 +252,9 @@ func TestPublishWithContextCancellation(t *testing.T) {
 		t.Fatalf("publish with cancelled context failed: %v", err)
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	// Give async dispatch a brief moment — no deterministic wait possible
+	// since the handler may or may not run with a cancelled context
+	time.Sleep(50 * time.Millisecond)
 
 	mu.Lock()
 	// The event may or may not be processed depending on timing
@@ -248,11 +302,14 @@ func TestCloseStopsProcessing(t *testing.T) {
 
 	count := 0
 	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(3)
 
 	bus.Subscribe(TypeWatcherEvent, func(ctx context.Context, event Event) error {
 		mu.Lock()
 		count++
 		mu.Unlock()
+		wg.Done()
 		return nil
 	})
 
@@ -271,8 +328,9 @@ func TestCloseStopsProcessing(t *testing.T) {
 		}
 	}
 
-	// Give them time to be processed
-	time.Sleep(200 * time.Millisecond)
+	if !waitWithTimeout(&wg, 2*time.Second) {
+		t.Fatal("timed out waiting for event handlers")
+	}
 
 	mu.Lock()
 	countBeforeClose := count
@@ -302,12 +360,15 @@ func TestHandlerError(t *testing.T) {
 	count2 := 0
 	count3 := 0
 	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(3)
 
 	// First handler returns an error
 	bus.Subscribe(TypeDreamCycleCompleted, func(ctx context.Context, event Event) error {
 		mu.Lock()
 		count1++
 		mu.Unlock()
+		wg.Done()
 		return errors.New("test error")
 	})
 
@@ -316,6 +377,7 @@ func TestHandlerError(t *testing.T) {
 		mu.Lock()
 		count2++
 		mu.Unlock()
+		wg.Done()
 		return nil
 	})
 
@@ -324,6 +386,7 @@ func TestHandlerError(t *testing.T) {
 		mu.Lock()
 		count3++
 		mu.Unlock()
+		wg.Done()
 		return nil
 	})
 
@@ -340,7 +403,9 @@ func TestHandlerError(t *testing.T) {
 		t.Fatalf("publish failed: %v", err)
 	}
 
-	time.Sleep(200 * time.Millisecond)
+	if !waitWithTimeout(&wg, 2*time.Second) {
+		t.Fatal("timed out waiting for event handlers")
+	}
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -365,11 +430,15 @@ func TestEventTypeFiltering(t *testing.T) {
 	countType1 := 0
 	countType2 := 0
 	var mu sync.Mutex
+	var wg sync.WaitGroup
+	// 2 consolidation events + 3 meta events = 5 handler calls
+	wg.Add(5)
 
 	bus.Subscribe(TypeConsolidationCompleted, func(ctx context.Context, event Event) error {
 		mu.Lock()
 		countType1++
 		mu.Unlock()
+		wg.Done()
 		return nil
 	})
 
@@ -377,6 +446,7 @@ func TestEventTypeFiltering(t *testing.T) {
 		mu.Lock()
 		countType2++
 		mu.Unlock()
+		wg.Done()
 		return nil
 	})
 
@@ -408,7 +478,9 @@ func TestEventTypeFiltering(t *testing.T) {
 		}
 	}
 
-	time.Sleep(200 * time.Millisecond)
+	if !waitWithTimeout(&wg, 2*time.Second) {
+		t.Fatal("timed out waiting for event handlers")
+	}
 
 	mu.Lock()
 	defer mu.Unlock()
@@ -428,11 +500,14 @@ func TestUnsubscribeInvalidID(t *testing.T) {
 
 	count := 0
 	var mu sync.Mutex
+	var wg sync.WaitGroup
+	wg.Add(1)
 
 	bus.Subscribe(TypeMemoryAccessed, func(ctx context.Context, event Event) error {
 		mu.Lock()
 		count++
 		mu.Unlock()
+		wg.Done()
 		return nil
 	})
 
@@ -449,7 +524,9 @@ func TestUnsubscribeInvalidID(t *testing.T) {
 		t.Fatalf("publish failed: %v", err)
 	}
 
-	time.Sleep(100 * time.Millisecond)
+	if !waitWithTimeout(&wg, 2*time.Second) {
+		t.Fatal("timed out waiting for event handler")
+	}
 
 	mu.Lock()
 	defer mu.Unlock()


### PR DESCRIPTION
## Summary
- `crossProjectLink` and `linkToPatterns` now require at least 1 shared concept (via existing `countSharedConcepts`) before creating associations or boosting patterns, preventing spurious embedding-only links
- Event bus tests replace `time.Sleep` with `sync.WaitGroup` + timeout-guarded waits for deterministic, race-free execution
- 3 new dreaming quality gate tests added

## Test plan
- [x] `go test ./internal/agent/dreaming/` — all pass including 3 new quality gate tests
- [x] `go test ./internal/events/ -count=5 -race` — 5 consecutive runs, zero flakes
- [x] `make check` (go fmt + go vet) clean
- [x] `golangci-lint run` — 0 issues

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)