### PR TITLE
feat: MMR diversity filter and encoding dedup

### DIFF
--- a/cmd/mnemonic/main.go
+++ b/cmd/mnemonic/main.go
@@ -1743,6 +1743,9 @@ func buildRetrievalConfig(cfg *config.Config) retrieval.RetrievalConfig {
 
 		CriticalBoost:  float32(cfg.Retrieval.CriticalBoost),
 		ImportantBoost: float32(cfg.Retrieval.ImportantBoost),
+
+		DiversityLambda:    float32(cfg.Retrieval.DiversityLambda),
+		DiversityThreshold: float32(cfg.Retrieval.DiversityThreshold),
 	}
 }
 
@@ -2764,6 +2767,7 @@ func buildEncodingConfig(cfg *config.Config) encoding.EncodingConfig {
 		BackoffMaxSec:           cfg.Encoding.BackoffMaxSec,
 		BatchSizeEvent:          cfg.Encoding.BatchSizeEvent,
 		BatchSizePoll:           cfg.Encoding.BatchSizePoll,
+		DeduplicationThreshold:  float32(cfg.Encoding.DeduplicationThreshold),
 	}
 }
 

--- a/internal/agent/encoding/agent.go
+++ b/internal/agent/encoding/agent.go
@@ -71,6 +71,7 @@ type EncodingConfig struct {
 	BatchSizeEvent          int      // batch size for EncodeAllPending (default: 50)
 	BatchSizePoll           int      // batch size for polling loop (default: 10)
 	EmbedBatchSize          int      // max memories to batch-embed in one call (default 10)
+	DeduplicationThreshold  float32  // cosine sim above which new memory is a duplicate (default: 0.9)
 }
 
 // compressedMemory holds the intermediate state between compression and embedding.
@@ -663,6 +664,33 @@ func (ea *EncodingAgent) finalizeEncodedMemory(ctx context.Context, raw store.Ra
 		if err != nil {
 			ea.log.Warn("failed to search for similar memories", "raw_id", raw.ID, "error", err)
 		} else {
+			// Check for near-duplicate before creating a new memory
+			dedupThreshold := ea.config.DeduplicationThreshold
+			if dedupThreshold <= 0 {
+				dedupThreshold = 0.9
+			}
+			if dup := findDuplicate(similar, dedupThreshold); dup != nil {
+				ea.log.Info("dedup: boosting existing memory instead of creating duplicate",
+					"raw_id", raw.ID,
+					"existing_id", dup.Memory.ID,
+					"similarity", dup.Score)
+				// Boost existing memory's salience (capped at 1.0)
+				newSalience := dup.Memory.Salience + 0.05
+				if newSalience > 1.0 {
+					newSalience = 1.0
+				}
+				if err := ea.store.UpdateSalience(ctx, dup.Memory.ID, newSalience); err != nil {
+					ea.log.Warn("dedup: failed to boost salience", "memory_id", dup.Memory.ID, "error", err)
+				}
+				if err := ea.store.IncrementAccess(ctx, dup.Memory.ID); err != nil {
+					ea.log.Warn("dedup: failed to increment access", "memory_id", dup.Memory.ID, "error", err)
+				}
+				if err := ea.store.MarkRawProcessed(ctx, raw.ID); err != nil {
+					ea.log.Warn("dedup: failed to mark raw as processed", "raw_id", raw.ID, "error", err)
+				}
+				return nil
+			}
+
 			for _, result := range similar {
 				if result.Score > ea.config.SimilarityThreshold {
 					relationType := ea.classifyRelationship(ctx, compression, result.Memory, raw)
@@ -1784,4 +1812,14 @@ func truncateString(s string, maxLen int) string {
 		return s
 	}
 	return string(runes[:maxLen]) + "..."
+}
+
+// findDuplicate returns the first result above the dedup threshold, or nil.
+func findDuplicate(results []store.RetrievalResult, threshold float32) *store.RetrievalResult {
+	for i := range results {
+		if results[i].Score >= threshold {
+			return &results[i]
+		}
+	}
+	return nil
 }

--- a/internal/agent/encoding/agent_test.go
+++ b/internal/agent/encoding/agent_test.go
@@ -2087,3 +2087,51 @@ func TestCompressionResponseRoundTrip(t *testing.T) {
 		t.Errorf("expected 1 topic after round-trip, got %d", len(decoded.StructuredConcepts.Topics))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// Tests for findDuplicate
+// ---------------------------------------------------------------------------
+
+func TestFindDuplicate(t *testing.T) {
+	t.Run("returns first result above threshold", func(t *testing.T) {
+		results := []store.RetrievalResult{
+			{Memory: store.Memory{ID: "a"}, Score: 0.95},
+			{Memory: store.Memory{ID: "b"}, Score: 0.85},
+		}
+		dup := findDuplicate(results, 0.9)
+		if dup == nil {
+			t.Fatal("expected duplicate to be found")
+		}
+		if dup.Memory.ID != "a" {
+			t.Errorf("expected id 'a', got %q", dup.Memory.ID)
+		}
+	})
+
+	t.Run("returns nil when nothing above threshold", func(t *testing.T) {
+		results := []store.RetrievalResult{
+			{Memory: store.Memory{ID: "a"}, Score: 0.85},
+			{Memory: store.Memory{ID: "b"}, Score: 0.70},
+		}
+		dup := findDuplicate(results, 0.9)
+		if dup != nil {
+			t.Errorf("expected nil, got %q", dup.Memory.ID)
+		}
+	})
+
+	t.Run("empty results returns nil", func(t *testing.T) {
+		dup := findDuplicate(nil, 0.9)
+		if dup != nil {
+			t.Error("expected nil for empty results")
+		}
+	})
+
+	t.Run("exact threshold match returns result", func(t *testing.T) {
+		results := []store.RetrievalResult{
+			{Memory: store.Memory{ID: "a"}, Score: 0.9},
+		}
+		dup := findDuplicate(results, 0.9)
+		if dup == nil {
+			t.Fatal("expected duplicate at exact threshold")
+		}
+	})
+}

--- a/internal/agent/retrieval/agent.go
+++ b/internal/agent/retrieval/agent.go
@@ -51,6 +51,10 @@ type RetrievalConfig struct {
 	// Significance multipliers
 	CriticalBoost  float32 // multiplier for "critical" significance memories (default: 1.2)
 	ImportantBoost float32 // multiplier for "important" significance memories (default: 1.1)
+
+	// Diversity filtering (MMR)
+	DiversityLambda    float32 // 0=max diversity, 1=pure relevance (default: 0.7)
+	DiversityThreshold float32 // cosine sim above which memories are near-duplicates (default: 0.85)
 }
 
 // DefaultConfig returns sensible defaults for retrieval configuration.
@@ -84,6 +88,9 @@ func DefaultConfig() RetrievalConfig {
 
 		CriticalBoost:  1.2,
 		ImportantBoost: 1.1,
+
+		DiversityLambda:    0.7,
+		DiversityThreshold: 0.85,
 	}
 }
 
@@ -248,6 +255,9 @@ func (ra *RetrievalAgent) Query(ctx context.Context, req QueryRequest) (QueryRes
 	if len(ranked) > maxResults {
 		ranked = ranked[:maxResults]
 	}
+
+	// Step 8b: Apply MMR diversity filter to reduce near-duplicate results
+	ranked = ra.applyDiversityFilter(ranked)
 
 	// Step 9: Side effect - increment access counts for returned memories
 	for _, result := range ranked {
@@ -972,4 +982,109 @@ func (ra *RetrievalAgent) applyFilters(results []store.RetrievalResult, req Quer
 		filtered = append(filtered, r)
 	}
 	return filtered
+}
+
+// cosineSimilarity computes the cosine similarity between two embedding vectors.
+// Returns 0.0 if either vector is empty or has zero magnitude.
+func cosineSimilarity(a, b []float32) float32 {
+	if len(a) != len(b) || len(a) == 0 {
+		return 0.0
+	}
+	var dot, normA, normB float64
+	for i := range a {
+		dot += float64(a[i]) * float64(b[i])
+		normA += float64(a[i]) * float64(a[i])
+		normB += float64(b[i]) * float64(b[i])
+	}
+	if normA == 0 || normB == 0 {
+		return 0.0
+	}
+	return float32(dot / (math.Sqrt(normA) * math.Sqrt(normB)))
+}
+
+// applyDiversityFilter reranks results using Maximal Marginal Relevance (MMR).
+// It iteratively selects results that balance relevance (original score) against
+// diversity (dissimilarity to already-selected results). Lambda controls the
+// trade-off: 1.0 = pure relevance, 0.0 = max diversity.
+func (ra *RetrievalAgent) applyDiversityFilter(results []store.RetrievalResult) []store.RetrievalResult {
+	if len(results) <= 1 {
+		return results
+	}
+
+	lambda := f32Or(ra.config.DiversityLambda, 0.7)
+	threshold := f32Or(ra.config.DiversityThreshold, 0.85)
+
+	// Normalize scores to [0,1] for fair MMR blending
+	maxScore := results[0].Score // results are pre-sorted by score descending
+	if maxScore <= 0 {
+		return results
+	}
+
+	selected := make([]store.RetrievalResult, 0, len(results))
+	remaining := make([]store.RetrievalResult, len(results))
+	copy(remaining, results)
+
+	// Always pick the top-ranked result first
+	selected = append(selected, remaining[0])
+	remaining = remaining[1:]
+
+	for len(remaining) > 0 {
+		bestIdx := -1
+		bestMMR := float32(-math.MaxFloat32)
+
+		for i, candidate := range remaining {
+			// Skip candidates without embeddings — they can't be compared for diversity
+			if len(candidate.Memory.Embedding) == 0 {
+				// Give them a neutral MMR based only on relevance
+				mmr := lambda * (candidate.Score / maxScore)
+				if mmr > bestMMR {
+					bestMMR = mmr
+					bestIdx = i
+				}
+				continue
+			}
+
+			// Find max similarity to any already-selected result
+			maxSim := float32(0.0)
+			for _, sel := range selected {
+				if len(sel.Memory.Embedding) == 0 {
+					continue
+				}
+				sim := cosineSimilarity(candidate.Memory.Embedding, sel.Memory.Embedding)
+				if sim > maxSim {
+					maxSim = sim
+				}
+			}
+
+			// If this candidate is a near-duplicate of something already selected, skip it entirely
+			if maxSim >= threshold {
+				ra.log.Debug("diversity filter: dropping near-duplicate",
+					"candidate_id", candidate.Memory.ID,
+					"max_similarity", maxSim,
+					"threshold", threshold)
+				continue
+			}
+
+			// MMR score: balance relevance vs diversity
+			relevance := candidate.Score / maxScore
+			diversity := 1.0 - maxSim
+			mmr := lambda*relevance + (1.0-lambda)*diversity
+
+			if mmr > bestMMR {
+				bestMMR = mmr
+				bestIdx = i
+			}
+		}
+
+		if bestIdx < 0 {
+			// All remaining candidates are near-duplicates
+			break
+		}
+
+		selected = append(selected, remaining[bestIdx])
+		// Remove selected from remaining
+		remaining = append(remaining[:bestIdx], remaining[bestIdx+1:]...)
+	}
+
+	return selected
 }

--- a/internal/agent/retrieval/diversity_test.go
+++ b/internal/agent/retrieval/diversity_test.go
@@ -1,0 +1,202 @@
+package retrieval
+
+import (
+	"log/slog"
+	"math"
+	"os"
+	"testing"
+
+	"github.com/appsprout-dev/mnemonic/internal/store"
+)
+
+func TestCosineSimilarity(t *testing.T) {
+	tests := []struct {
+		name string
+		a, b []float32
+		want float32
+	}{
+		{
+			name: "identical vectors",
+			a:    []float32{1, 0, 0},
+			b:    []float32{1, 0, 0},
+			want: 1.0,
+		},
+		{
+			name: "orthogonal vectors",
+			a:    []float32{1, 0, 0},
+			b:    []float32{0, 1, 0},
+			want: 0.0,
+		},
+		{
+			name: "opposite vectors",
+			a:    []float32{1, 0, 0},
+			b:    []float32{-1, 0, 0},
+			want: -1.0,
+		},
+		{
+			name: "similar vectors",
+			a:    []float32{1, 1, 0},
+			b:    []float32{1, 0.9, 0.1},
+			want: 0.992, // approximately
+		},
+		{
+			name: "empty vectors",
+			a:    []float32{},
+			b:    []float32{},
+			want: 0.0,
+		},
+		{
+			name: "mismatched lengths",
+			a:    []float32{1, 0},
+			b:    []float32{1, 0, 0},
+			want: 0.0,
+		},
+		{
+			name: "zero magnitude",
+			a:    []float32{0, 0, 0},
+			b:    []float32{1, 0, 0},
+			want: 0.0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := cosineSimilarity(tt.a, tt.b)
+			if math.Abs(float64(got-tt.want)) > 0.01 {
+				t.Errorf("cosineSimilarity() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// makeResult creates a RetrievalResult with the given score and embedding.
+func makeResult(id string, score float32, embedding []float32) store.RetrievalResult {
+	return store.RetrievalResult{
+		Memory: store.Memory{
+			ID:        id,
+			Embedding: embedding,
+		},
+		Score: score,
+	}
+}
+
+func newTestRetrievalAgent(cfg RetrievalConfig) *RetrievalAgent {
+	log := slog.New(slog.NewTextHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelError}))
+	return &RetrievalAgent{
+		config: cfg,
+		log:    log,
+	}
+}
+
+func TestApplyDiversityFilter_DropsNearDuplicates(t *testing.T) {
+	ra := newTestRetrievalAgent(RetrievalConfig{
+		DiversityLambda:    0.7,
+		DiversityThreshold: 0.85,
+	})
+
+	// 5 near-identical embeddings (score descending) + 2 diverse ones
+	dup := []float32{1, 0, 0, 0}
+	diverse1 := []float32{0, 1, 0, 0}
+	diverse2 := []float32{0, 0, 1, 0}
+
+	results := []store.RetrievalResult{
+		makeResult("dup1", 1.0, dup),
+		makeResult("dup2", 0.95, dup),
+		makeResult("dup3", 0.90, dup),
+		makeResult("diverse1", 0.80, diverse1),
+		makeResult("dup4", 0.75, dup),
+		makeResult("diverse2", 0.70, diverse2),
+		makeResult("dup5", 0.65, dup),
+	}
+
+	filtered := ra.applyDiversityFilter(results)
+
+	// Should keep dup1 (first pick), diverse1, diverse2 — and drop the other dups
+	ids := make(map[string]bool)
+	for _, r := range filtered {
+		ids[r.Memory.ID] = true
+	}
+
+	if !ids["dup1"] {
+		t.Error("expected dup1 (highest scored) to be kept")
+	}
+	if !ids["diverse1"] {
+		t.Error("expected diverse1 to be kept")
+	}
+	if !ids["diverse2"] {
+		t.Error("expected diverse2 to be kept")
+	}
+
+	// At most one of the duplicate cluster should survive
+	dupCount := 0
+	for _, id := range []string{"dup1", "dup2", "dup3", "dup4", "dup5"} {
+		if ids[id] {
+			dupCount++
+		}
+	}
+	if dupCount > 1 {
+		t.Errorf("expected at most 1 duplicate to survive, got %d", dupCount)
+	}
+}
+
+func TestApplyDiversityFilter_PureRelevance(t *testing.T) {
+	// Lambda=1.0 means no diversity penalty — order should be preserved
+	ra := newTestRetrievalAgent(RetrievalConfig{
+		DiversityLambda:    1.0,
+		DiversityThreshold: 0.85,
+	})
+
+	dup := []float32{1, 0, 0}
+	results := []store.RetrievalResult{
+		makeResult("a", 1.0, dup),
+		makeResult("b", 0.9, dup),
+		makeResult("c", 0.8, dup),
+	}
+
+	filtered := ra.applyDiversityFilter(results)
+
+	// Near-duplicates above threshold are still dropped even with lambda=1.0
+	// because the threshold is a hard gate, not part of the MMR score
+	if len(filtered) > 1 {
+		t.Errorf("expected near-duplicates to be dropped, got %d results", len(filtered))
+	}
+}
+
+func TestApplyDiversityFilter_EmptyAndSingle(t *testing.T) {
+	ra := newTestRetrievalAgent(RetrievalConfig{
+		DiversityLambda:    0.7,
+		DiversityThreshold: 0.85,
+	})
+
+	// Empty
+	got := ra.applyDiversityFilter(nil)
+	if len(got) != 0 {
+		t.Errorf("expected empty result for nil input, got %d", len(got))
+	}
+
+	// Single
+	single := []store.RetrievalResult{makeResult("only", 1.0, []float32{1, 0})}
+	got = ra.applyDiversityFilter(single)
+	if len(got) != 1 || got[0].Memory.ID != "only" {
+		t.Error("single result should pass through unchanged")
+	}
+}
+
+func TestApplyDiversityFilter_NoEmbeddings(t *testing.T) {
+	ra := newTestRetrievalAgent(RetrievalConfig{
+		DiversityLambda:    0.7,
+		DiversityThreshold: 0.85,
+	})
+
+	// Results with no embeddings should still be returned (can't compare for diversity)
+	results := []store.RetrievalResult{
+		makeResult("a", 1.0, nil),
+		makeResult("b", 0.9, nil),
+		makeResult("c", 0.8, nil),
+	}
+
+	filtered := ra.applyDiversityFilter(results)
+	if len(filtered) != 3 {
+		t.Errorf("expected all 3 results (no embeddings to compare), got %d", len(filtered))
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -160,17 +160,18 @@ type EncodingConfig struct {
 	EnableLLMClassification  bool     `yaml:"enable_llm_classification"`
 	CompletionMaxTokens      int      `yaml:"completion_max_tokens"`
 	ConceptVocabulary        []string `yaml:"concept_vocabulary"`
-	SimilarityThreshold      float64  `yaml:"similarity_threshold"`  // min cosine similarity for associations (default: 0.3)
-	PollingIntervalSec       int      `yaml:"polling_interval_sec"`  // seconds between unprocessed-memory polls (default: 5)
-	MaxRetries               int      `yaml:"max_retries"`           // encoding attempts before skipping (default: 3)
-	MaxLLMContentChars       int      `yaml:"max_llm_content_chars"` // max chars sent to LLM for compression (default: 8000)
-	MaxEmbeddingChars        int      `yaml:"max_embedding_chars"`   // max chars sent to embedding model (default: 4000)
-	TemporalWindowMin        int      `yaml:"temporal_window_min"`   // minutes for temporal relationship detection (default: 5)
-	BackoffThreshold         int      `yaml:"backoff_threshold"`     // consecutive failures before backoff (default: 3)
-	BackoffBaseSec           int      `yaml:"backoff_base_sec"`      // base backoff per failure in seconds (default: 30)
-	BackoffMaxSec            int      `yaml:"backoff_max_sec"`       // maximum backoff in seconds (default: 300)
-	BatchSizeEvent           int      `yaml:"batch_size_event"`      // batch size for EncodeAllPending (default: 50)
-	BatchSizePoll            int      `yaml:"batch_size_poll"`       // batch size for polling loop (default: 10)
+	SimilarityThreshold      float64  `yaml:"similarity_threshold"`    // min cosine similarity for associations (default: 0.3)
+	PollingIntervalSec       int      `yaml:"polling_interval_sec"`    // seconds between unprocessed-memory polls (default: 5)
+	MaxRetries               int      `yaml:"max_retries"`             // encoding attempts before skipping (default: 3)
+	MaxLLMContentChars       int      `yaml:"max_llm_content_chars"`   // max chars sent to LLM for compression (default: 8000)
+	MaxEmbeddingChars        int      `yaml:"max_embedding_chars"`     // max chars sent to embedding model (default: 4000)
+	TemporalWindowMin        int      `yaml:"temporal_window_min"`     // minutes for temporal relationship detection (default: 5)
+	BackoffThreshold         int      `yaml:"backoff_threshold"`       // consecutive failures before backoff (default: 3)
+	BackoffBaseSec           int      `yaml:"backoff_base_sec"`        // base backoff per failure in seconds (default: 30)
+	BackoffMaxSec            int      `yaml:"backoff_max_sec"`         // maximum backoff in seconds (default: 300)
+	BatchSizeEvent           int      `yaml:"batch_size_event"`        // batch size for EncodeAllPending (default: 50)
+	BatchSizePoll            int      `yaml:"batch_size_poll"`         // batch size for polling loop (default: 10)
+	DeduplicationThreshold   float64  `yaml:"deduplication_threshold"` // cosine sim above which new memory is a duplicate (default: 0.9)
 }
 
 // ConsolidationConfig holds consolidation settings.
@@ -251,6 +252,10 @@ type RetrievalConfig struct {
 	// Significance multipliers
 	CriticalBoost  float64 `yaml:"critical_boost"`
 	ImportantBoost float64 `yaml:"important_boost"`
+
+	// Diversity filtering (MMR)
+	DiversityLambda    float64 `yaml:"diversity_lambda"`    // 0=max diversity, 1=pure relevance (default 0.7)
+	DiversityThreshold float64 `yaml:"diversity_threshold"` // cosine sim above which memories are near-duplicates (default 0.85)
 }
 
 // MetacognitionConfig holds metacognition settings.
@@ -520,6 +525,7 @@ func Default() *Config {
 			BackoffMaxSec:            300,
 			BatchSizeEvent:           50,
 			BatchSizePoll:            10,
+			DeduplicationThreshold:   0.9,
 		},
 		Consolidation: ConsolidationConfig{
 			Enabled:                   true,
@@ -583,6 +589,9 @@ func Default() *Config {
 
 			CriticalBoost:  1.2,
 			ImportantBoost: 1.1,
+
+			DiversityLambda:    0.7,
+			DiversityThreshold: 0.85,
 		},
 		Metacognition: MetacognitionConfig{
 			Enabled:     true,


### PR DESCRIPTION
## Summary

- **Retrieval (#192):** MMR diversity filter reranks results to suppress near-duplicate memories. Hard gate at 0.85 cosine similarity, soft reranking via lambda-weighted MMR score.
- **Encoding (#194):** Duplicate prevention gate at 0.9 cosine similarity. Near-duplicates boost existing memory salience instead of creating new entries.
- **Config:** `retrieval.diversity_lambda`, `retrieval.diversity_threshold`, `encoding.deduplication_threshold` — all externalized with defaults.

Closes #192
Closes #194

## Test plan

- [x] `TestCosineSimilarity` — identical, orthogonal, opposite, similar, empty, mismatched, zero-magnitude vectors
- [x] `TestApplyDiversityFilter_DropsNearDuplicates` — 5 near-identical + 2 diverse, verifies diverse results surface
- [x] `TestApplyDiversityFilter_PureRelevance` — lambda=1.0 still drops hard-gate duplicates
- [x] `TestApplyDiversityFilter_EmptyAndSingle` — edge cases
- [x] `TestApplyDiversityFilter_NoEmbeddings` — results without embeddings pass through
- [x] `TestFindDuplicate` — threshold matching, below threshold, empty, exact boundary
- [x] Full `make check && make test` passing
- [x] Built, deployed, daemon running

🤖 Generated with [Claude Code](https://claude.com/claude-code)