### PR TITLE
feat: sweep automation and EXP-2 registry fix

### DIFF
--- a/training/docs/experiment_registry.md
+++ b/training/docs/experiment_registry.md
@@ -114,8 +114,19 @@ Pre-registered experiments for Felix-LM v3 100M pretraining on mnemonic's curate
 - **Variable:** Learning rate (6e-4, 1e-3, 2e-3) x weight decay (0.1, 0.05)
 - **Control:** LR 6e-4 / WD 0.1 (current default from train_mnemonic_lm.py)
 - **Prediction:** LR 1e-3 beats 6e-4 by 5-15% lower loss at 4000 micro-steps. WD 0.05 vs 0.1 will show <2% difference (WD matters more in longer runs).
-- **Config:** v3_mnemonic_100m, batch 12, accum 22, 4000 micro-steps, torch.compile, wandb group hp_sweep_v3_100m
+- **Config:** v3_mnemonic_100m, batch 10, accum 4, 4000 micro-steps (1000 optimizer steps), torch.compile, wandb group hp_sweep_v3_100m
 - **Hardware:** AMD RX 7800 XT 16GB, ROCm, Linux x86_64
-- **Result:** (pending)
-- **Verdict:** (pending)
+- **Note:** Originally attempted batch 12 / accum 22 but OOM-killed twice at ~step 2000. Dropped to batch 10 / accum 4 with 90% VRAM cap. Batch-12 results lost (never written to TSV).
+- **Result (batch 10, 2 of 5 complete):**
+
+| Run | LR | WD | Loss | PPL | Delta vs control | Time |
+|-----|----|----|------|-----|------------------|------|
+| sweep_lr6e4_wd01 (control) | 6e-4 | 0.1 | 4.847 | 127.4 | — | 8297s |
+| sweep_lr1e3_wd01 | 1e-3 | 0.1 | 4.557 | 95.3 | -6.0% loss, -25% PPL | 8329s |
+| sweep_lr2e3_wd01 | 2e-3 | 0.1 | (pending) | | | |
+| sweep_lr6e4_wd005 | 6e-4 | 0.05 | (pending) | | | |
+| sweep_lr1e3_wd005 | 1e-3 | 0.05 | (pending) | | | |
+
+- **Early observation:** LR 1e-3 beats 6e-4 by 6% lower loss at 4000 micro-steps, consistent with prediction (5-15%). Next run (LR 2e-3) will test whether the optimum is higher still or if 1e-3 is the sweet spot.
+- **Verdict:** (pending — 3 runs remaining)
 - **Analysis:** (pending)

--- a/training/scripts/run_sweep.sh
+++ b/training/scripts/run_sweep.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# Run remaining HP sweep configs for EXP-2 (LR + Weight Decay).
+#
+# Each run: 4000 micro-steps (1000 optimizer steps) at batch 10 / accum 4.
+# Results are appended to sweep_results.tsv after each run completes.
+#
+# Usage:
+#   ./training/scripts/run_sweep.sh              # run all remaining
+#   ./training/scripts/run_sweep.sh lr2e3_wd01   # run a single config
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TRAINING_DIR="$(dirname "$SCRIPT_DIR")"
+TRAIN_SCRIPT="$SCRIPT_DIR/train_mnemonic_lm.py"
+TSV="$TRAINING_DIR/sweep_results.tsv"
+
+# Shared args
+CONFIG="v3_mnemonic_100m"
+BATCH=10
+ACCUM=4
+STEPS=4000
+BETA2=0.95
+DEVICE="cuda"
+WANDB_GROUP="hp_sweep_v3_100m"
+
+# Sweep grid: name -> "lr wd"
+declare -A SWEEP_GRID=(
+    ["lr2e3_wd01"]="2e-3 0.1"
+    ["lr6e4_wd005"]="6e-4 0.05"
+    ["lr1e3_wd005"]="1e-3 0.05"
+)
+
+# Ordered run list (bash associative arrays don't preserve order)
+SWEEP_ORDER=("lr2e3_wd01" "lr6e4_wd005" "lr1e3_wd005")
+
+run_one() {
+    local name="$1"
+    local lr wd
+    read -r lr wd <<< "${SWEEP_GRID[$name]}"
+    local run_name="sweep_${name}"
+
+    # Skip if already in TSV
+    if grep -q "^${run_name}	" "$TSV" 2>/dev/null; then
+        echo "=== SKIP: $run_name (already in $TSV) ==="
+        return 0
+    fi
+
+    echo ""
+    echo "========================================"
+    echo "  SWEEP: $run_name"
+    echo "  LR=$lr  WD=$wd  batch=$BATCH  accum=$ACCUM  steps=$STEPS"
+    echo "========================================"
+    echo ""
+
+    local start_time
+    start_time=$(date +%s)
+
+    python "$TRAIN_SCRIPT" \
+        --config "$CONFIG" \
+        --device "$DEVICE" \
+        --batch-size "$BATCH" \
+        --grad-accum "$ACCUM" \
+        --lr "$lr" \
+        --weight-decay "$wd" \
+        --beta2 "$BETA2" \
+        --max-steps "$STEPS" \
+        --compile \
+        --wandb-name "$run_name" \
+        2>&1 | tee "/tmp/${run_name}.log"
+
+    local end_time elapsed
+    end_time=$(date +%s)
+    elapsed=$((end_time - start_time))
+
+    # Parse final loss and PPL from training output
+    local final_loss final_ppl
+    final_loss=$(grep "Last 100 avg loss:" "/tmp/${run_name}.log" | awk '{print $NF}')
+    final_ppl=$(grep "Final PPL:" "/tmp/${run_name}.log" | awk '{print $NF}')
+
+    if [[ -z "$final_loss" || -z "$final_ppl" ]]; then
+        echo "ERROR: Could not parse results from $run_name — check /tmp/${run_name}.log"
+        return 1
+    fi
+
+    # Append to TSV
+    printf '%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\t%s\n' \
+        "$run_name" "$final_loss" "$final_ppl" "$lr" "$wd" "$BETA2" "auto" "$BATCH" "$ACCUM" "$STEPS" "$elapsed" \
+        >> "$TSV"
+
+    echo ""
+    echo "=== DONE: $run_name — loss=$final_loss ppl=$final_ppl time=${elapsed}s ==="
+    echo "=== Logged to $TSV ==="
+    echo ""
+}
+
+# Main
+if [[ $# -gt 0 ]]; then
+    # Run specific config(s)
+    for name in "$@"; do
+        if [[ -z "${SWEEP_GRID[$name]+x}" ]]; then
+            echo "ERROR: Unknown sweep config '$name'"
+            echo "Available: ${!SWEEP_GRID[*]}"
+            exit 1
+        fi
+        run_one "$name"
+    done
+else
+    # Run all remaining
+    echo "=== HP Sweep: ${#SWEEP_ORDER[@]} configs remaining ==="
+    echo "=== Estimated time: ~7h (3 x ~2.3h each) ==="
+    echo ""
+    for name in "${SWEEP_ORDER[@]}"; do
+        run_one "$name"
+    done
+    echo ""
+    echo "=== All sweep runs complete ==="
+    echo "=== Results in $TSV ==="
+    cat "$TSV"
+fi

--- a/training/scripts/train_mnemonic_lm.py
+++ b/training/scripts/train_mnemonic_lm.py
@@ -203,9 +203,10 @@ def train(config, args):
     # wandb
     if not args.no_wandb:
         import wandb
+        run_name = args.wandb_name or f"{args.config}_lr{args.lr}_wd{args.weight_decay}"
         wandb.init(
             project="mnemonic-lm",
-            name=args.config,
+            name=run_name,
             config={
                 "model_params": n_params,
                 "config": args.config,
@@ -337,9 +338,10 @@ def main():
     parser.add_argument("--weight-decay", type=float, default=0.1)
     parser.add_argument("--warmup-steps", type=int, default=0, help="0=auto (10%% of total)")
     parser.add_argument("--grad-clip", type=float, default=1.0)
-    parser.add_argument("--max-steps", type=int, default=100000)
+    parser.add_argument("--max-steps", type=int, default=100000, help="Total micro-steps (forward passes). Optimizer steps = max_steps / grad_accum.")
     parser.add_argument("--save-interval", type=int, default=5000)
     parser.add_argument("--no-wandb", action="store_true")
+    parser.add_argument("--wandb-name", type=str, default=None, help="Custom wandb run name. Defaults to config_lr{lr}_wd{wd}.")
     parser.add_argument("--dtype", type=str, default="bf16", choices=["bf16", "fp32"])
     parser.add_argument("--beta2", type=float, default=0.95)
     parser.add_argument("--compile", action="store_true")


### PR DESCRIPTION
## Summary
- Add `run_sweep.sh` to run remaining 3 HP sweep configs (lr2e3_wd01, lr6e4_wd005, lr1e3_wd005) sequentially with auto-logging to `sweep_results.tsv` and duplicate detection
- Fix EXP-2 registry entry to match actual runs (batch 10/accum 4, not 12/22) with results table
- Add `--wandb-name` flag to training script for distinct run names per sweep config
- Clarify `--max-steps` help text (micro-steps, not optimizer steps)

## Test plan
- [ ] Verify `run_sweep.sh` skips already-completed runs (lr6e4_wd01, lr1e3_wd01 are in TSV)
- [ ] Run one config manually to confirm TSV logging and wandb naming
- [ ] Verify full sweep completes overnight

🤖 Generated with [Claude Code](https://claude.com/claude-code)