### PR TITLE
feat: add Tools dashboard tab for MCP usage analytics

### DIFF
--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -1248,6 +1248,10 @@
                     <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M12 2L2 7l10 5 10-5-10-5z"/><path d="M2 17l10 5 10-5"/><path d="M2 12l10 5 10-5"/></svg>
                     <span>LLM</span>
                 </button>
+                <button class="nav-tab" data-view="tools" onclick="switchView('tools')">
+                    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"><path d="M14.7 6.3a1 1 0 000 1.4l1.6 1.6a1 1 0 001.4 0l3.77-3.77a6 6 0 01-7.94 7.94l-6.91 6.91a2.12 2.12 0 01-3-3l6.91-6.91a6 6 0 017.94-7.94l-3.76 3.76z"/></svg>
+                    <span>Tools</span>
+                </button>
             </div>
             <div class="nav-spacer"></div>
             <div class="nav-stats">
@@ -1546,6 +1550,75 @@
                     </div>
                 </div>
             </section>
+
+            <!-- Tool Usage View -->
+            <section class="view" id="view-tools">
+                <div class="llm-view">
+                    <div class="llm-header">
+                        <div class="llm-header-title">MCP Tool Usage</div>
+                        <div class="llm-header-sub">recall &middot; remember &middot; feedback &middot; 13 tools</div>
+                        <div class="llm-header-meta">
+                            <div class="llm-range-tabs" id="toolRangeTabs">
+                                <button class="llm-range-tab" data-range="1h" onclick="setToolRange('1h')">1h</button>
+                                <button class="llm-range-tab" data-range="6h" onclick="setToolRange('6h')">6h</button>
+                                <button class="llm-range-tab active" data-range="24h" onclick="setToolRange('24h')">24h</button>
+                                <button class="llm-range-tab" data-range="168h" onclick="setToolRange('168h')">7d</button>
+                            </div>
+                            <span class="llm-updated" id="toolUpdated"></span>
+                            <button class="agent-refresh-btn" onclick="loadToolUsage()">
+                                <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 4v6h6M23 20v-6h-6"/><path d="M20.49 9A9 9 0 005.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 013.51 15"/></svg>
+                                Refresh
+                            </button>
+                        </div>
+                    </div>
+                    <div class="llm-cards" id="toolCards">
+                        <div class="llm-card"><div class="llm-card-label">Tool Calls</div><div class="llm-card-value" id="toolCalls">-</div></div>
+                        <div class="llm-card"><div class="llm-card-label">Avg Latency</div><div class="llm-card-value" id="toolLatency">-</div></div>
+                        <div class="llm-card"><div class="llm-card-label">Errors</div><div class="llm-card-value" id="toolErrors">-</div></div>
+                        <div class="llm-card"><div class="llm-card-label">Top Tool</div><div class="llm-card-value" id="toolTopTool">-</div></div>
+                        <div class="llm-card"><div class="llm-card-label">Projects</div><div class="llm-card-value" id="toolProjects">-</div></div>
+                        <div class="llm-card"><div class="llm-card-label">Success Rate</div><div class="llm-card-value" id="toolSuccessRate">-</div></div>
+                    </div>
+                    <div class="llm-panel" style="margin-bottom:16px">
+                        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:10px">
+                            <div class="llm-panel-title" style="margin-bottom:0" id="toolChartTitle">Tool Calls (24h)</div>
+                            <div class="llm-chart-legend">
+                                <div class="llm-legend-item"><div class="llm-legend-dot" style="background:var(--accent-cyan)"></div>Calls</div>
+                                <div class="llm-legend-item"><div class="llm-legend-dot" style="background:var(--accent-red)"></div>Errors</div>
+                            </div>
+                        </div>
+                        <div class="llm-chart-wrap">
+                            <div id="toolChart" style="height:200px"></div>
+                            <div class="llm-chart-tooltip" id="toolChartTooltip"></div>
+                        </div>
+                    </div>
+                    <div class="llm-grid" style="margin-bottom:16px">
+                        <div class="llm-panel">
+                            <div class="llm-panel-title">Calls by Tool</div>
+                            <table class="llm-table" id="toolByToolTable">
+                                <thead><tr><th>Tool</th><th>Calls</th><th>Avg Latency</th><th>Avg Size</th></tr></thead>
+                                <tbody id="toolByToolBody"><tr><td colspan="4" class="llm-empty">No data yet</td></tr></tbody>
+                            </table>
+                        </div>
+                        <div class="llm-panel">
+                            <div class="llm-panel-title">Calls by Project</div>
+                            <table class="llm-table" id="toolByProjectTable">
+                                <thead><tr><th>Project</th><th>Calls</th></tr></thead>
+                                <tbody id="toolByProjectBody"><tr><td colspan="2" class="llm-empty">No data yet</td></tr></tbody>
+                            </table>
+                        </div>
+                    </div>
+                    <div class="llm-panel">
+                        <div class="llm-panel-title">Recent Tool Calls</div>
+                        <div class="llm-log-scroll">
+                            <table class="llm-table" id="toolLogTable">
+                                <thead><tr><th>Time</th><th>Tool</th><th>Project</th><th>Query / Context</th><th>Latency</th><th>Size</th><th>Status</th></tr></thead>
+                                <tbody id="toolLogBody"><tr><td colspan="7" class="llm-empty">No tool calls recorded yet</td></tr></tbody>
+                            </table>
+                        </div>
+                    </div>
+                </div>
+            </section>
         </div>
 
         <!-- Activity Drawer -->
@@ -1610,6 +1683,7 @@
         agentLoaded: false,
         agentData: null,
         llmLoaded: false,
+        toolsLoaded: false,
     };
 
     const CONFIG = {
@@ -1668,6 +1742,7 @@
         if (name === 'timeline' && !state.timelineInitialized) { populateTimelineProjects(); loadTimelineData(false); }
         if (name === 'agent' && !state.agentLoaded) loadAgentData();
         if (name === 'llm' && !state.llmLoaded) loadLLMUsage();
+        if (name === 'tools' && !state.toolsLoaded) loadToolUsage();
     }
 
     function switchExploreTab(tab) {
@@ -2963,6 +3038,208 @@
             .attr('class', 'llm-err-mark')
             .attr('cx', function(d) { return x(d.idx) + x.bandwidth() / 2; })
             .attr('cy', function(d) { return y(d.prompt + d.completion) - 5; })
+            .attr('r', 3)
+            .attr('fill', 'var(--accent-red)')
+            .style('pointer-events', 'none');
+    }
+
+    // ── Tool Usage Analytics ──
+    var _toolRange = '24h';
+
+    function setToolRange(range) {
+        _toolRange = range;
+        document.querySelectorAll('#toolRangeTabs .llm-range-tab').forEach(function(t) {
+            t.classList.toggle('active', t.getAttribute('data-range') === range);
+        });
+        var titles = { '1h': 'Tool Calls (1h)', '6h': 'Tool Calls (6h)', '24h': 'Tool Calls (24h)', '168h': 'Tool Calls (7d)' };
+        document.getElementById('toolChartTitle').textContent = titles[range] || 'Tool Calls';
+        loadToolUsage();
+    }
+
+    async function loadToolUsage() {
+        try {
+            var limit = _toolRange === '168h' ? 500 : 200;
+            var data = await fetchJSON('/tool/usage?since=' + _toolRange + '&limit=' + limit);
+            state.toolsLoaded = true;
+
+            var s = data.summary || {};
+            document.getElementById('toolCalls').textContent = (s.total_calls || 0).toLocaleString();
+            document.getElementById('toolLatency').textContent = (s.avg_latency_ms || 0).toFixed(0) + 'ms';
+
+            var errEl = document.getElementById('toolErrors');
+            errEl.textContent = s.error_count || 0;
+            errEl.style.color = (s.error_count || 0) > 0 ? 'var(--accent-red)' : '';
+
+            // Top tool
+            var byTool = s.by_tool || {};
+            var topTool = Object.keys(byTool).sort(function(a, b) { return byTool[b] - byTool[a]; })[0] || '-';
+            document.getElementById('toolTopTool').textContent = topTool;
+
+            // Project count
+            var byProject = s.by_project || {};
+            document.getElementById('toolProjects').textContent = Object.keys(byProject).length || 0;
+
+            // Success rate
+            var total = s.total_calls || 0;
+            var errors = s.error_count || 0;
+            document.getElementById('toolSuccessRate').textContent = total > 0 ? ((total - errors) / total * 100).toFixed(1) + '%' : '-';
+
+            document.getElementById('toolUpdated').textContent = 'Updated ' + new Date().toLocaleTimeString();
+
+            var log = data.log || [];
+
+            // Per-tool extras from log (avg latency, avg size)
+            var toolExtras = {};
+            log.forEach(function(r) {
+                var t = r.tool_name || 'unknown';
+                if (!toolExtras[t]) toolExtras[t] = { latencySum: 0, sizeSum: 0, count: 0 };
+                toolExtras[t].latencySum += (r.latency_ms || 0);
+                toolExtras[t].sizeSum += (r.response_size || 0);
+                toolExtras[t].count++;
+            });
+
+            // By Tool table
+            var toolBody = document.getElementById('toolByToolBody');
+            var toolKeys = Object.keys(byTool).sort(function(a, b) { return byTool[b] - byTool[a]; });
+            if (toolKeys.length === 0) {
+                toolBody.innerHTML = '<tr><td colspan="4" class="llm-empty">No tool data yet</td></tr>';
+            } else {
+                toolBody.innerHTML = toolKeys.map(function(k) {
+                    var ext = toolExtras[k] || {};
+                    var avgLat = ext.count ? (ext.latencySum / ext.count).toFixed(0) + 'ms' : '-';
+                    var avgSize = ext.count ? formatBytes(ext.sizeSum / ext.count) : '-';
+                    return '<tr><td><strong>' + escapeHtml(k) + '</strong></td><td>' + byTool[k] + '</td><td>' + avgLat + '</td><td>' + avgSize + '</td></tr>';
+                }).join('');
+            }
+
+            // By Project table
+            var projBody = document.getElementById('toolByProjectBody');
+            var projKeys = Object.keys(byProject).sort(function(a, b) { return byProject[b] - byProject[a]; });
+            if (projKeys.length === 0) {
+                projBody.innerHTML = '<tr><td colspan="2" class="llm-empty">No project data yet</td></tr>';
+            } else {
+                projBody.innerHTML = projKeys.map(function(k) {
+                    return '<tr><td><strong>' + escapeHtml(k) + '</strong></td><td>' + byProject[k] + '</td></tr>';
+                }).join('');
+            }
+
+            // Request log
+            var logBody = document.getElementById('toolLogBody');
+            if (log.length === 0) {
+                logBody.innerHTML = '<tr><td colspan="7" class="llm-empty">No tool calls recorded yet</td></tr>';
+            } else {
+                logBody.innerHTML = log.map(function(r) {
+                    var t = r.timestamp ? new Date(r.timestamp).toLocaleTimeString() : '-';
+                    var statusCls = r.success ? 'llm-status-ok' : 'llm-status-err';
+                    var statusTxt = r.success ? 'OK' : 'ERR';
+                    var rowCls = r.success ? '' : ' class="llm-log-row-err"';
+                    var context = r.query_text || r.memory_type || r.rating || '-';
+                    if (context.length > 60) context = context.substring(0, 57) + '...';
+                    var size = r.response_size ? formatBytes(r.response_size) : '-';
+                    var row = '<tr' + rowCls + '><td>' + t + '</td><td>' + escapeHtml(r.tool_name || '-') + '</td><td>' + escapeHtml(r.project || '-') + '</td><td>' + escapeHtml(context) + '</td><td>' + (r.latency_ms || 0) + 'ms</td><td>' + size + '</td><td class="' + statusCls + '">' + statusTxt + '</td></tr>';
+                    if (!r.success && r.error_message) {
+                        row += '<tr class="llm-log-row-err"><td colspan="7" class="llm-error-detail">' + escapeHtml(r.error_message) + '</td></tr>';
+                    }
+                    return row;
+                }).join('');
+            }
+
+            renderToolChart(data.chart_buckets || [], _toolRange);
+        } catch (e) {
+            document.getElementById('toolCalls').textContent = 'ERR';
+        }
+    }
+
+    function formatBytes(bytes) {
+        if (bytes < 1024) return Math.round(bytes) + 'B';
+        if (bytes < 1024 * 1024) return (bytes / 1024).toFixed(1) + 'KB';
+        return (bytes / (1024 * 1024)).toFixed(1) + 'MB';
+    }
+
+    function renderToolChart(chartBuckets, range) {
+        var container = document.getElementById('toolChart');
+        var tooltip = document.getElementById('toolChartTooltip');
+        container.innerHTML = '';
+        if (!chartBuckets || chartBuckets.length === 0) { container.innerHTML = '<div class="llm-empty">No data for chart</div>'; return; }
+
+        var labelFmt, labelEvery;
+        if (range === '1h') {
+            labelFmt = function(d) { return String(d.getHours()).padStart(2,'0') + ':' + String(d.getMinutes()).padStart(2,'0'); };
+            labelEvery = 3;
+        } else if (range === '6h') {
+            labelFmt = function(d) { return String(d.getHours()).padStart(2,'0') + ':' + String(d.getMinutes()).padStart(2,'0'); };
+            labelEvery = 2;
+        } else if (range === '168h') {
+            var days = ['Sun','Mon','Tue','Wed','Thu','Fri','Sat'];
+            labelFmt = function(d) { return days[d.getDay()]; };
+            labelEvery = 1;
+        } else {
+            labelFmt = function(d) { return String(d.getHours()).padStart(2,'0') + ':00'; };
+            labelEvery = 4;
+        }
+
+        var buckets = chartBuckets.map(function(b, i) {
+            var ts = new Date(b.timestamp);
+            return { idx: i, start: ts, label: labelFmt(ts), calls: b.calls || 0, errors: b.errors || 0 };
+        });
+
+        var w = container.clientWidth || 400;
+        var h = 200;
+        var margin = { top: 10, right: 10, bottom: 28, left: 50 };
+        var iw = w - margin.left - margin.right;
+        var ih = h - margin.top - margin.bottom;
+
+        var svg = d3.select(container).append('svg').attr('width', w).attr('height', h);
+        var g = svg.append('g').attr('transform', 'translate(' + margin.left + ',' + margin.top + ')');
+
+        var maxCalls = d3.max(buckets, function(d) { return d.calls; }) || 1;
+        var x = d3.scaleBand().domain(buckets.map(function(d) { return d.idx; })).range([0, iw]).padding(0.25);
+        var y = d3.scaleLinear().domain([0, maxCalls]).nice().range([ih, 0]);
+
+        g.append('g').attr('transform', 'translate(0,' + ih + ')')
+            .call(d3.axisBottom(x)
+                .tickValues(buckets.map(function(d) { return d.idx; }).filter(function(i) { return i % labelEvery === 0; }))
+                .tickFormat(function(i) { return buckets[i].label; }))
+            .selectAll('text').attr('fill', 'var(--text-dim)').style('font-size', '10px');
+        g.append('g').call(d3.axisLeft(y).ticks(4).tickFormat(d3.format('d')))
+            .selectAll('text').attr('fill', 'var(--text-dim)').style('font-size', '10px');
+        g.selectAll('.domain, .tick line').attr('stroke', 'var(--border-subtle)');
+
+        // Call bars (cyan)
+        g.selectAll('.tool-bar-calls').data(buckets).enter().append('rect')
+            .attr('class', 'tool-bar-calls')
+            .attr('x', function(d) { return x(d.idx); })
+            .attr('y', function(d) { return d.calls > 0 ? y(d.calls) : ih; })
+            .attr('width', x.bandwidth())
+            .attr('height', function(d) { return d.calls > 0 ? ih - y(d.calls) : 0; })
+            .attr('rx', 2).attr('fill', 'var(--accent-cyan)').attr('opacity', 0.8);
+
+        // Transparent hit areas for tooltip
+        g.selectAll('.tool-hit').data(buckets).enter().append('rect')
+            .attr('class', 'tool-hit')
+            .attr('x', function(d) { return x(d.idx) - x.bandwidth() * 0.1; })
+            .attr('y', 0).attr('width', function() { return x.bandwidth() * 1.2; }).attr('height', ih)
+            .attr('fill', 'transparent')
+            .on('mouseover', function(event, d) {
+                if (d.calls === 0) return;
+                var errLine = d.errors > 0 ? '<br><span style="color:var(--accent-red)">' + d.errors + ' error' + (d.errors === 1 ? '' : 's') + '</span>' : '';
+                tooltip.innerHTML = '<strong>' + d.label + '</strong><br>' +
+                    d.calls + ' call' + (d.calls === 1 ? '' : 's') + errLine;
+                tooltip.style.display = 'block';
+                var barX = margin.left + x(d.idx) + x.bandwidth() / 2;
+                var ttLeft = barX + 10;
+                if (ttLeft + 180 > w) ttLeft = barX - 190;
+                tooltip.style.left = ttLeft + 'px';
+                tooltip.style.top = (margin.top + 2) + 'px';
+            })
+            .on('mouseout', function() { tooltip.style.display = 'none'; });
+
+        // Error markers
+        g.selectAll('.tool-err-mark').data(buckets.filter(function(d) { return d.errors > 0; }))
+            .enter().append('circle')
+            .attr('class', 'tool-err-mark')
+            .attr('cx', function(d) { return x(d.idx) + x.bandwidth() / 2; })
+            .attr('cy', function(d) { return y(d.calls) - 5; })
             .attr('r', 3)
             .attr('fill', 'var(--accent-red)')
             .style('pointer-events', 'none');


### PR DESCRIPTION
## Summary

- New "Tools" tab in the web dashboard for MCP tool usage analytics
- 6 stat cards: total calls, avg latency, errors, top tool, project count, success rate
- D3 bar chart with time-series call counts and error markers
- Calls by Tool table (avg latency, avg response size)
- Calls by Project breakdown table
- Recent Tool Calls log with query context, latency, size, status
- Time range selector (1h/6h/24h/7d) with lazy loading
- Reuses existing llm-* CSS classes for consistent styling

Follow-up to PR #217 which added the storage and API layer.

## Test plan
- [x] make build, golangci-lint, make test all pass
- [x] Tab renders with "No data yet" state when no tool calls recorded
- [ ] Will show live data once MCP session restarts with new binary

Generated with [Claude Code](https://claude.com/claude-code)