### PR TITLE
fix: prevent duplicate encoding across multiple mnemonic processes

### DIFF
--- a/cmd/benchmark-quality/comparison.go
+++ b/cmd/benchmark-quality/comparison.go
@@ -160,22 +160,20 @@ func runComparisonScenario(
 		p = cfg.Provider
 	}
 
-	// Create dummy raw memory for FK constraint.
-	rawID := "compare-raw-" + sc.Name
-	if err := s.WriteRaw(ctx, store.RawMemory{
-		ID:        rawID,
-		Timestamp: time.Now(),
-		Source:    "benchmark",
-		Type:      "synthetic",
-		Content:   "Comparison scenario: " + sc.Name,
-		Processed: true,
-		CreatedAt: time.Now(),
-	}); err != nil {
-		return result, fmt.Errorf("writing raw memory: %w", err)
-	}
-
-	// Ingest all memories.
-	for i := range sc.Memories {
+	// Create a raw memory per benchmark memory for FK + UNIQUE constraints.
+	for i, mem := range sc.Memories {
+		rawID := fmt.Sprintf("compare-raw-%s-%d", sc.Name, i)
+		if err := s.WriteRaw(ctx, store.RawMemory{
+			ID:        rawID,
+			Timestamp: time.Now(),
+			Source:    "benchmark",
+			Type:      "synthetic",
+			Content:   "Comparison memory: " + mem.Memory.Summary,
+			Processed: true,
+			CreatedAt: time.Now(),
+		}); err != nil {
+			return result, fmt.Errorf("writing raw memory: %w", err)
+		}
 		sc.Memories[i].Memory.RawID = rawID
 	}
 	for _, mem := range sc.Memories {

--- a/cmd/benchmark-quality/main.go
+++ b/cmd/benchmark-quality/main.go
@@ -312,22 +312,21 @@ func runScenario(
 	retAgent := retrieval.NewRetrievalAgent(s, p, cfg.Retrieval, log)
 	consolAgent := consolidation.NewConsolidationAgent(s, p, cfg.Consolidation, log)
 
-	// Phase 1: Create a dummy raw memory so FK constraints are satisfied,
-	// then ingest all benchmark memories referencing it.
-	rawID := "bench-raw-" + sc.Name
-	if err := s.WriteRaw(ctx, store.RawMemory{
-		ID:        rawID,
-		Timestamp: time.Now(),
-		Source:    "benchmark",
-		Type:      "synthetic",
-		Content:   "Benchmark scenario: " + sc.Name,
-		Processed: true,
-		CreatedAt: time.Now(),
-	}); err != nil {
-		return result, fmt.Errorf("writing raw memory: %w", err)
-	}
-
-	for i := range sc.Memories {
+	// Phase 1: Create a raw memory per benchmark memory so FK and UNIQUE
+	// constraints are satisfied, then ingest all benchmark memories.
+	for i, mem := range sc.Memories {
+		rawID := fmt.Sprintf("bench-raw-%s-%d", sc.Name, i)
+		if err := s.WriteRaw(ctx, store.RawMemory{
+			ID:        rawID,
+			Timestamp: time.Now(),
+			Source:    "benchmark",
+			Type:      "synthetic",
+			Content:   "Benchmark memory: " + mem.Memory.Summary,
+			Processed: true,
+			CreatedAt: time.Now(),
+		}); err != nil {
+			return result, fmt.Errorf("writing raw memory: %w", err)
+		}
 		sc.Memories[i].Memory.RawID = rawID
 	}
 

--- a/cmd/mnemonic/main.go
+++ b/cmd/mnemonic/main.go
@@ -2575,8 +2575,13 @@ func mcpCommand(configPath string) {
 	bus := events.NewInMemoryBus(100)
 	defer func() { _ = bus.Close() }()
 
-	// Create encoding agent so remembered memories get encoded
-	encoder := encoding.NewEncodingAgentWithConfig(db, llmProvider, log, buildEncodingConfig(cfg))
+	// Create encoding agent so remembered memories get encoded.
+	// Polling is disabled in MCP mode — each MCP process only encodes via events
+	// for memories it creates. The daemon is the sole poller. This prevents N
+	// MCP processes from independently encoding the same unprocessed raw memories.
+	mcpEncodingCfg := buildEncodingConfig(cfg)
+	mcpEncodingCfg.DisablePolling = true
+	encoder := encoding.NewEncodingAgentWithConfig(db, llmProvider, log, mcpEncodingCfg)
 	if err := encoder.Start(ctx, bus); err != nil {
 		log.Error("failed to start encoding agent for MCP", "error", err)
 	}

--- a/internal/agent/encoding/agent.go
+++ b/internal/agent/encoding/agent.go
@@ -3,6 +3,7 @@ package encoding
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"os"
@@ -73,6 +74,7 @@ type EncodingConfig struct {
 	EmbedBatchSize          int      // max memories to batch-embed in one call (default 10)
 	DeduplicationThreshold  float32  // cosine sim above which new memory is a duplicate (default: 0.9)
 	SalienceFloor           float32  // min salience to encode; non-MCP sources below this are skipped (default: 0.0)
+	DisablePolling          bool     // if true, skip the polling loop (MCP processes should not poll)
 }
 
 // compressedMemory holds the intermediate state between compression and embedding.
@@ -340,10 +342,16 @@ func (ea *EncodingAgent) Start(ctx context.Context, bus events.Bus) error {
 		ea.log.Info("LLM association classification enabled", "agent", ea.name)
 	}
 
-	// Start the polling loop as a fallback mechanism
-	ea.wg.Add(1)
-	go ea.pollingLoop()
-	ea.log.Info("started polling loop", "agent", ea.name, "interval", ea.config.PollingInterval)
+	// Start the polling loop as a fallback mechanism.
+	// MCP processes disable polling — they only encode via events for memories
+	// they themselves create. The daemon's polling loop is the single poller.
+	if !ea.config.DisablePolling {
+		ea.wg.Add(1)
+		go ea.pollingLoop()
+		ea.log.Info("started polling loop", "agent", ea.name, "interval", ea.config.PollingInterval)
+	} else {
+		ea.log.Info("polling disabled (event-only mode)", "agent", ea.name)
+	}
 
 	return nil
 }
@@ -536,7 +544,9 @@ func (ea *EncodingAgent) pollAndProcessRawMemories(ctx context.Context) error {
 
 	ea.log.Debug("polling found unprocessed memories", "count", len(unprocessed))
 
-	// Filter and claim memories for processing
+	// Filter and atomically claim memories for processing.
+	// ClaimRawForEncoding is the cross-process guard: it flips processed 0→1
+	// atomically so only one process can encode each raw memory.
 	var toProcess []store.RawMemory
 	for _, raw := range unprocessed {
 		if path, ok := raw.Metadata["path"]; ok {
@@ -560,6 +570,19 @@ func (ea *EncodingAgent) pollAndProcessRawMemories(ctx context.Context) error {
 			ea.processingMutex.Unlock()
 			continue
 		}
+		ea.processingMutex.Unlock()
+
+		// Atomically claim in DB before adding to in-memory set.
+		if err := ea.store.ClaimRawForEncoding(ctx, raw.ID); err != nil {
+			if errors.Is(err, store.ErrAlreadyClaimed) {
+				ea.log.Debug("raw memory already claimed by another process, skipping", "raw_id", raw.ID)
+				continue
+			}
+			ea.log.Warn("failed to claim raw memory for encoding", "raw_id", raw.ID, "error", err)
+			continue
+		}
+
+		ea.processingMutex.Lock()
 		ea.processingMemories[raw.ID] = true
 		ea.processingMutex.Unlock()
 
@@ -707,9 +730,7 @@ func (ea *EncodingAgent) finalizeEncodedMemory(ctx context.Context, raw store.Ra
 				if err := ea.store.IncrementAccess(ctx, dup.Memory.ID); err != nil {
 					ea.log.Warn("dedup: failed to increment access", "memory_id", dup.Memory.ID, "error", err)
 				}
-				if err := ea.store.MarkRawProcessed(ctx, raw.ID); err != nil {
-					ea.log.Warn("dedup: failed to mark raw as processed", "raw_id", raw.ID, "error", err)
-				}
+				// Raw was already claimed — no MarkRawProcessed needed.
 				return nil
 			}
 
@@ -752,6 +773,10 @@ func (ea *EncodingAgent) finalizeEncodedMemory(ctx context.Context, raw store.Ra
 		SessionID:    raw.SessionID,
 	}
 	if err := ea.store.WriteMemory(ctx, memory); err != nil {
+		if errors.Is(err, store.ErrDuplicateRawID) {
+			ea.log.Info("dedup: another process already encoded this raw memory", "raw_id", raw.ID)
+			return nil
+		}
 		return fmt.Errorf("failed to write encoded memory: %w", err)
 	}
 
@@ -829,10 +854,8 @@ func (ea *EncodingAgent) finalizeEncodedMemory(ctx context.Context, raw store.Ra
 		}
 	}
 
-	// Mark raw as processed
-	if err := ea.store.MarkRawProcessed(ctx, raw.ID); err != nil {
-		ea.log.Error("failed to mark raw memory as processed", "raw_id", raw.ID, "error", err)
-	}
+	// Raw was already claimed (processed=1) by pollAndProcessRawMemories before
+	// compression started. No additional MarkRawProcessed needed.
 
 	// Publish events
 	if ea.bus != nil {
@@ -873,7 +896,9 @@ func (ea *EncodingAgent) handleEncodingFailure(ctx context.Context, rawID string
 		delete(ea.failureCounts, rawID)
 		ea.processingMutex.Unlock()
 	} else {
-		ea.log.Warn("encoding failed, will retry later",
+		// Unclaim so the raw can be retried on the next poll cycle.
+		_ = ea.store.UnclaimRawMemory(ctx, rawID)
+		ea.log.Warn("encoding failed, unclaimed for retry",
 			"raw_id", rawID, "attempt", count, "max", ea.maxRetries(), "error", err)
 	}
 
@@ -899,16 +924,30 @@ func (ea *EncodingAgent) releaseProcessing(raws []store.RawMemory) {
 
 // encodeMemory performs the complete encoding pipeline for a single raw memory.
 func (ea *EncodingAgent) encodeMemory(ctx context.Context, rawID string) error {
+	// Step 0: Atomically claim the raw memory for encoding.
+	// This is the cross-process guard: multiple mnemonic processes (daemon + MCP
+	// instances) share the same DB. Only the process that successfully flips
+	// processed from 0→1 proceeds; all others bail out.
+	if err := ea.store.ClaimRawForEncoding(ctx, rawID); err != nil {
+		if errors.Is(err, store.ErrAlreadyClaimed) {
+			ea.log.Debug("raw memory already claimed by another process, skipping", "raw_id", rawID)
+			return nil
+		}
+		return fmt.Errorf("failed to claim raw memory: %w", err)
+	}
+	// If encoding fails after claiming, unclaim so the raw can be retried.
+	claimed := true
+	defer func() {
+		if claimed {
+			ea.log.Debug("unclaiming raw memory after encoding failure", "raw_id", rawID)
+			_ = ea.store.UnclaimRawMemory(ctx, rawID)
+		}
+	}()
+
 	// Step 1: Get the raw memory from store
 	raw, err := ea.store.GetRaw(ctx, rawID)
 	if err != nil {
 		return fmt.Errorf("failed to get raw memory: %w", err)
-	}
-
-	// Guard: skip if already processed (race between event handler and polling)
-	if raw.Processed {
-		ea.log.Debug("raw memory already processed, skipping", "raw_id", raw.ID)
-		return nil
 	}
 
 	ea.log.Debug("encoding raw memory", "raw_id", raw.ID, "source", raw.Source)
@@ -968,9 +1007,8 @@ func (ea *EncodingAgent) encodeMemory(ctx context.Context, rawID string) error {
 				if err := ea.store.IncrementAccess(ctx, dup.Memory.ID); err != nil {
 					ea.log.Warn("dedup: failed to increment access", "memory_id", dup.Memory.ID, "error", err)
 				}
-				if err := ea.store.MarkRawProcessed(ctx, raw.ID); err != nil {
-					ea.log.Warn("dedup: failed to mark raw as processed", "raw_id", raw.ID, "error", err)
-				}
+				// Raw was already claimed in Step 0 — no MarkRawProcessed needed.
+				claimed = false // dedup success — don't unclaim
 				return nil
 			}
 
@@ -1020,8 +1058,18 @@ func (ea *EncodingAgent) encodeMemory(ctx context.Context, rawID string) error {
 	}
 
 	if err := ea.store.WriteMemory(ctx, memory); err != nil {
+		// UNIQUE constraint on raw_id: another process encoded this raw memory
+		// between our claim and our write. Treat as successful dedup.
+		if errors.Is(err, store.ErrDuplicateRawID) {
+			ea.log.Info("dedup: another process already encoded this raw memory", "raw_id", raw.ID)
+			claimed = false // don't unclaim — encoding succeeded elsewhere
+			return nil
+		}
 		return fmt.Errorf("failed to write encoded memory: %w", err)
 	}
+
+	// Encoding succeeded — don't unclaim on defer.
+	claimed = false
 
 	ea.log.Debug("memory written to store", "memory_id", memoryID, "raw_id", raw.ID)
 
@@ -1097,11 +1145,7 @@ func (ea *EncodingAgent) encodeMemory(ctx context.Context, rawID string) error {
 		}
 	}
 
-	// Step 7: Mark the raw memory as processed
-	if err := ea.store.MarkRawProcessed(ctx, raw.ID); err != nil {
-		ea.log.Error("failed to mark raw memory as processed", "raw_id", raw.ID, "error", err)
-		// Don't fail the entire operation, just log
-	}
+	// Step 7: Raw was already claimed (processed=1) in Step 0. No additional mark needed.
 
 	// Step 8: Publish MemoryEncoded event
 	encodedEvent := events.MemoryEncoded{

--- a/internal/agent/encoding/agent_test.go
+++ b/internal/agent/encoding/agent_test.go
@@ -24,18 +24,19 @@ import (
 
 type mockStore struct {
 	storetest.MockStore
-	getRawFn             func(ctx context.Context, id string) (store.RawMemory, error)
-	listRawUnprocessedFn func(ctx context.Context, limit int) ([]store.RawMemory, error)
-	markRawProcessedFn   func(ctx context.Context, id string) error
-	writeMemoryFn        func(ctx context.Context, mem store.Memory) error
-	searchByEmbeddingFn  func(ctx context.Context, embedding []float32, limit int) ([]store.RetrievalResult, error)
-	createAssociationFn  func(ctx context.Context, assoc store.Association) error
-	countMemoriesFn      func(ctx context.Context) (int, error)
-	getOpenEpisodeFn     func(ctx context.Context) (store.Episode, error)
-	searchByConceptsFn   func(ctx context.Context, concepts []string, limit int) ([]store.Memory, error)
-	writeMemoryResFn     func(ctx context.Context, res store.MemoryResolution) error
-	writeConceptSetFn    func(ctx context.Context, cs store.ConceptSet) error
-	writeMemoryAttrsFn   func(ctx context.Context, attrs store.MemoryAttributes) error
+	getRawFn              func(ctx context.Context, id string) (store.RawMemory, error)
+	listRawUnprocessedFn  func(ctx context.Context, limit int) ([]store.RawMemory, error)
+	markRawProcessedFn    func(ctx context.Context, id string) error
+	claimRawForEncodingFn func(ctx context.Context, id string) error
+	writeMemoryFn         func(ctx context.Context, mem store.Memory) error
+	searchByEmbeddingFn   func(ctx context.Context, embedding []float32, limit int) ([]store.RetrievalResult, error)
+	createAssociationFn   func(ctx context.Context, assoc store.Association) error
+	countMemoriesFn       func(ctx context.Context) (int, error)
+	getOpenEpisodeFn      func(ctx context.Context) (store.Episode, error)
+	searchByConceptsFn    func(ctx context.Context, concepts []string, limit int) ([]store.Memory, error)
+	writeMemoryResFn      func(ctx context.Context, res store.MemoryResolution) error
+	writeConceptSetFn     func(ctx context.Context, cs store.ConceptSet) error
+	writeMemoryAttrsFn    func(ctx context.Context, attrs store.MemoryAttributes) error
 }
 
 func (m *mockStore) GetRaw(ctx context.Context, id string) (store.RawMemory, error) {
@@ -53,6 +54,12 @@ func (m *mockStore) ListRawUnprocessed(ctx context.Context, limit int) ([]store.
 func (m *mockStore) MarkRawProcessed(ctx context.Context, id string) error {
 	if m.markRawProcessedFn != nil {
 		return m.markRawProcessedFn(ctx, id)
+	}
+	return nil
+}
+func (m *mockStore) ClaimRawForEncoding(ctx context.Context, id string) error {
+	if m.claimRawForEncodingFn != nil {
+		return m.claimRawForEncodingFn(ctx, id)
 	}
 	return nil
 }
@@ -943,7 +950,7 @@ func TestEncodeMemory(t *testing.T) {
 				writtenMemory = mem
 				return nil
 			},
-			markRawProcessedFn: func(_ context.Context, id string) error {
+			claimRawForEncodingFn: func(_ context.Context, id string) error {
 				if id == "raw-1" {
 					markedProcessed = true
 				}

--- a/internal/store/sqlite/schema.go
+++ b/internal/store/sqlite/schema.go
@@ -415,6 +415,25 @@ CREATE INDEX IF NOT EXISTS idx_tool_usage_tool ON tool_usage(tool_name);
 		return fmt.Errorf("failed to add retrieval_feedback.access_snapshot column: %w", err)
 	}
 
+	// Migration 011: Unique constraint on memories.raw_id to prevent duplicate encoding.
+	// Multiple mnemonic processes (daemon + MCP instances) share the same DB; without a
+	// DB-level guard, each process can independently encode the same raw memory.
+	// Step 1: Delete duplicate encoded memories, keeping the oldest per raw_id.
+	_, _ = db.Exec(`
+		DELETE FROM memories
+		WHERE raw_id IS NOT NULL
+		  AND id NOT IN (
+		    SELECT id FROM (
+		      SELECT id, ROW_NUMBER() OVER (PARTITION BY raw_id ORDER BY created_at ASC) as rn
+		      FROM memories
+		      WHERE raw_id IS NOT NULL
+		    ) ranked
+		    WHERE rn = 1
+		  )
+	`)
+	// Step 2: Create unique partial index (allows NULLs for gist/consolidated memories).
+	_, _ = db.Exec(`CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_raw_id_unique ON memories(raw_id) WHERE raw_id IS NOT NULL`)
+
 	return nil
 }
 

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -708,6 +708,38 @@ func (s *SQLiteStore) MarkRawProcessed(ctx context.Context, id string) error {
 	return nil
 }
 
+// ClaimRawForEncoding atomically claims a raw memory for encoding.
+// It sets processed=1 only if the current value is 0 (unclaimed).
+// Returns store.ErrAlreadyClaimed if another process already claimed it.
+func (s *SQLiteStore) ClaimRawForEncoding(ctx context.Context, id string) error {
+	query := `UPDATE raw_memories SET processed = 1 WHERE id = ? AND processed = 0`
+
+	result, err := s.db.ExecContext(ctx, query, id)
+	if err != nil {
+		return fmt.Errorf("failed to claim raw memory for encoding: %w", err)
+	}
+
+	rowsAffected, err := result.RowsAffected()
+	if err != nil {
+		return fmt.Errorf("failed to get rows affected: %w", err)
+	}
+
+	if rowsAffected == 0 {
+		return store.ErrAlreadyClaimed
+	}
+
+	return nil
+}
+
+// UnclaimRawMemory resets a raw memory to unprocessed so it can be retried.
+func (s *SQLiteStore) UnclaimRawMemory(ctx context.Context, id string) error {
+	_, err := s.db.ExecContext(ctx, `UPDATE raw_memories SET processed = 0 WHERE id = ?`, id)
+	if err != nil {
+		return fmt.Errorf("failed to unclaim raw memory: %w", err)
+	}
+	return nil
+}
+
 // Memory Operations
 
 // WriteMemory writes a memory to the database.
@@ -762,6 +794,10 @@ func (s *SQLiteStore) WriteMemory(ctx context.Context, mem store.Memory) error {
 	)
 
 	if err != nil {
+		// Check for UNIQUE constraint violation on raw_id (cross-process dedup).
+		if strings.Contains(err.Error(), "UNIQUE constraint failed") && strings.Contains(err.Error(), "raw_id") {
+			return fmt.Errorf("memory for raw_id %s: %w", mem.RawID, store.ErrDuplicateRawID)
+		}
 		return fmt.Errorf("failed to write memory: %w", err)
 	}
 

--- a/internal/store/sqlite/sqlite_test.go
+++ b/internal/store/sqlite/sqlite_test.go
@@ -4,6 +4,7 @@ package sqlite
 
 import (
 	"context"
+	"errors"
 	"path/filepath"
 	"testing"
 	"time"
@@ -935,6 +936,93 @@ func TestMarkRawProcessed(t *testing.T) {
 
 	if !retrieved.Processed {
 		t.Fatal("expected raw memory to be marked processed")
+	}
+}
+
+// TestClaimRawForEncoding tests the atomic claim-or-skip behavior.
+func TestClaimRawForEncoding(t *testing.T) {
+	s := createTestStore(t)
+	defer func() { _ = s.Close() }()
+
+	ctx := context.Background()
+
+	raw := store.RawMemory{
+		ID:              "claim-test-1",
+		Timestamp:       time.Now(),
+		Source:          "test",
+		Content:         "test content",
+		Processed:       false,
+		CreatedAt:       time.Now(),
+		HeuristicScore:  0.5,
+		InitialSalience: 0.6,
+	}
+
+	if err := s.WriteRaw(ctx, raw); err != nil {
+		t.Fatalf("write raw failed: %v", err)
+	}
+
+	// First claim should succeed
+	if err := s.ClaimRawForEncoding(ctx, raw.ID); err != nil {
+		t.Fatalf("first claim should succeed: %v", err)
+	}
+
+	// Second claim should return ErrAlreadyClaimed
+	err := s.ClaimRawForEncoding(ctx, raw.ID)
+	if err == nil {
+		t.Fatal("second claim should fail")
+	}
+	if !errors.Is(err, store.ErrAlreadyClaimed) {
+		t.Fatalf("expected ErrAlreadyClaimed, got: %v", err)
+	}
+
+	// Verify raw is marked processed
+	retrieved, err := s.GetRaw(ctx, raw.ID)
+	if err != nil {
+		t.Fatalf("get raw failed: %v", err)
+	}
+	if !retrieved.Processed {
+		t.Fatal("expected raw memory to be marked processed after claim")
+	}
+}
+
+// TestWriteMemoryDuplicateRawID tests the UNIQUE constraint on raw_id.
+func TestWriteMemoryDuplicateRawID(t *testing.T) {
+	s := createTestStore(t)
+	defer func() { _ = s.Close() }()
+
+	ctx := context.Background()
+
+	mem1 := store.Memory{
+		ID:        "m1",
+		RawID:     "raw-1",
+		Timestamp: time.Now(),
+		Content:   "first encoding",
+		Summary:   "first",
+		State:     "active",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+	mem2 := store.Memory{
+		ID:        "m2",
+		RawID:     "raw-1", // same raw_id
+		Timestamp: time.Now(),
+		Content:   "duplicate encoding",
+		Summary:   "duplicate",
+		State:     "active",
+		CreatedAt: time.Now(),
+		UpdatedAt: time.Now(),
+	}
+
+	if err := s.WriteMemory(ctx, mem1); err != nil {
+		t.Fatalf("first write should succeed: %v", err)
+	}
+
+	err := s.WriteMemory(ctx, mem2)
+	if err == nil {
+		t.Fatal("second write with same raw_id should fail")
+	}
+	if !errors.Is(err, store.ErrDuplicateRawID) {
+		t.Fatalf("expected ErrDuplicateRawID, got: %v", err)
 	}
 }
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -11,6 +11,12 @@ import (
 // ErrNotFound is returned when a requested entity does not exist.
 var ErrNotFound = errors.New("not found")
 
+// ErrAlreadyClaimed is returned when a raw memory has already been claimed for encoding by another process.
+var ErrAlreadyClaimed = errors.New("already claimed")
+
+// ErrDuplicateRawID is returned when a memory with the same raw_id already exists.
+var ErrDuplicateRawID = errors.New("duplicate raw_id")
+
 // Memory state constants.
 const (
 	MemoryStateActive   = "active"
@@ -120,7 +126,7 @@ type LLMChartBucket struct {
 // ToolUsageRecord captures metrics from a single MCP tool invocation.
 type ToolUsageRecord struct {
 	Timestamp    time.Time `json:"timestamp"`
-	ToolName     string    `json:"tool_name"`     // "recall", "remember", "feedback", etc.
+	ToolName     string    `json:"tool_name"` // "recall", "remember", "feedback", etc.
 	SessionID    string    `json:"session_id"`
 	Project      string    `json:"project"`
 	LatencyMs    int64     `json:"latency_ms"`
@@ -135,11 +141,11 @@ type ToolUsageRecord struct {
 
 // ToolUsageSummary aggregates MCP tool usage metrics over a time period.
 type ToolUsageSummary struct {
-	TotalCalls   int                `json:"total_calls"`
-	AvgLatencyMs float64            `json:"avg_latency_ms"`
-	ErrorCount   int                `json:"error_count"`
-	ByTool       map[string]int     `json:"by_tool"`
-	ByProject    map[string]int     `json:"by_project"`
+	TotalCalls   int            `json:"total_calls"`
+	AvgLatencyMs float64        `json:"avg_latency_ms"`
+	ErrorCount   int            `json:"error_count"`
+	ByTool       map[string]int `json:"by_tool"`
+	ByProject    map[string]int `json:"by_project"`
 }
 
 // ToolChartBucket holds pre-aggregated tool call counts for a single time bucket.
@@ -343,6 +349,14 @@ type Store interface {
 	ListRawUnprocessed(ctx context.Context, limit int) ([]RawMemory, error)
 	ListRawMemoriesAfter(ctx context.Context, after time.Time, limit int) ([]RawMemory, error)
 	MarkRawProcessed(ctx context.Context, id string) error
+	// ClaimRawForEncoding atomically marks a raw memory as processed only if it
+	// hasn't been claimed yet (processed=0). Returns ErrAlreadyClaimed if another
+	// process already claimed it. This prevents duplicate encoding across multiple
+	// mnemonic processes sharing the same database.
+	ClaimRawForEncoding(ctx context.Context, id string) error
+	// UnclaimRawMemory resets a raw memory to unprocessed (processed=0) so it
+	// can be retried after a failed encoding attempt.
+	UnclaimRawMemory(ctx context.Context, id string) error
 
 	// --- Encoded memory operations ---
 	WriteMemory(ctx context.Context, mem Memory) error

--- a/internal/store/storetest/mock.go
+++ b/internal/store/storetest/mock.go
@@ -30,7 +30,9 @@ func (MockStore) ListRawUnprocessed(context.Context, int) ([]store.RawMemory, er
 func (MockStore) ListRawMemoriesAfter(context.Context, time.Time, int) ([]store.RawMemory, error) {
 	return nil, nil
 }
-func (MockStore) MarkRawProcessed(context.Context, string) error { return nil }
+func (MockStore) MarkRawProcessed(context.Context, string) error    { return nil }
+func (MockStore) ClaimRawForEncoding(context.Context, string) error { return nil }
+func (MockStore) UnclaimRawMemory(context.Context, string) error    { return nil }
 
 // --- Encoded memory operations ---
 

--- a/migrations/005_unique_raw_id.sql
+++ b/migrations/005_unique_raw_id.sql
@@ -1,0 +1,33 @@
+-- Migration 005: Add unique constraint on memories.raw_id
+-- Prevents duplicate encoding of the same raw memory across processes.
+
+-- Step 1: Remove duplicate encoded memories, keeping only the oldest per raw_id.
+-- For each raw_id with multiple encoded memories, keep the one with the earliest
+-- created_at and archive the rest.
+UPDATE memories
+SET state = 'archived'
+WHERE raw_id IS NOT NULL
+  AND id NOT IN (
+    SELECT id FROM (
+      SELECT id, ROW_NUMBER() OVER (PARTITION BY raw_id ORDER BY created_at ASC) as rn
+      FROM memories
+      WHERE raw_id IS NOT NULL
+    ) ranked
+    WHERE rn = 1
+  )
+  AND state != 'archived';
+
+-- Step 2: Delete archived duplicates (they have no unique value).
+DELETE FROM memories
+WHERE raw_id IS NOT NULL
+  AND id NOT IN (
+    SELECT id FROM (
+      SELECT id, ROW_NUMBER() OVER (PARTITION BY raw_id ORDER BY created_at ASC) as rn
+      FROM memories
+      WHERE raw_id IS NOT NULL
+    ) ranked
+    WHERE rn = 1
+  );
+
+-- Step 3: Create unique index on raw_id (partial — allows NULLs).
+CREATE UNIQUE INDEX IF NOT EXISTS idx_memories_raw_id_unique ON memories(raw_id) WHERE raw_id IS NOT NULL;


### PR DESCRIPTION
## Summary

- Every `mnemonic mcp` process starts its own encoding agent with a polling loop. With 9+ concurrent MCP processes sharing the same DB, each independently encodes the same raw memory — producing 7-8 duplicates per `remember` call
- Root cause: the in-memory `processingMemories` guard is per-process, useless across process boundaries

## Fix (3 layers)

- **Atomic DB claim** (`ClaimRawForEncoding`): `UPDATE SET processed=1 WHERE processed=0` — only one process wins the race. Failed encodings unclaim via `UnclaimRawMemory` so retries still work
- **Polling disabled in MCP mode**: MCP processes only encode via events for memories they create. The daemon is the sole poller
- **UNIQUE constraint on `memories(raw_id)`**: DB-level backstop. Migration deduplicates existing rows, then creates a partial unique index. `WriteMemory` returns `ErrDuplicateRawID` on violation

## Test plan

- [x] Unit tests for `ClaimRawForEncoding` (atomic claim, double-claim returns `ErrAlreadyClaimed`)
- [x] Unit tests for `WriteMemory` duplicate `raw_id` (returns `ErrDuplicateRawID`)
- [x] Existing encoding tests updated to use `ClaimRawForEncoding`
- [x] Benchmark tests updated for unique `raw_id` per memory
- [x] Live test: single `remember` → exactly 1 encoded memory (was 7-8 before)
- [x] All tests pass, `golangci-lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)