### PR TITLE
feat: feedback-informed ranking and source-weighted scoring

### DIFF
--- a/cmd/mnemonic/main.go
+++ b/cmd/mnemonic/main.go
@@ -1794,7 +1794,22 @@ func buildRetrievalConfig(cfg *config.Config) retrieval.RetrievalConfig {
 
 		DiversityLambda:    float32(cfg.Retrieval.DiversityLambda),
 		DiversityThreshold: float32(cfg.Retrieval.DiversityThreshold),
+
+		FeedbackWeight: float32(cfg.Retrieval.FeedbackWeight),
+		SourceWeights:  convertSourceWeights(cfg.Retrieval.SourceWeights),
 	}
+}
+
+// convertSourceWeights converts map[string]float64 to map[string]float32.
+func convertSourceWeights(src map[string]float64) map[string]float32 {
+	if src == nil {
+		return nil
+	}
+	out := make(map[string]float32, len(src))
+	for k, v := range src {
+		out[k] = float32(v)
+	}
+	return out
 }
 
 // initRuntime loads config, opens store and LLM for CLI commands.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -359,6 +359,19 @@ retrieval:
   # Bonus for memories found by both FTS and embedding search
   dual_hit_bonus: 0.15
 
+  # Weight of user feedback in ranking (0.0-1.0).
+  # Memories rated "helpful" get +feedback_weight, "irrelevant" get -feedback_weight.
+  feedback_weight: 0.15
+
+  # Per-source multipliers for unfiltered recall.
+  # Noisier sources (filesystem, clipboard) are down-weighted relative to MCP memories.
+  # Unknown sources default to 1.0.
+  source_weights:
+    mcp: 1.0
+    terminal: 0.8
+    clipboard: 0.6
+    filesystem: 0.5
+
 # Metacognition Configuration
 metacognition:
   # Enable metacognitive reflection

--- a/internal/agent/retrieval/agent.go
+++ b/internal/agent/retrieval/agent.go
@@ -55,6 +55,12 @@ type RetrievalConfig struct {
 	// Diversity filtering (MMR)
 	DiversityLambda    float32 // 0=max diversity, 1=pure relevance (default: 0.7)
 	DiversityThreshold float32 // cosine sim above which memories are near-duplicates (default: 0.85)
+
+	// Feedback-informed ranking
+	FeedbackWeight float32 // weight of user feedback score in ranking (default: 0.15)
+
+	// Source-weighted scoring
+	SourceWeights map[string]float32 // per-source multipliers (default: mcp=1.0, terminal=0.8, clipboard=0.6, filesystem=0.5)
 }
 
 // DefaultConfig returns sensible defaults for retrieval configuration.
@@ -91,6 +97,14 @@ func DefaultConfig() RetrievalConfig {
 
 		DiversityLambda:    0.7,
 		DiversityThreshold: 0.85,
+
+		FeedbackWeight: 0.15,
+		SourceWeights: map[string]float32{
+			"mcp":        1.0,
+			"terminal":   0.8,
+			"clipboard":  0.6,
+			"filesystem": 0.5,
+		},
 	}
 }
 
@@ -505,12 +519,28 @@ func (ra *RetrievalAgent) spreadActivation(ctx context.Context, entryPoints map[
 // rankResults sorts activated memories by a combined score and prepares results.
 func (ra *RetrievalAgent) rankResults(ctx context.Context, activated map[string]activationState, includeReasoning bool) []store.RetrievalResult {
 	type scoredMemory struct {
-		mem           store.Memory
-		activation    float32
-		finalScore    float32
-		recencyBonus  float32
-		activityBonus float32
+		mem            store.Memory
+		activation     float32
+		finalScore     float32
+		recencyBonus   float32
+		activityBonus  float32
+		sourceWeight   float32
+		feedbackAdjust float32
 	}
+
+	// Collect memory IDs for batch feedback lookup
+	memoryIDs := make([]string, 0, len(activated))
+	for memID := range activated {
+		memoryIDs = append(memoryIDs, memID)
+	}
+
+	// Fetch feedback scores for all candidate memories
+	feedbackScores, err := ra.store.GetMemoryFeedbackScores(ctx, memoryIDs)
+	if err != nil {
+		ra.log.Warn("failed to fetch feedback scores for ranking", "error", err)
+		feedbackScores = nil
+	}
+	feedbackWt := f32Or(ra.config.FeedbackWeight, 0.15)
 
 	scored := make([]scoredMemory, 0, len(activated))
 
@@ -538,25 +568,43 @@ func (ra *RetrievalAgent) rankResults(ctx context.Context, activated map[string]
 		activityBonus := float32(math.Min(actMax, actScale*math.Log1p(float64(state.activationCount))))
 
 		// Combined score
-		finalScore := state.activation * (1.0 + recencyBonus + activityBonus)
+		baseScore := state.activation * (1.0 + recencyBonus + activityBonus)
 
 		// Valence boost for significant memories
 		attrs, attrErr := ra.store.GetMemoryAttributes(ctx, memID)
 		if attrErr == nil {
 			switch attrs.Significance {
 			case "critical":
-				finalScore *= f32Or(ra.config.CriticalBoost, 1.2)
+				baseScore *= f32Or(ra.config.CriticalBoost, 1.2)
 			case "important":
-				finalScore *= f32Or(ra.config.ImportantBoost, 1.1)
+				baseScore *= f32Or(ra.config.ImportantBoost, 1.1)
 			}
 		}
 
+		// Apply source weight as a multiplier (before feedback adjustment)
+		sourceWeight := float32(1.0)
+		if ra.config.SourceWeights != nil {
+			if sw, ok := ra.config.SourceWeights[mem.Source]; ok && sw > 0 {
+				sourceWeight = sw
+			}
+		}
+		finalScore := baseScore * sourceWeight
+
+		// Apply feedback adjustment (after source weighting)
+		var feedbackAdjust float32
+		if fbScore, ok := feedbackScores[memID]; ok {
+			feedbackAdjust = fbScore * feedbackWt
+			finalScore += feedbackAdjust
+		}
+
 		scored = append(scored, scoredMemory{
-			mem:           mem,
-			activation:    state.activation,
-			finalScore:    finalScore,
-			recencyBonus:  recencyBonus,
-			activityBonus: activityBonus,
+			mem:            mem,
+			activation:     state.activation,
+			finalScore:     finalScore,
+			recencyBonus:   recencyBonus,
+			activityBonus:  activityBonus,
+			sourceWeight:   sourceWeight,
+			feedbackAdjust: feedbackAdjust,
 		})
 	}
 
@@ -571,8 +619,8 @@ func (ra *RetrievalAgent) rankResults(ctx context.Context, activated map[string]
 		explanation := ""
 		if includeReasoning {
 			explanation = fmt.Sprintf(
-				"activation: %.3f, recency_bonus: %.3f, activity_bonus: %.3f, combined_score: %.3f",
-				sm.activation, sm.recencyBonus, sm.activityBonus, sm.finalScore,
+				"activation: %.3f, recency_bonus: %.3f, activity_bonus: %.3f, source_weight: %.2f, feedback_adjust: %.3f, combined_score: %.3f",
+				sm.activation, sm.recencyBonus, sm.activityBonus, sm.sourceWeight, sm.feedbackAdjust, sm.finalScore,
 			)
 		}
 

--- a/internal/agent/retrieval/agent_test.go
+++ b/internal/agent/retrieval/agent_test.go
@@ -85,7 +85,8 @@ type mockStore struct {
 	getAssociationsFunc   func(ctx context.Context, memoryID string) ([]store.Association, error)
 	getMemoryFunc         func(ctx context.Context, id string) (store.Memory, error)
 	incrementAccessFunc   func(ctx context.Context, id string) error
-	getMemoryAttrsFunc    func(ctx context.Context, memoryID string) (store.MemoryAttributes, error)
+	getMemoryAttrsFunc         func(ctx context.Context, memoryID string) (store.MemoryAttributes, error)
+	getMemoryFeedbackScoresFunc func(ctx context.Context, memoryIDs []string) (map[string]float32, error)
 
 	// Call tracking
 	incrementAccessCalls []string
@@ -130,6 +131,12 @@ func (m *mockStore) GetMemoryAttributes(ctx context.Context, memoryID string) (s
 		return m.getMemoryAttrsFunc(ctx, memoryID)
 	}
 	return store.MemoryAttributes{}, fmt.Errorf("no attributes")
+}
+func (m *mockStore) GetMemoryFeedbackScores(ctx context.Context, memoryIDs []string) (map[string]float32, error) {
+	if m.getMemoryFeedbackScoresFunc != nil {
+		return m.getMemoryFeedbackScoresFunc(ctx, memoryIDs)
+	}
+	return nil, nil
 }
 
 // ---------------------------------------------------------------------------
@@ -1008,4 +1015,231 @@ func abs32(x float32) float32 {
 		return -x
 	}
 	return x
+}
+
+// ---------------------------------------------------------------------------
+// Feedback-informed ranking tests
+// ---------------------------------------------------------------------------
+
+func TestRankResults_FeedbackInfluence(t *testing.T) {
+	// Two memories with identical activation scores; feedback should differentiate them.
+	memA := store.Memory{ID: "helpful-mem", Summary: "helpful memory", Salience: 0.5, Source: "mcp", LastAccessed: time.Now()}
+	memB := store.Memory{ID: "irrelevant-mem", Summary: "irrelevant memory", Salience: 0.5, Source: "mcp", LastAccessed: time.Now()}
+
+	s := &mockStore{
+		getMemoryFunc: func(_ context.Context, id string) (store.Memory, error) {
+			switch id {
+			case memA.ID:
+				return memA, nil
+			case memB.ID:
+				return memB, nil
+			default:
+				return store.Memory{}, fmt.Errorf("not found")
+			}
+		},
+		getMemoryFeedbackScoresFunc: func(_ context.Context, ids []string) (map[string]float32, error) {
+			return map[string]float32{
+				"helpful-mem":    1.0,  // consistently helpful
+				"irrelevant-mem": -1.0, // consistently irrelevant
+			}, nil
+		},
+	}
+
+	cfg := DefaultConfig()
+	cfg.FeedbackWeight = 0.15
+	agent := NewRetrievalAgent(s, &mockLLMProvider{}, cfg, testLogger())
+
+	activated := map[string]activationState{
+		memA.ID: {activation: 0.8},
+		memB.ID: {activation: 0.8},
+	}
+
+	results := agent.rankResults(context.Background(), activated, true)
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	// The helpful memory should rank higher
+	if results[0].Memory.ID != "helpful-mem" {
+		t.Errorf("expected helpful-mem to rank first, got %s", results[0].Memory.ID)
+	}
+	if results[1].Memory.ID != "irrelevant-mem" {
+		t.Errorf("expected irrelevant-mem to rank second, got %s", results[1].Memory.ID)
+	}
+
+	// Score difference should be ~0.3 (0.15 * 1.0 - 0.15 * -1.0)
+	diff := results[0].Score - results[1].Score
+	if diff < 0.2 || diff > 0.4 {
+		t.Errorf("expected score difference ~0.3 from feedback, got %.3f (scores: %.3f, %.3f)",
+			diff, results[0].Score, results[1].Score)
+	}
+}
+
+func TestRankResults_FeedbackErrorGraceful(t *testing.T) {
+	// When feedback lookup fails, ranking should still work (graceful degradation).
+	mem := store.Memory{ID: "m1", Summary: "test", Salience: 0.5, Source: "mcp", LastAccessed: time.Now()}
+
+	s := &mockStore{
+		getMemoryFunc: func(_ context.Context, id string) (store.Memory, error) {
+			return mem, nil
+		},
+		getMemoryFeedbackScoresFunc: func(_ context.Context, _ []string) (map[string]float32, error) {
+			return nil, fmt.Errorf("database error")
+		},
+	}
+
+	cfg := DefaultConfig()
+	agent := NewRetrievalAgent(s, &mockLLMProvider{}, cfg, testLogger())
+
+	activated := map[string]activationState{
+		"m1": {activation: 0.7},
+	}
+
+	results := agent.rankResults(context.Background(), activated, false)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result despite feedback error, got %d", len(results))
+	}
+	if results[0].Score <= 0 {
+		t.Errorf("expected positive score, got %f", results[0].Score)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// Source-weighted scoring tests
+// ---------------------------------------------------------------------------
+
+func TestRankResults_SourceWeighting(t *testing.T) {
+	// Two memories with identical activation, different sources.
+	now := time.Now()
+	mcpMem := store.Memory{ID: "mcp-mem", Summary: "mcp memory", Salience: 0.5, Source: "mcp", LastAccessed: now}
+	fsMem := store.Memory{ID: "fs-mem", Summary: "filesystem memory", Salience: 0.5, Source: "filesystem", LastAccessed: now}
+
+	s := &mockStore{
+		getMemoryFunc: func(_ context.Context, id string) (store.Memory, error) {
+			switch id {
+			case mcpMem.ID:
+				return mcpMem, nil
+			case fsMem.ID:
+				return fsMem, nil
+			default:
+				return store.Memory{}, fmt.Errorf("not found")
+			}
+		},
+	}
+
+	cfg := DefaultConfig()
+	cfg.SourceWeights = map[string]float32{
+		"mcp":        1.0,
+		"filesystem": 0.5,
+	}
+	agent := NewRetrievalAgent(s, &mockLLMProvider{}, cfg, testLogger())
+
+	activated := map[string]activationState{
+		mcpMem.ID: {activation: 0.8},
+		fsMem.ID:  {activation: 0.8},
+	}
+
+	results := agent.rankResults(context.Background(), activated, false)
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	// MCP memory (weight 1.0) should rank higher than filesystem (weight 0.5)
+	if results[0].Memory.ID != "mcp-mem" {
+		t.Errorf("expected mcp-mem to rank first, got %s", results[0].Memory.ID)
+	}
+
+	// The filesystem score should be roughly half the MCP score
+	ratio := results[1].Score / results[0].Score
+	if ratio < 0.4 || ratio > 0.6 {
+		t.Errorf("expected score ratio ~0.5, got %.3f (mcp=%.3f, fs=%.3f)",
+			ratio, results[0].Score, results[1].Score)
+	}
+}
+
+func TestRankResults_UnknownSourceGetsWeight1(t *testing.T) {
+	// Unknown source should default to weight 1.0 (no penalty).
+	now := time.Now()
+	mem := store.Memory{ID: "m1", Summary: "test", Salience: 0.5, Source: "unknown_source", LastAccessed: now}
+
+	s := &mockStore{
+		getMemoryFunc: func(_ context.Context, id string) (store.Memory, error) {
+			return mem, nil
+		},
+	}
+
+	cfg := DefaultConfig()
+	cfg.SourceWeights = map[string]float32{
+		"mcp":        1.0,
+		"filesystem": 0.5,
+	}
+	agent := NewRetrievalAgent(s, &mockLLMProvider{}, cfg, testLogger())
+
+	activated := map[string]activationState{
+		"m1": {activation: 0.8},
+	}
+
+	results := agent.rankResults(context.Background(), activated, false)
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	// With source weight 1.0 (default) and activation 0.8, the base score should be
+	// 0.8 * (1.0 + recency_bonus + activity_bonus) ~ 0.8 * (1.0 + ~0.2) = ~0.96
+	// The important thing is it's not penalized.
+	if results[0].Score < 0.7 {
+		t.Errorf("expected score > 0.7 for unknown source (weight 1.0), got %f", results[0].Score)
+	}
+}
+
+func TestRankResults_SourceAndFeedbackCombined(t *testing.T) {
+	// Source weighting applies first (as multiplier), then feedback adjustment (additive).
+	now := time.Now()
+	fsMem := store.Memory{ID: "fs-helpful", Summary: "fs helpful", Salience: 0.5, Source: "filesystem", LastAccessed: now}
+	mcpMem := store.Memory{ID: "mcp-irrelevant", Summary: "mcp irrelevant", Salience: 0.5, Source: "mcp", LastAccessed: now}
+
+	s := &mockStore{
+		getMemoryFunc: func(_ context.Context, id string) (store.Memory, error) {
+			switch id {
+			case fsMem.ID:
+				return fsMem, nil
+			case mcpMem.ID:
+				return mcpMem, nil
+			default:
+				return store.Memory{}, fmt.Errorf("not found")
+			}
+		},
+		getMemoryFeedbackScoresFunc: func(_ context.Context, _ []string) (map[string]float32, error) {
+			return map[string]float32{
+				"fs-helpful":      1.0,  // strong positive feedback
+				"mcp-irrelevant": -1.0, // strong negative feedback
+			}, nil
+		},
+	}
+
+	cfg := DefaultConfig()
+	cfg.SourceWeights = map[string]float32{
+		"mcp":        1.0,
+		"filesystem": 0.5,
+	}
+	cfg.FeedbackWeight = 0.3 // high weight to override source bias
+	agent := NewRetrievalAgent(s, &mockLLMProvider{}, cfg, testLogger())
+
+	activated := map[string]activationState{
+		fsMem.ID:  {activation: 0.8},
+		mcpMem.ID: {activation: 0.8},
+	}
+
+	results := agent.rankResults(context.Background(), activated, false)
+	if len(results) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(results))
+	}
+
+	// With high feedback weight, the filesystem memory (helpful, +0.3) should overcome
+	// its 0.5x source penalty relative to the MCP memory (irrelevant, -0.3).
+	// fs score: 0.8 * ~1.2 * 0.5 + 0.3 = ~0.78
+	// mcp score: 0.8 * ~1.2 * 1.0 - 0.3 = ~0.66
+	if results[0].Memory.ID != "fs-helpful" {
+		t.Errorf("expected feedback to override source bias; got %s first", results[0].Memory.ID)
+	}
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -257,6 +257,12 @@ type RetrievalConfig struct {
 	// Diversity filtering (MMR)
 	DiversityLambda    float64 `yaml:"diversity_lambda"`    // 0=max diversity, 1=pure relevance (default 0.7)
 	DiversityThreshold float64 `yaml:"diversity_threshold"` // cosine sim above which memories are near-duplicates (default 0.85)
+
+	// Feedback-informed ranking
+	FeedbackWeight float64 `yaml:"feedback_weight"` // weight of user feedback score in ranking (default 0.15)
+
+	// Source-weighted scoring
+	SourceWeights map[string]float64 `yaml:"source_weights"` // per-source multipliers (default: mcp=1.0, terminal=0.8, clipboard=0.6, filesystem=0.5)
 }
 
 // MetacognitionConfig holds metacognition settings.
@@ -593,6 +599,14 @@ func Default() *Config {
 
 			DiversityLambda:    0.7,
 			DiversityThreshold: 0.85,
+
+			FeedbackWeight: 0.15,
+			SourceWeights: map[string]float64{
+				"mcp":        1.0,
+				"terminal":   0.8,
+				"clipboard":  0.6,
+				"filesystem": 0.5,
+			},
 		},
 		Metacognition: MetacognitionConfig{
 			Enabled:     true,

--- a/internal/store/sqlite/feedback_scores_test.go
+++ b/internal/store/sqlite/feedback_scores_test.go
@@ -1,0 +1,132 @@
+//go:build sqlite_fts5
+
+package sqlite
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	store "github.com/appsprout-dev/mnemonic/internal/store"
+)
+
+func TestGetMemoryFeedbackScores(t *testing.T) {
+	s := createTestStore(t)
+	defer func() { _ = s.Close() }()
+	ctx := context.Background()
+
+	// Insert some feedback records
+	now := time.Now()
+	feedbacks := []store.RetrievalFeedback{
+		{
+			QueryID:      "q1",
+			QueryText:    "test query 1",
+			RetrievedIDs: []string{"m1", "m2", "m3"},
+			Feedback:     "helpful",
+			CreatedAt:    now,
+		},
+		{
+			QueryID:      "q2",
+			QueryText:    "test query 2",
+			RetrievedIDs: []string{"m1", "m3"},
+			Feedback:     "irrelevant",
+			CreatedAt:    now,
+		},
+		{
+			QueryID:      "q3",
+			QueryText:    "test query 3",
+			RetrievedIDs: []string{"m2"},
+			Feedback:     "partial",
+			CreatedAt:    now,
+		},
+		{
+			QueryID:      "q4",
+			QueryText:    "test query 4 (no rating)",
+			RetrievedIDs: []string{"m1", "m2"},
+			Feedback:     "",
+			CreatedAt:    now,
+		},
+	}
+	for _, fb := range feedbacks {
+		if err := s.WriteRetrievalFeedback(ctx, fb); err != nil {
+			t.Fatalf("failed to write feedback: %v", err)
+		}
+	}
+
+	t.Run("scores computed correctly", func(t *testing.T) {
+		scores, err := s.GetMemoryFeedbackScores(ctx, []string{"m1", "m2", "m3", "m4"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+
+		// m1: helpful(+1) + irrelevant(-1) = 0/2 = 0.0
+		if score, ok := scores["m1"]; !ok || abs32(score-0.0) > 0.001 {
+			t.Errorf("m1 score: want ~0.0, got %v (present=%v)", score, ok)
+		}
+
+		// m2: helpful(+1) + partial(0) = 1/2 = 0.5
+		if score, ok := scores["m2"]; !ok || abs32(score-0.5) > 0.001 {
+			t.Errorf("m2 score: want ~0.5, got %v (present=%v)", score, ok)
+		}
+
+		// m3: helpful(+1) + irrelevant(-1) = 0/2 = 0.0
+		if score, ok := scores["m3"]; !ok || abs32(score-0.0) > 0.001 {
+			t.Errorf("m3 score: want ~0.0, got %v (present=%v)", score, ok)
+		}
+
+		// m4: no feedback records
+		if _, ok := scores["m4"]; ok {
+			t.Errorf("m4 should not have a score")
+		}
+	})
+
+	t.Run("empty input returns nil", func(t *testing.T) {
+		scores, err := s.GetMemoryFeedbackScores(ctx, []string{})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if scores != nil {
+			t.Errorf("expected nil for empty input, got %v", scores)
+		}
+	})
+
+	t.Run("nil input returns nil", func(t *testing.T) {
+		scores, err := s.GetMemoryFeedbackScores(ctx, nil)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if scores != nil {
+			t.Errorf("expected nil for nil input, got %v", scores)
+		}
+	})
+
+	t.Run("consistently helpful memory gets score 1.0", func(t *testing.T) {
+		// Write additional feedback where m5 is always helpful
+		for i := 0; i < 3; i++ {
+			fb := store.RetrievalFeedback{
+				QueryID:      "q_helpful_" + string(rune('a'+i)),
+				QueryText:    "helpful query",
+				RetrievedIDs: []string{"m5"},
+				Feedback:     "helpful",
+				CreatedAt:    now,
+			}
+			if err := s.WriteRetrievalFeedback(ctx, fb); err != nil {
+				t.Fatalf("failed to write feedback: %v", err)
+			}
+		}
+		scores, err := s.GetMemoryFeedbackScores(ctx, []string{"m5"})
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if score, ok := scores["m5"]; !ok || abs32(score-1.0) > 0.001 {
+			t.Errorf("m5 score: want 1.0, got %v", score)
+		}
+	})
+}
+
+func abs32(v float32) float32 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1911,6 +1911,78 @@ func (s *SQLiteStore) ListRecentRetrievalFeedback(ctx context.Context, since tim
 	return results, rows.Err()
 }
 
+// GetMemoryFeedbackScores computes a normalized feedback score for each memory ID
+// by scanning retrieval_feedback rows where the memory appears in retrieved_memory_ids.
+// "helpful" = +1, "irrelevant" = -1, "partial" = 0. Returns sum/count per memory.
+func (s *SQLiteStore) GetMemoryFeedbackScores(ctx context.Context, memoryIDs []string) (map[string]float32, error) {
+	if len(memoryIDs) == 0 {
+		return nil, nil
+	}
+
+	// Build a set of target memory IDs for fast lookup
+	targetSet := make(map[string]bool, len(memoryIDs))
+	for _, id := range memoryIDs {
+		targetSet[id] = true
+	}
+
+	// Query all feedback rows that have a non-empty feedback rating
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT retrieved_memory_ids, feedback FROM retrieval_feedback WHERE feedback != '' AND feedback IS NOT NULL`)
+	if err != nil {
+		return nil, fmt.Errorf("querying retrieval feedback scores: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	type accumulator struct {
+		sum   float32
+		count int
+	}
+	accum := make(map[string]*accumulator)
+
+	for rows.Next() {
+		var idsJSON, feedback string
+		if err := rows.Scan(&idsJSON, &feedback); err != nil {
+			return nil, fmt.Errorf("scanning retrieval feedback row: %w", err)
+		}
+
+		var feedbackScore float32
+		switch feedback {
+		case "helpful":
+			feedbackScore = 1.0
+		case "irrelevant":
+			feedbackScore = -1.0
+		case "partial":
+			feedbackScore = 0.0
+		default:
+			continue
+		}
+
+		var retrievedIDs []string
+		_ = json.Unmarshal([]byte(idsJSON), &retrievedIDs)
+
+		for _, memID := range retrievedIDs {
+			if !targetSet[memID] {
+				continue
+			}
+			if accum[memID] == nil {
+				accum[memID] = &accumulator{}
+			}
+			accum[memID].sum += feedbackScore
+			accum[memID].count++
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, fmt.Errorf("iterating retrieval feedback rows: %w", err)
+	}
+
+	// Normalize: sum / count
+	result := make(map[string]float32, len(accum))
+	for memID, a := range accum {
+		result[memID] = a.sum / float32(a.count)
+	}
+	return result, nil
+}
+
 // ListMetaObservations retrieves observations, optionally filtered by type.
 func (s *SQLiteStore) ListMetaObservations(ctx context.Context, observationType string, limit int) ([]store.MetaObservation, error) {
 	var rows *sql.Rows

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -425,6 +425,10 @@ type Store interface {
 	WriteRetrievalFeedback(ctx context.Context, fb RetrievalFeedback) error
 	GetRetrievalFeedback(ctx context.Context, queryID string) (RetrievalFeedback, error)
 	ListRecentRetrievalFeedback(ctx context.Context, since time.Time, limit int) ([]RetrievalFeedback, error)
+	// GetMemoryFeedbackScores computes a normalized feedback score for each memory ID
+	// based on retrieval_feedback records. "helpful" = +1, "irrelevant" = -1, "partial" = 0.
+	// Returns sum/count per memory, so scores range from -1.0 to +1.0.
+	GetMemoryFeedbackScores(ctx context.Context, memoryIDs []string) (map[string]float32, error)
 
 	// --- Episode operations ---
 	CreateEpisode(ctx context.Context, ep Episode) error

--- a/internal/store/storetest/mock.go
+++ b/internal/store/storetest/mock.go
@@ -162,6 +162,9 @@ func (MockStore) GetRetrievalFeedback(context.Context, string) (store.RetrievalF
 func (MockStore) ListRecentRetrievalFeedback(context.Context, time.Time, int) ([]store.RetrievalFeedback, error) {
 	return nil, nil
 }
+func (MockStore) GetMemoryFeedbackScores(context.Context, []string) (map[string]float32, error) {
+	return nil, nil
+}
 
 // --- Episode operations ---
 


### PR DESCRIPTION
## Summary

- **Feedback-informed ranking** (#221): `rankResults()` now queries the `retrieval_feedback` table via a new `GetMemoryFeedbackScores()` store method. Each candidate memory gets a normalized score (-1.0 to +1.0) based on cumulative helpful/irrelevant/partial ratings, applied as an additive adjustment weighted by `feedback_weight` (default 0.15). Memories consistently rated "irrelevant" are penalized; "helpful" memories are boosted.
- **Source-weighted scoring** (#223): When no source filter is specified, each memory's base score is multiplied by a configurable per-source weight (default: `mcp=1.0`, `terminal=0.8`, `clipboard=0.6`, `filesystem=0.5`). This down-weights noisier sources so MCP-originated memories naturally rank higher. Unknown sources default to weight 1.0.
- Source weighting applies as a multiplier **before** the feedback adjustment, so strong feedback can override source bias.

Closes #221
Closes #223

## Changes

| File | What |
|------|------|
| `internal/store/store.go` | Added `GetMemoryFeedbackScores` to `Store` interface |
| `internal/store/sqlite/sqlite.go` | SQLite implementation — scans `retrieval_feedback` rows, computes normalized scores |
| `internal/store/storetest/mock.go` | Mock implementation (returns nil) |
| `internal/store/sqlite/feedback_scores_test.go` | Unit tests for the SQLite query with known feedback data |
| `internal/config/config.go` | Added `FeedbackWeight` and `SourceWeights` to `RetrievalConfig` with defaults |
| `config.example.yaml` | Documented new config fields |
| `internal/agent/retrieval/agent.go` | Added fields to agent `RetrievalConfig`, updated `rankResults()` with source weighting + feedback adjustment |
| `internal/agent/retrieval/agent_test.go` | 5 new tests: feedback influence, feedback error graceful degradation, source weighting, unknown source default, combined source+feedback |
| `cmd/mnemonic/main.go` | Wired new config fields through `buildRetrievalConfig()` |

## Test plan

- [x] `make build` compiles cleanly
- [x] `make test` — all existing + new tests pass
- [x] `golangci-lint run` — 0 issues
- [x] Unit test: SQLite `GetMemoryFeedbackScores` with known feedback data (helpful, irrelevant, partial, missing)
- [x] Unit test: `rankResults` feedback influence — same activation, different feedback → different ranking
- [x] Unit test: `rankResults` feedback error — graceful degradation when DB fails
- [x] Unit test: `rankResults` source weighting — same activation, different sources → different final ranking
- [x] Unit test: unknown sources get weight 1.0 (no penalty)
- [x] Unit test: combined source+feedback — feedback can override source bias

🤖 Generated with [Claude Code](https://claude.com/claude-code)