### PR TITLE
Fix FTS5 search query missing columns

### DIFF
--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -1125,7 +1125,8 @@ func (s *SQLiteStore) SearchByFullText(ctx context.Context, query string, limit 
 	ftsQuery := `
 	SELECT m.id, m.raw_id, m.timestamp, m.type, m.content, m.summary, m.concepts, m.embedding,
 	       m.salience, m.access_count, m.last_accessed, m.state, m.gist_of, m.episode_id,
-	       m.source, m.project, m.session_id, m.created_at, m.updated_at
+	       m.source, m.project, m.session_id, m.created_at, m.updated_at,
+	       m.feedback_score, m.recall_suppressed
 	FROM memories m
 	JOIN memories_fts ON m.rowid = memories_fts.rowid
 	WHERE memories_fts MATCH ?


### PR DESCRIPTION
## Summary

Add `feedback_score` and `recall_suppressed` to the `SearchByFullText` FTS5 join query. These columns were added to the memories table but not this query, causing every full-text search to fail with "sql: expected 19 destination arguments in Scan, not 21".

## Impact

Every retrieval query was silently falling back to embedding-only search, losing the BM25/FTS5 half of hybrid retrieval. This affected recall quality on the running daemon.

## Fix

2-line change: add the two missing columns to the SELECT list in the FTS query.

## Test plan

- [x] `make build` + `make test` pass
- [x] `golangci-lint run` — 0 issues
- [x] Restarted daemon, ran retrieval query — no FTS errors in logs
- [x] Discovered during lifecycle test real-LLM run (#262)