### PR TITLE
Agent UX: type filter, recall_project noise reduction, current session

### DIFF
--- a/internal/agent/retrieval/agent.go
+++ b/internal/agent/retrieval/agent.go
@@ -136,6 +136,7 @@ type QueryRequest struct {
 	TimeTo              time.Time // if set, filter memories created before this time
 	Source              string    // if set, filter by memory source (mcp, filesystem, terminal, clipboard)
 	State               string    // if set, filter by memory state (active, fading, archived)
+	Type                string    // if set, filter by memory type (decision, error, insight, learning, general)
 	MinSalience         float32   // if > 0, filter out memories below this salience
 	IncludeSuppressed   bool      // if true, include recall-suppressed memories
 }
@@ -265,7 +266,7 @@ func (ra *RetrievalAgent) Query(ctx context.Context, req QueryRequest) (QueryRes
 	ranked := ra.rankResults(ctx, activated, req.IncludeReasoning)
 
 	// Step 7: Apply filters (project, time, source, state, salience)
-	if req.Project != "" || !req.TimeFrom.IsZero() || !req.TimeTo.IsZero() || req.Source != "" || req.State != "" || req.MinSalience > 0 {
+	if req.Project != "" || !req.TimeFrom.IsZero() || !req.TimeTo.IsZero() || req.Source != "" || req.State != "" || req.Type != "" || req.MinSalience > 0 {
 		ranked = ra.applyFilters(ranked, req)
 	}
 
@@ -1059,6 +1060,9 @@ func (ra *RetrievalAgent) applyFilters(results []store.RetrievalResult, req Quer
 			continue
 		}
 		if req.State != "" && r.Memory.State != req.State {
+			continue
+		}
+		if req.Type != "" && r.Memory.Type != req.Type {
 			continue
 		}
 		if req.MinSalience > 0 && r.Memory.Salience < req.MinSalience {

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -416,6 +416,11 @@ func (srv *MCPServer) handleRecall(ctx context.Context, args map[string]interfac
 		state = s
 	}
 
+	memType := ""
+	if t, ok := args["type"].(string); ok {
+		memType = t
+	}
+
 	var minSalience float32
 	if ms, ok := args["min_salience"].(float64); ok {
 		minSalience = float32(ms)
@@ -457,7 +462,7 @@ func (srv *MCPServer) handleRecall(ctx context.Context, args map[string]interfac
 			srv.log.Error("concept recall failed", "concepts", concepts, "error", err)
 			return nil, fmt.Errorf("concept recall failed: %w", err)
 		}
-		filtered := filterMemories(memories, source, state, minSalience)
+		filtered := filterMemories(memories, source, state, memType, minSalience)
 		text := fmt.Sprintf("Found %d memories matching concepts %v:\n\n", len(filtered), concepts)
 		for i, mem := range filtered {
 			text += fmt.Sprintf("%d. %s\n   Summary: %s\n   Concepts: %v\n\n",
@@ -477,6 +482,7 @@ func (srv *MCPServer) handleRecall(ctx context.Context, args map[string]interfac
 		Project:             project,
 		Source:              source,
 		State:               state,
+		Type:                memType,
 		MinSalience:         minSalience,
 	}
 
@@ -779,8 +785,12 @@ func (srv *MCPServer) handleRecallProject(ctx context.Context, args map[string]i
 		limit = int(l)
 	}
 
-	// Parse optional filters
-	source, state, minSalience := parseRecallFilters(args)
+	// Parse optional filters — default min_salience to 0.7 for project recall
+	// to filter out watcher noise that agents don't need.
+	source, state, memType, minSalience := parseRecallFilters(args)
+	if _, explicit := args["min_salience"]; !explicit && minSalience == 0 {
+		minSalience = 0.7
+	}
 
 	// Get project summary
 	summary, err := srv.store.GetProjectSummary(ctx, project)
@@ -824,6 +834,7 @@ func (srv *MCPServer) handleRecallProject(ctx context.Context, args map[string]i
 			Project:             project,
 			Source:              source,
 			State:               state,
+			Type:                memType,
 			MinSalience:         minSalience,
 		}
 
@@ -849,7 +860,7 @@ func (srv *MCPServer) handleRecallProject(ctx context.Context, args map[string]i
 			srv.log.Error("project recall failed", "project", project, "error", err)
 			return nil, fmt.Errorf("project recall failed: %w", err)
 		}
-		filtered := filterMemories(memories, source, state, minSalience)
+		filtered := filterMemories(memories, source, state, memType, minSalience)
 
 		text += fmt.Sprintf("\nMemories (%d):\n\n", len(filtered))
 		for i, mem := range filtered {
@@ -875,7 +886,7 @@ func (srv *MCPServer) handleRecallTimeline(ctx context.Context, args map[string]
 		limit = int(l)
 	}
 
-	source, state, minSalience := parseRecallFilters(args)
+	source, state, memType, minSalience := parseRecallFilters(args)
 
 	from := time.Now().Add(-time.Duration(hoursBack) * time.Hour)
 	to := time.Now()
@@ -886,7 +897,7 @@ func (srv *MCPServer) handleRecallTimeline(ctx context.Context, args map[string]
 		return nil, fmt.Errorf("timeline recall failed: %w", err)
 	}
 
-	filtered := filterMemories(memories, source, state, minSalience)
+	filtered := filterMemories(memories, source, state, memType, minSalience)
 
 	text := fmt.Sprintf("Timeline (last %dh, %d memories):\n\n", hoursBack, len(filtered))
 	for i, mem := range filtered {
@@ -1511,12 +1522,15 @@ func toolError(text string) map[string]interface{} {
 }
 
 // parseRecallFilters extracts optional source/state/min_salience from MCP args.
-func parseRecallFilters(args map[string]interface{}) (source, state string, minSalience float32) {
+func parseRecallFilters(args map[string]interface{}) (source, state, memType string, minSalience float32) {
 	if s, ok := args["source"].(string); ok {
 		source = s
 	}
 	if s, ok := args["state"].(string); ok {
 		state = s
+	}
+	if t, ok := args["type"].(string); ok {
+		memType = t
 	}
 	if ms, ok := args["min_salience"].(float64); ok {
 		minSalience = float32(ms)
@@ -1525,13 +1539,16 @@ func parseRecallFilters(args map[string]interface{}) (source, state string, minS
 }
 
 // filterMemories filters a slice of memories by source, state, and minimum salience.
-func filterMemories(memories []store.Memory, source, state string, minSalience float32) []store.Memory {
+func filterMemories(memories []store.Memory, source, state, memType string, minSalience float32) []store.Memory {
 	var filtered []store.Memory
 	for _, m := range memories {
 		if source != "" && m.Source != source {
 			continue
 		}
 		if state != "" && m.State != state {
+			continue
+		}
+		if memType != "" && m.Type != memType {
 			continue
 		}
 		if minSalience > 0 && m.Salience < minSalience {
@@ -1625,6 +1642,11 @@ func (srv *MCPServer) handleRecallSession(ctx context.Context, args map[string]i
 	sessionID, ok := args["session_id"].(string)
 	if !ok || sessionID == "" {
 		return nil, fmt.Errorf("session_id parameter is required")
+	}
+
+	// Allow "current" to resolve to the active MCP session.
+	if sessionID == "current" {
+		sessionID = srv.sessionID
 	}
 
 	limit := 20

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -61,6 +61,11 @@ func recallToolDef() ToolDefinition {
 					"type":        "string",
 					"description": "Filter by memory source: mcp, filesystem, terminal, clipboard",
 				},
+				"type": map[string]interface{}{
+					"type":        "string",
+					"description": "Filter by memory type: decision, error, insight, learning, general",
+					"enum":        []string{"decision", "error", "insight", "learning", "general"},
+				},
 				"min_salience": map[string]interface{}{
 					"type":        "number",
 					"description": "Minimum salience threshold (0.0-1.0). Filters out low-quality memories.",
@@ -370,7 +375,7 @@ func listSessionsToolDef() ToolDefinition {
 func recallSessionToolDef() ToolDefinition {
 	return ToolDefinition{
 		Name:        "recall_session",
-		Description: "Retrieve all memories from a specific MCP session, ordered by creation time. Use list_sessions to find session IDs.",
+		Description: "Retrieve all memories from a specific MCP session, ordered by creation time. Use \"current\" for the active session, or list_sessions to find past session IDs.",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{


### PR DESCRIPTION
## Summary

Three improvements for AI agent users of the MCP tools:

1. **Type filter on recall** — new `type` parameter (decision, error, insight, learning, general) filters results by memory type. Wired through MCP tool schema, handler, retrieval agent QueryRequest, and applyFilters.

2. **recall_project noise reduction** — default min_salience raised to 0.7 when no explicit value provided. Filters out watcher noise (filesystem events, clipboard copies) that pollute agent context at session start.

3. **"current" session in recall_session** — passing `session_id: "current"` now resolves to the active MCP session, eliminating the need to call list_sessions first.

## Test plan

- [x] `make build` + `make test` pass
- [x] `golangci-lint run` — 0 issues
- [x] Daemon restarted, retrieval queries return results
- [x] Type filter wired through retrieval agent applyFilters

Partial fix for #266 (items 1-3; dedup threshold tuning deferred)