### PR TITLE
Fix pattern decay rates and watcher noise filtering

### DIFF
--- a/internal/agent/consolidation/agent.go
+++ b/internal/agent/consolidation/agent.go
@@ -48,15 +48,15 @@ type ConsolidationConfig struct {
 	StrongEvidenceMinCount   int     // evidence count to unlock strong ceiling (default 10)
 
 	// Pattern decay tunables
-	PatternBaselineDecay float32 // per-cycle baseline decay (default 0.998)
-	StaleDecayHealthy    float32 // decay when evidence ratio >= 0.5 (default 0.98)
-	StaleDecayModerate   float32 // decay when evidence ratio >= 0.2 (default 0.95)
-	StaleDecayAggressive float32 // decay when evidence ratio < 0.2 (default 0.90)
+	PatternBaselineDecay float32 // per-cycle baseline decay (default 0.995)
+	StaleDecayHealthy    float32 // decay when evidence ratio >= 0.5 (default 0.97)
+	StaleDecayModerate   float32 // decay when evidence ratio >= 0.2 (default 0.93)
+	StaleDecayAggressive float32 // decay when evidence ratio < 0.2 (default 0.85)
 
 	// Self-sustaining pattern tunables
 	SelfSustainingMinEvidence int     // evidence count to qualify (default 10)
 	SelfSustainingMinStrength float32 // minimum strength to qualify (default 0.9)
-	SelfSustainingDecay       float32 // reduced decay for qualifying patterns (default 0.9999)
+	SelfSustainingDecay       float32 // reduced decay for qualifying patterns (default 0.995)
 
 	// Never-recalled watcher memory archival
 	NeverRecalledArchiveDays int // archive non-MCP memories with 0 access after this many days (default 30, 0=disabled)
@@ -87,13 +87,13 @@ func DefaultConfig() ConsolidationConfig {
 		PatternStrengthCeiling:    0.95,
 		StrongEvidenceCeiling:     1.0,
 		StrongEvidenceMinCount:    10,
-		PatternBaselineDecay:      0.998,
-		StaleDecayHealthy:         0.98,
-		StaleDecayModerate:        0.95,
-		StaleDecayAggressive:      0.90,
+		PatternBaselineDecay:      0.995,
+		StaleDecayHealthy:         0.97,
+		StaleDecayModerate:        0.93,
+		StaleDecayAggressive:      0.85,
 		SelfSustainingMinEvidence: 10,
 		SelfSustainingMinStrength: 0.9,
-		SelfSustainingDecay:       0.9999,
+		SelfSustainingDecay:       0.995,
 		NeverRecalledArchiveDays:  30,
 	}
 }
@@ -1531,12 +1531,12 @@ func (ca *ConsolidationAgent) decayPatterns(ctx context.Context) (int, error) {
 			p.Strength *= cfgFloat32(ca.config.PatternBaselineDecay, 0.998)
 		}
 
-		// Additional evidence-based decay for patterns not accessed within 7 days
+		// Additional evidence-based decay for patterns not accessed within 3 days
 		recency := p.LastAccessed
 		if recency.IsZero() {
 			recency = p.CreatedAt
 		}
-		stale := recency.IsZero() || time.Since(recency).Hours() >= 168
+		stale := recency.IsZero() || time.Since(recency).Hours() >= 72
 
 		if stale {
 			totalEvidence := len(p.EvidenceIDs)

--- a/internal/agent/encoding/agent.go
+++ b/internal/agent/encoding/agent.go
@@ -74,7 +74,7 @@ type EncodingConfig struct {
 	EmbedBatchSize          int      // max memories to batch-embed in one call (default 10)
 	DeduplicationThreshold     float32  // cosine sim above which new memory is a duplicate (default: 0.95)
 	MCPDeduplicationThreshold  float32  // higher threshold for MCP-sourced memories (default: 0.98)
-	SalienceFloor              float32  // min salience to encode; non-MCP sources below this are skipped (default: 0.0)
+	SalienceFloor              float32  // min salience to encode; non-MCP sources below this are skipped (default: 0.5)
 	DisablePolling          bool     // if true, skip the polling loop (MCP processes should not poll)
 }
 
@@ -129,6 +129,7 @@ func DefaultConfig() EncodingConfig {
 		BatchSizePoll:              10,
 		DeduplicationThreshold:     0.95,
 		MCPDeduplicationThreshold:  0.98,
+		SalienceFloor:              0.5,
 	}
 }
 

--- a/internal/agent/perception/heuristic.go
+++ b/internal/agent/perception/heuristic.go
@@ -269,9 +269,10 @@ func (h *HeuristicFilter) evaluateFilesystem(path, content string) (float32, str
 		"venv/", ".venv/", "site-packages/", ".tox/", ".mypy_cache/", ".ruff_cache/", ".pytest_cache/",
 		".egg-info/", ".eggs/"}
 
-	// Hard-reject lockfiles and checksums — deterministic files with zero semantic value
+	// Hard-reject lockfiles, checksums, and release tooling — deterministic files with zero semantic value
 	lockfileNames := []string{"go.sum", "package-lock.json", "yarn.lock", "Cargo.lock",
-		"poetry.lock", "pnpm-lock.yaml", "Gemfile.lock", "composer.lock"}
+		"poetry.lock", "pnpm-lock.yaml", "Gemfile.lock", "composer.lock",
+		".release-please-manifest.json", "CHANGELOG.md"}
 	baseName := path
 	if idx := strings.LastIndex(baseName, "/"); idx >= 0 {
 		baseName = baseName[idx+1:]


### PR DESCRIPTION
## Summary

Three signal quality fixes found during agent audit of v0.26.0:

### 1. Pattern decay was effectively disabled for established patterns

Self-sustaining patterns (10+ evidence, 0.9+ strength) had 0.9999 per-cycle decay — a month of hourly consolidation only reduced them by 0.07%. Stale patterns from weeks ago were stuck at strength 1.0.

| Decay type | Before | After | Monthly loss |
|------------|--------|-------|-------------|
| Self-sustaining | 0.9999 | 0.995 | 0.07% → ~30% |
| Normal baseline | 0.998 | 0.995 | ~18% → ~30% |
| Stale (healthy evidence) | 0.98 | 0.97 | per 7-day check → per 3-day |
| Stale (weak evidence) | 0.90 | 0.85 | per 7-day check → per 3-day |

### 2. Release tooling files bypassed heuristic filtering

`.release-please-manifest.json` scored 0.45 heuristic (0.3 base + 0.15 JSON config bonus), clearing the 0.4 salience floor. Added to hard-reject list alongside `CHANGELOG.md`.

### 3. Salience floor was too permissive

Default was 0.0 (effectively disabled). Raised to 0.5 to filter shallow config changes and desktop noise before they reach the encoding pipeline.

## Test plan

- [x] `make build` + `make test` pass
- [x] `golangci-lint run` — 0 issues
- [x] Pattern decay, perception, and encoding tests all pass