### PR TITLE
Lifecycle test: DB checkpointing for expensive LLM runs

### DIFF
--- a/cmd/lifecycle-test/harness.go
+++ b/cmd/lifecycle-test/harness.go
@@ -92,6 +92,72 @@ func NewHarness(provider llm.Provider, log *slog.Logger) (*Harness, error) {
 	return h, nil
 }
 
+// NewHarnessFromCheckpoint loads a DB snapshot and creates agents around it.
+// The checkpoint file is copied to a temp dir so the original is preserved.
+func NewHarnessFromCheckpoint(checkpointPath string, provider llm.Provider, log *slog.Logger) (*Harness, error) {
+	tmpDir, err := os.MkdirTemp("", "mnemonic-lifecycle-*")
+	if err != nil {
+		return nil, fmt.Errorf("creating temp dir: %w", err)
+	}
+
+	dbPath := filepath.Join(tmpDir, "lifecycle.db")
+
+	// Copy checkpoint to temp dir.
+	src, err := os.ReadFile(checkpointPath)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("reading checkpoint %s: %w", checkpointPath, err)
+	}
+	if err := os.WriteFile(dbPath, src, 0o644); err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("writing checkpoint copy: %w", err)
+	}
+
+	s, err := sqlite.NewSQLiteStore(dbPath, 5000)
+	if err != nil {
+		_ = os.RemoveAll(tmpDir)
+		return nil, fmt.Errorf("opening checkpoint store: %w", err)
+	}
+
+	bus := events.NewInMemoryBus(100)
+
+	h := &Harness{
+		Store:  s,
+		LLM:    provider,
+		Bus:    bus,
+		Log:    log,
+		Clock:  NewSimClock(),
+		TmpDir: tmpDir,
+		DBPath: dbPath,
+	}
+
+	h.Encoder = encoding.NewEncodingAgentWithConfig(s, provider, log, encoding.DefaultConfig())
+	h.Episoder = episoding.NewEpisodingAgent(s, provider, log, episoding.EpisodingConfig{
+		EpisodeWindowSizeMin: 10,
+		MinEventsPerEpisode:  2,
+		PollingInterval:      10 * time.Second,
+	})
+	h.Consolidator = consolidation.NewConsolidationAgent(s, provider, consolidation.DefaultConfig(), log)
+	h.Dreamer = dreaming.NewDreamingAgent(s, provider, dreaming.DreamingConfig{
+		Interval:               time.Hour,
+		BatchSize:              60,
+		SalienceThreshold:      0.3,
+		AssociationBoostFactor: 1.15,
+		NoisePruneThreshold:    0.15,
+	}, log)
+	h.Abstractor = abstraction.NewAbstractionAgent(s, provider, abstraction.AbstractionConfig{
+		Interval:    time.Hour,
+		MinStrength: 0.4,
+		MaxLLMCalls: 5,
+	}, log)
+	h.Metacog = metacognition.NewMetacognitionAgent(s, provider, metacognition.MetacognitionConfig{
+		Interval: time.Hour,
+	}, log)
+	h.Retriever = retrieval.NewRetrievalAgent(s, provider, retrieval.DefaultConfig(), log)
+
+	return h, nil
+}
+
 // Cleanup removes the temp directory and closes resources.
 func (h *Harness) Cleanup() {
 	_ = h.Bus.Close()

--- a/cmd/lifecycle-test/main.go
+++ b/cmd/lifecycle-test/main.go
@@ -18,12 +18,14 @@ var Version = "dev"
 
 func main() {
 	var (
-		verbose    bool
-		llmMode    bool
-		configPath string
-		report     string
-		phaseFlag  string
-		skipFlag   string
+		verbose        bool
+		llmMode        bool
+		configPath     string
+		report         string
+		phaseFlag      string
+		skipFlag       string
+		checkpointDir  string
+		fromCheckpoint string
 	)
 
 	flag.BoolVar(&verbose, "verbose", false, "verbose output")
@@ -32,6 +34,8 @@ func main() {
 	flag.StringVar(&report, "report", "", "output format: 'markdown' writes lifecycle-results.md")
 	flag.StringVar(&phaseFlag, "phase", "", "run a single phase by name (auto-seeds prerequisites)")
 	flag.StringVar(&skipFlag, "skip", "", "comma-separated phases to skip")
+	flag.StringVar(&checkpointDir, "checkpoint", "", "save DB snapshot after each phase to this directory")
+	flag.StringVar(&fromCheckpoint, "from-checkpoint", "", "load DB from checkpoint file instead of creating fresh")
 	flag.Parse()
 
 	logLevel := slog.LevelError
@@ -99,16 +103,31 @@ func main() {
 
 	ctx := context.Background()
 
-	// Create harness.
-	h, err := NewHarness(provider, log)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "Error creating harness: %v\n", err)
-		os.Exit(1)
+	// Create harness — from checkpoint or fresh.
+	var h *Harness
+	if fromCheckpoint != "" {
+		var err error
+		h, err = NewHarnessFromCheckpoint(fromCheckpoint, provider, log)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error loading checkpoint: %v\n", err)
+			os.Exit(1)
+		}
+		fmt.Printf("  Loaded checkpoint: %s\n\n", fromCheckpoint)
+	} else {
+		var err error
+		h, err = NewHarness(provider, log)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "Error creating harness: %v\n", err)
+			os.Exit(1)
+		}
 	}
 	defer h.Cleanup()
 
+	// When loading from checkpoint, only run the target phase (skip prerequisites).
+	skipPrereqs := fromCheckpoint != ""
+
 	// Run phases.
-	results, err := RunPhases(ctx, h, allPhases, phaseFlag, skipSet, verbose)
+	results, err := RunPhases(ctx, h, allPhases, phaseFlag, skipSet, checkpointDir, skipPrereqs, verbose)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)

--- a/cmd/lifecycle-test/phases.go
+++ b/cmd/lifecycle-test/phases.go
@@ -3,6 +3,8 @@ package main
 import (
 	"context"
 	"fmt"
+	"os"
+	"path/filepath"
 	"time"
 )
 
@@ -86,13 +88,20 @@ func (r *PhaseResult) Passed() bool {
 // RunPhases executes the phases according to the given filters.
 // If phaseFlag is set, only that phase runs (prerequisites are auto-seeded).
 // Phases in skipSet are skipped.
-func RunPhases(ctx context.Context, h *Harness, phases []Phase, phaseFlag string, skipSet map[string]bool, verbose bool) ([]*PhaseResult, error) {
+// If checkpointDir is non-empty, the DB is copied there after each phase.
+func RunPhases(ctx context.Context, h *Harness, phases []Phase, phaseFlag string, skipSet map[string]bool, checkpointDir string, skipPrereqs bool, verbose bool) ([]*PhaseResult, error) {
+	if checkpointDir != "" {
+		if err := os.MkdirAll(checkpointDir, 0o755); err != nil {
+			return nil, fmt.Errorf("creating checkpoint dir: %w", err)
+		}
+	}
+
 	var results []*PhaseResult
 
 	for _, p := range phases {
 		if phaseFlag != "" && p.Name() != phaseFlag {
-			// If targeting a specific phase, silently run prerequisites.
-			if !isPrerequisiteOf(p.Name(), phaseFlag, phases) {
+			// If targeting a specific phase, run prerequisites unless loading from checkpoint.
+			if skipPrereqs || !isPrerequisiteOf(p.Name(), phaseFlag, phases) {
 				continue
 			}
 		}
@@ -119,9 +128,28 @@ func RunPhases(ctx context.Context, h *Harness, phases []Phase, phaseFlag string
 		fmt.Printf("\r  [%s] %s (%dms)\n", status, p.Name(), result.Duration.Milliseconds())
 
 		results = append(results, result)
+
+		// Save checkpoint after each phase.
+		if checkpointDir != "" {
+			if err := saveCheckpoint(h.DBPath, checkpointDir, p.Name()); err != nil {
+				fmt.Printf("  [WARN] checkpoint failed for %s: %v\n", p.Name(), err)
+			} else if verbose {
+				fmt.Printf("  [CKPT] saved %s\n", filepath.Join(checkpointDir, p.Name()+".db"))
+			}
+		}
 	}
 
 	return results, nil
+}
+
+// saveCheckpoint copies the current DB to checkpointDir/phaseName.db.
+func saveCheckpoint(dbPath, checkpointDir, phaseName string) error {
+	src, err := os.ReadFile(dbPath)
+	if err != nil {
+		return fmt.Errorf("reading DB: %w", err)
+	}
+	dst := filepath.Join(checkpointDir, phaseName+".db")
+	return os.WriteFile(dst, src, 0o644)
 }
 
 // isPrerequisiteOf returns true if candidate comes before target in the phase list.


### PR DESCRIPTION
## Summary

Add `--checkpoint` and `--from-checkpoint` flags so expensive Gemini runs (~70 min) can be preserved and reused.

## Usage

    # Save checkpoints during a full run
    ./bin/lifecycle-test --llm --checkpoint ./snapshots/

    # Re-run consolidation against saved encoded data (seconds, not hours)
    ./bin/lifecycle-test --from-checkpoint ./snapshots/daily.db --phase=consolidation

## What it does

- `--checkpoint DIR`: copies the DB after each phase to `DIR/phasename.db`
- `--from-checkpoint FILE`: loads an existing DB, skips prerequisite phases, runs only the target phase

## Why

We lost the first 70-min Gemini baseline DB because the harness cleaned it up on exit. This ensures expensive encoding work is never wasted.

## Test plan

- [x] Full stub run with `--checkpoint` saves 8 snapshots
- [x] `--from-checkpoint daily.db --phase=consolidation` loads and passes
- [x] `golangci-lint run` — 0 issues

Closes #272