### PR TITLE
Add batch_recall MCP tool for parallel multi-query recall

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -223,6 +223,8 @@ func (srv *MCPServer) handleToolCall(ctx context.Context, req *jsonRPCRequest) *
 		result, toolErr = srv.handleRemember(ctx, params.Arguments)
 	case "recall":
 		result, toolErr = srv.handleRecall(ctx, params.Arguments)
+	case "batch_recall":
+		result, toolErr = srv.handleBatchRecall(ctx, params.Arguments)
 	case "forget":
 		result, toolErr = srv.handleForget(ctx, params.Arguments)
 	case "status":
@@ -682,6 +684,111 @@ func formatPatternsJSON(patterns []store.Pattern) []map[string]interface{} {
 		}
 	}
 	return result
+}
+
+// handleBatchRecall runs multiple recall queries in parallel and returns combined JSON results.
+func (srv *MCPServer) handleBatchRecall(ctx context.Context, args map[string]interface{}) (interface{}, error) {
+	queriesRaw, ok := args["queries"].([]interface{})
+	if !ok || len(queriesRaw) == 0 {
+		return nil, fmt.Errorf("queries parameter is required and must be a non-empty array")
+	}
+
+	if len(queriesRaw) > 10 {
+		return nil, fmt.Errorf("maximum 10 queries per batch (got %d)", len(queriesRaw))
+	}
+
+	type batchResult struct {
+		Index int
+		Query string
+		Data  map[string]interface{}
+		Err   error
+	}
+
+	results := make(chan batchResult, len(queriesRaw))
+
+	for i, qRaw := range queriesRaw {
+		qMap, ok := qRaw.(map[string]interface{})
+		if !ok {
+			results <- batchResult{Index: i, Err: fmt.Errorf("query %d: invalid format", i)}
+			continue
+		}
+
+		query, _ := qMap["query"].(string)
+		if query == "" {
+			results <- batchResult{Index: i, Err: fmt.Errorf("query %d: query string is required", i)}
+			continue
+		}
+
+		go func(idx int, q string, qArgs map[string]interface{}) {
+			limit := 5
+			if l, ok := qArgs["limit"].(float64); ok {
+				limit = int(l)
+			}
+			project := ""
+			if p, ok := qArgs["project"].(string); ok {
+				project = p
+			}
+			source := ""
+			if s, ok := qArgs["source"].(string); ok {
+				source = s
+			}
+			memType := ""
+			if t, ok := qArgs["type"].(string); ok {
+				memType = t
+			}
+			var minSalience float32
+			if ms, ok := qArgs["min_salience"].(float64); ok {
+				minSalience = float32(ms)
+			}
+
+			qr, err := srv.retriever.Query(ctx, retrieval.QueryRequest{
+				Query:               q,
+				MaxResults:          limit,
+				IncludeReasoning:    true,
+				IncludePatterns:     true,
+				IncludeAbstractions: true,
+				Project:             project,
+				Source:              source,
+				Type:                memType,
+				MinSalience:         minSalience,
+			})
+			if err != nil {
+				results <- batchResult{Index: idx, Query: q, Err: err}
+				return
+			}
+
+			results <- batchResult{
+				Index: idx,
+				Query: q,
+				Data:  formatRecallJSON(qr),
+			}
+		}(i, query, qMap)
+	}
+
+	// Collect results in order.
+	collected := make([]map[string]interface{}, len(queriesRaw))
+	for range queriesRaw {
+		r := <-results
+		if r.Err != nil {
+			collected[r.Index] = map[string]interface{}{
+				"query": r.Query,
+				"error": r.Err.Error(),
+			}
+		} else {
+			r.Data["query"] = r.Query
+			collected[r.Index] = r.Data
+		}
+	}
+
+	jsonBytes, err := json.Marshal(map[string]interface{}{
+		"results": collected,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("marshaling batch results: %w", err)
+	}
+
+	srv.log.Info("batch recall completed", "queries", len(queriesRaw))
+	return toolResult(string(jsonBytes)), nil
 }
 
 // handleForget archives a memory by ID.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -126,14 +126,15 @@ func TestHandleToolsList(t *testing.T) {
 		t.Fatalf("tools is not an array, got %T", toolsInterface)
 	}
 
-	if len(toolsArray) != 19 {
-		t.Fatalf("expected 19 tools, got %d", len(toolsArray))
+	if len(toolsArray) != 20 {
+		t.Fatalf("expected 20 tools, got %d", len(toolsArray))
 	}
 
 	// Verify tool names
 	expectedTools := map[string]bool{
 		"remember":        false,
 		"recall":          false,
+		"batch_recall":    false,
 		"forget":          false,
 		"status":          false,
 		"recall_project":  false,

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -98,6 +98,53 @@ func recallToolDef() ToolDefinition {
 	}
 }
 
+func batchRecallToolDef() ToolDefinition {
+	return ToolDefinition{
+		Name:        "batch_recall",
+		Description: "Run multiple recall queries in a single request. Returns structured JSON results for each query. Ideal for session start when you need project context, prior decisions, and task-specific memories in one round-trip.",
+		InputSchema: map[string]interface{}{
+			"type": "object",
+			"properties": map[string]interface{}{
+				"queries": map[string]interface{}{
+					"type":        "array",
+					"description": "Array of recall queries to execute",
+					"items": map[string]interface{}{
+						"type": "object",
+						"properties": map[string]interface{}{
+							"query": map[string]interface{}{
+								"type":        "string",
+								"description": "The search query",
+							},
+							"limit": map[string]interface{}{
+								"type":        "integer",
+								"description": "Maximum results for this query (default: 5)",
+							},
+							"project": map[string]interface{}{
+								"type":        "string",
+								"description": "Filter by project name",
+							},
+							"source": map[string]interface{}{
+								"type":        "string",
+								"description": "Filter by memory source: mcp, filesystem, terminal, clipboard",
+							},
+							"type": map[string]interface{}{
+								"type":        "string",
+								"description": "Filter by memory type: decision, error, insight, learning, general",
+							},
+							"min_salience": map[string]interface{}{
+								"type":        "number",
+								"description": "Minimum salience threshold (0.0-1.0)",
+							},
+						},
+						"required": []string{"query"},
+					},
+				},
+			},
+			"required": []string{"queries"},
+		},
+	}
+}
+
 func forgetToolDef() ToolDefinition {
 	return ToolDefinition{
 		Name:        "forget",
@@ -482,6 +529,7 @@ func allToolDefs() []ToolDefinition {
 	return []ToolDefinition{
 		rememberToolDef(),
 		recallToolDef(),
+		batchRecallToolDef(),
 		forgetToolDef(),
 		statusToolDef(),
 		recallProjectToolDef(),


### PR DESCRIPTION
## Summary

New `batch_recall` MCP tool that accepts an array of recall queries and executes them in parallel. Returns structured JSON with results for each query.

## Why

Agents make 3-4 sequential recall calls at session start (~600ms each = ~2s). Batch recall reduces this to a single round-trip with parallel execution.

## Usage

```json
{
  "queries": [
    {"query": "project context", "project": "mnemonic", "limit": 5},
    {"query": "prior decisions about dedup", "type": "decision"},
    {"query": "known bugs", "type": "error", "limit": 3}
  ]
}
```

## Design

- Max 10 queries per batch
- Each query runs as a goroutine calling `retriever.Query()` in parallel
- Results collected in order (index-matched to input)
- Failed queries return error message instead of blocking the batch
- Returns same JSON structure as `recall` with `format: "json"`

## Test plan

- [x] `make build` + `make test` pass (tool count updated 19 → 20)
- [x] `golangci-lint run` — 0 issues

Closes #275