### PR TITLE
fix: extract get_context themes from file paths instead of source code

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -59,8 +60,8 @@ type MCPServer struct {
 	maxContentBytes int
 
 	// Proactive context state (session-scoped)
-	lastContextTime    time.Time          // watermark for get_context polling
-	sessionRecalledIDs map[string]bool    // memory IDs already surfaced via recall this session
+	lastContextTime    time.Time       // watermark for get_context polling
+	sessionRecalledIDs map[string]bool // memory IDs already surfaced via recall this session
 }
 
 // NewMCPServer creates a new MCP server with the given dependencies.
@@ -81,15 +82,15 @@ func NewMCPServer(s store.Store, r *retrieval.RetrievalAgent, bus events.Bus, lo
 	log.Info("MCP server initialized", "session_id", sessionID, "project", project)
 
 	return &MCPServer{
-		store:           s,
-		retriever:       r,
-		bus:             bus,
-		log:             log,
-		version:         version,
-		sessionID:       sessionID,
-		project:         project,
-		resolver:        resolver,
-		coachingFile:    coachingFile,
+		store:              s,
+		retriever:          r,
+		bus:                bus,
+		log:                log,
+		version:            version,
+		sessionID:          sessionID,
+		project:            project,
+		resolver:           resolver,
+		coachingFile:       coachingFile,
 		excludePatterns:    excludePatterns,
 		maxContentBytes:    maxContentBytes,
 		lastContextTime:    time.Now(),
@@ -862,6 +863,13 @@ func (srv *MCPServer) handleGetContext(ctx context.Context, args map[string]inte
 		var concepts []string
 		if err == nil && len(mem.Concepts) > 0 {
 			concepts = mem.Concepts
+		} else if raw.Source == "filesystem" {
+			// For filesystem events, extract concepts from the file path
+			// instead of content — raw content is source code whose tokens
+			// (Go keywords, type names, etc.) pollute theme extraction.
+			if pathVal, ok := raw.Metadata["path"].(string); ok && pathVal != "" {
+				concepts = conceptsFromPath(pathVal)
+			}
 		} else {
 			concepts = retrieval.ParseQueryConcepts(raw.Content)
 		}
@@ -969,6 +977,38 @@ func (srv *MCPServer) handleGetContext(ctx context.Context, args map[string]inte
 	}
 
 	return toolResult(sb.String()), nil
+}
+
+// conceptsFromPath extracts meaningful concept tokens from a file path.
+// Used instead of ParseQueryConcepts on raw source code content, which
+// produces garbage themes from language keywords and syntax tokens.
+func conceptsFromPath(path string) []string {
+	// Strip extension and split into directory/file segments.
+	path = strings.TrimSuffix(path, filepath.Ext(path))
+	// Normalize separators and split.
+	parts := strings.FieldsFunc(path, func(r rune) bool {
+		return r == '/' || r == '\\' || r == '_' || r == '-' || r == '.'
+	})
+
+	// Filter short/noisy segments.
+	skip := map[string]bool{
+		"internal": true, "cmd": true, "pkg": true, "src": true,
+		"lib": true, "bin": true, "tmp": true, "test": true,
+		"main": true, "index": true, "mod": true, "sum": true,
+		"go": true, "the": true, "and": true, "for": true,
+	}
+
+	seen := make(map[string]bool)
+	var concepts []string
+	for _, seg := range parts {
+		seg = strings.ToLower(seg)
+		if len(seg) <= 2 || skip[seg] || seen[seg] {
+			continue
+		}
+		seen[seg] = true
+		concepts = append(concepts, seg)
+	}
+	return concepts
 }
 
 // handleForget archives a memory by ID.

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -377,3 +377,68 @@ func TestJSONRPCMarshal(t *testing.T) {
 		t.Fatalf("error message mismatch")
 	}
 }
+
+// TestConceptsFromPath tests that file paths produce meaningful concepts
+// and not programming language keywords.
+func TestConceptsFromPath(t *testing.T) {
+	tests := []struct {
+		name     string
+		path     string
+		expected []string
+	}{
+		{
+			name:     "go agent file",
+			path:     "internal/agent/retrieval/agent.go",
+			expected: []string{"agent", "retrieval"},
+		},
+		{
+			name:     "mcp server",
+			path:     "internal/mcp/server.go",
+			expected: []string{"mcp", "server"},
+		},
+		{
+			name:     "absolute path with project",
+			path:     "/home/user/Projects/mnemonic/internal/store/sqlite/sqlite.go",
+			expected: []string{"home", "user", "projects", "mnemonic", "store", "sqlite"},
+		},
+		{
+			name:     "test file with underscores",
+			path:     "internal/agent/perception/heuristic_filter_test.go",
+			expected: []string{"agent", "perception", "heuristic", "filter"},
+		},
+		{
+			name:     "config yaml",
+			path:     "config.yaml",
+			expected: []string{"config"},
+		},
+		{
+			name:     "short segments filtered",
+			path:     "a/b/cd/mcp.go",
+			expected: []string{"mcp"},
+		},
+		{
+			name:     "no duplicates",
+			path:     "agent/agent/agent.go",
+			expected: []string{"agent"},
+		},
+		{
+			name:     "empty path",
+			path:     "",
+			expected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := conceptsFromPath(tc.path)
+			if len(got) != len(tc.expected) {
+				t.Fatalf("expected %v, got %v", tc.expected, got)
+			}
+			for i := range tc.expected {
+				if got[i] != tc.expected[i] {
+					t.Fatalf("expected[%d] = %q, got %q (full: %v)", i, tc.expected[i], got[i], got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- The `get_context` MCP tool was running `ParseQueryConcepts` on raw file content from filesystem watcher events, producing garbage themes like `map[string]interface{}{` and `return nil` from Go source tokens
- For filesystem-source events, now extracts concepts from **file path segments** instead — e.g. `internal/agent/retrieval/agent.go` yields `["agent", "retrieval"]`
- Non-filesystem sources (terminal, clipboard) still use `ParseQueryConcepts` on content as before

## Test plan

- [x] Added `TestConceptsFromPath` with 8 table-driven cases (paths, dedup, empty, short segments)
- [x] All existing MCP tests pass
- [x] `golangci-lint run` clean
- [ ] Manual: rebuild daemon, call `get_context` via MCP, verify themes are meaningful path-derived concepts

🤖 Generated with [Claude Code](https://claude.com/claude-code)