### PR TITLE
2-tier early dedup to prevent wasted LLM tokens

### DIFF
--- a/internal/agent/encoding/agent.go
+++ b/internal/agent/encoding/agent.go
@@ -15,6 +15,7 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/appsprout-dev/mnemonic/internal/agent/agentutil"
+	"github.com/appsprout-dev/mnemonic/internal/agent/retrieval"
 	"github.com/appsprout-dev/mnemonic/internal/events"
 	"github.com/appsprout-dev/mnemonic/internal/llm"
 	"github.com/appsprout-dev/mnemonic/internal/store"
@@ -953,19 +954,40 @@ func (ea *EncodingAgent) encodeMemory(ctx context.Context, rawID string) error {
 
 	ea.log.Debug("encoding raw memory", "raw_id", raw.ID, "source", raw.Source)
 
-	// Step 2: Call LLM to compress and extract concepts
-	compression, err := ea.compressAndExtractConcepts(ctx, raw)
-	if err != nil {
-		ea.log.Error("failed to compress raw memory with LLM", "raw_id", raw.ID, "error", err)
-		// For filesystem events, don't create garbage fallback memories.
-		// The raw memory stays unprocessed and will be retried on the next polling cycle.
-		if raw.Source == "filesystem" {
-			ea.log.Info("skipping fallback encoding for filesystem event, will retry later", "raw_id", raw.ID)
-			return fmt.Errorf("LLM unavailable for filesystem encoding: %w", err)
+	// Step 1b: Tier 2 concept pre-check — skip expensive LLM compression if a
+	// semantically similar memory likely already exists (zero LLM cost).
+	skipCompression := false
+	if raw.Source != "mcp" { // Never skip MCP memories — they're explicit user input.
+		rawConcepts := retrieval.ParseQueryConcepts(raw.Content)
+		if len(rawConcepts) >= 3 {
+			candidates, cerr := ea.store.SearchByConceptsInProject(ctx, rawConcepts, raw.Project, 5)
+			if cerr == nil && len(candidates) > 0 {
+				for _, cand := range candidates {
+					if conceptOverlap(rawConcepts, cand.Concepts) >= 0.8 {
+						ea.log.Info("tier2-dedup: likely duplicate, skipping LLM compression",
+							"raw_id", raw.ID, "existing_id", cand.ID)
+						skipCompression = true
+						break
+					}
+				}
+			}
 		}
-		// Non-filesystem sources (MCP remember, terminal) use fallback since their
-		// content is already human-authored and meaningful without LLM compression.
+	}
+
+	// Step 2: Call LLM to compress and extract concepts (skipped if Tier 2 dedup triggered)
+	var compression *compressionResponse
+	if skipCompression {
 		compression = ea.fallbackCompression(raw)
+	} else {
+		compression, err = ea.compressAndExtractConcepts(ctx, raw)
+		if err != nil {
+			ea.log.Error("failed to compress raw memory with LLM", "raw_id", raw.ID, "error", err)
+			if raw.Source == "filesystem" {
+				ea.log.Info("skipping fallback encoding for filesystem event, will retry later", "raw_id", raw.ID)
+				return fmt.Errorf("LLM unavailable for filesystem encoding: %w", err)
+			}
+			compression = ea.fallbackCompression(raw)
+		}
 	}
 
 	ea.log.Debug("compression completed", "raw_id", raw.ID, "summary_length", len(compression.Summary))
@@ -1997,4 +2019,23 @@ func findDuplicate(results []store.RetrievalResult, dc dedupContext) *store.Retr
 		return r
 	}
 	return nil
+}
+
+// conceptOverlap returns the fraction of query concepts that appear in the
+// candidate's concept list. Used for Tier 2 pre-dedup before LLM compression.
+func conceptOverlap(queryConcepts, candidateConcepts []string) float64 {
+	if len(queryConcepts) == 0 {
+		return 0
+	}
+	candidateSet := make(map[string]bool, len(candidateConcepts))
+	for _, c := range candidateConcepts {
+		candidateSet[strings.ToLower(c)] = true
+	}
+	matches := 0
+	for _, c := range queryConcepts {
+		if candidateSet[strings.ToLower(c)] {
+			matches++
+		}
+	}
+	return float64(matches) / float64(len(queryConcepts))
 }

--- a/internal/agent/perception/agent.go
+++ b/internal/agent/perception/agent.go
@@ -382,12 +382,28 @@ func (pa *PerceptionAgent) processEvent(ctx context.Context, event Event) {
 		}
 	}
 
-	// 3. Create a raw memory entry
+	// 3. Compute content hash for early dedup
+	truncatedContent := pa.truncateContent(event.Content, pa.maxRawContentLen())
+	contentHash := computeContentHash(event.Source, event.Type, truncatedContent)
+
+	// 3b. Check if identical content already exists in last 24h (Tier 1 dedup)
+	exists, err := pa.store.RawMemoryExistsByHash(ctx, contentHash)
+	if err != nil {
+		pa.log.Warn("content hash dedup check failed", "error", err)
+	} else if exists {
+		pa.log.Debug("content-hash dedup: skipping duplicate",
+			"source", event.Source,
+			"type", event.Type,
+			"hash", contentHash[:12])
+		return
+	}
+
+	// 4. Create a raw memory entry
 	rawMemory := store.RawMemory{
 		ID:              uuid.New().String(),
 		Source:          event.Source,
 		Type:            event.Type,
-		Content:         pa.truncateContent(event.Content, pa.maxRawContentLen()),
+		Content:         truncatedContent,
 		Timestamp:       event.Timestamp,
 		CreatedAt:       time.Now(),
 		Metadata:        pa.mergeMetadata(event.Metadata, event.Path, heuristicResult.Score),
@@ -395,9 +411,10 @@ func (pa *PerceptionAgent) processEvent(ctx context.Context, event Event) {
 		InitialSalience: salience,
 		Processed:       false,
 		Project:         pa.resolveProject(event.Path),
+		ContentHash:     contentHash,
 	}
 
-	// 4. Write to store
+	// 5. Write to store
 	if err := pa.store.WriteRaw(ctx, rawMemory); err != nil {
 		pa.log.Error(
 			"failed to write raw memory",
@@ -544,6 +561,13 @@ func (pa *PerceptionAgent) truncateContent(content string, maxLen int) string {
 		return content
 	}
 	return content[:maxLen]
+}
+
+// computeContentHash returns a hex-encoded SHA-256 hash of source+type+content.
+// Used for Tier 1 early dedup — identical content produces identical hashes.
+func computeContentHash(source, memType, content string) string {
+	h := sha256.Sum256([]byte(source + "\x00" + memType + "\x00" + content))
+	return hex.EncodeToString(h[:16]) // 32-char hex string (128 bits)
 }
 
 // mergeMetadata merges event metadata with additional fields.

--- a/internal/store/sqlite/schema.go
+++ b/internal/store/sqlite/schema.go
@@ -470,6 +470,13 @@ CREATE TABLE IF NOT EXISTS memory_amendments (
 CREATE INDEX IF NOT EXISTS idx_amendments_memory ON memory_amendments(memory_id);
 `)
 
+	// Migration 014: Content hash for early dedup.
+	_, err = db.Exec(`ALTER TABLE raw_memories ADD COLUMN content_hash TEXT`)
+	if err != nil && !isAlterTableDuplicateColumn(err) {
+		return fmt.Errorf("failed to add raw_memories.content_hash column: %w", err)
+	}
+	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_raw_content_hash ON raw_memories(content_hash)`)
+
 	return nil
 }
 

--- a/internal/store/sqlite/sqlite.go
+++ b/internal/store/sqlite/sqlite.go
@@ -479,8 +479,8 @@ func (s *SQLiteStore) WriteRaw(ctx context.Context, raw store.RawMemory) error {
 
 	query := `
 	INSERT INTO raw_memories
-	(id, timestamp, source, type, content, metadata, heuristic_score, initial_salience, processed, project, session_id, created_at)
-	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+	(id, timestamp, source, type, content, metadata, heuristic_score, initial_salience, processed, project, session_id, content_hash, created_at)
+	VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
 	`
 
 	_, err = s.db.ExecContext(ctx, query,
@@ -495,6 +495,7 @@ func (s *SQLiteStore) WriteRaw(ctx context.Context, raw store.RawMemory) error {
 		boolToInt(raw.Processed),
 		nullableString(raw.Project),
 		nullableString(raw.SessionID),
+		nullableString(raw.ContentHash),
 		raw.CreatedAt.Format(time.RFC3339),
 	)
 
@@ -503,6 +504,22 @@ func (s *SQLiteStore) WriteRaw(ctx context.Context, raw store.RawMemory) error {
 	}
 
 	return nil
+}
+
+// RawMemoryExistsByHash checks if a raw memory with the given content hash
+// exists in the last 24 hours. Used for early dedup before LLM calls.
+func (s *SQLiteStore) RawMemoryExistsByHash(ctx context.Context, contentHash string) (bool, error) {
+	if contentHash == "" {
+		return false, nil
+	}
+	var count int
+	err := s.db.QueryRowContext(ctx,
+		`SELECT COUNT(1) FROM raw_memories WHERE content_hash = ? AND created_at > datetime('now', '-24 hours')`,
+		contentHash).Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("checking content hash: %w", err)
+	}
+	return count > 0, nil
 }
 
 // RawMemoryExistsByPath checks if a raw memory with the given source, project, and file path already exists.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -44,6 +44,7 @@ type RawMemory struct {
 	Processed       bool                   `json:"processed"`
 	Project         string                 `json:"project,omitempty"`
 	SessionID       string                 `json:"session_id,omitempty"`
+	ContentHash     string                 `json:"content_hash,omitempty"`
 	CreatedAt       time.Time              `json:"created_at"`
 }
 
@@ -356,6 +357,7 @@ type RetrievalFeedback struct {
 type Store interface {
 	// --- Raw memory operations ---
 	WriteRaw(ctx context.Context, raw RawMemory) error
+	RawMemoryExistsByHash(ctx context.Context, contentHash string) (bool, error)
 	GetRaw(ctx context.Context, id string) (RawMemory, error)
 	ListRawUnprocessed(ctx context.Context, limit int) ([]RawMemory, error)
 	ListRawMemoriesAfter(ctx context.Context, after time.Time, limit int) ([]RawMemory, error)

--- a/internal/store/storetest/mock.go
+++ b/internal/store/storetest/mock.go
@@ -75,6 +75,9 @@ func (MockStore) SearchByConceptsInProject(context.Context, []string, string, in
 func (MockStore) GetAnalytics(context.Context) (store.AnalyticsData, error) {
 	return store.AnalyticsData{}, nil
 }
+func (MockStore) RawMemoryExistsByHash(context.Context, string) (bool, error) {
+	return false, nil
+}
 
 // --- Association graph operations ---
 


### PR DESCRIPTION
## Summary

Add fast dedup gates BEFORE the expensive LLM calls, saving ~450-900 tokens per duplicate memory.

## The Problem

Current flow: raw memory → LLM compression (300-500 tokens) → LLM embedding (50-100 tokens) → THEN cosine similarity dedup check. Every duplicate wastes two LLM calls.

## The Fix

| Tier | Where | Cost | Catches |
|------|-------|------|---------|
| 1 | Perception (before raw write) | Zero | Exact content duplicates (24h window, SHA-256 hash) |
| 2 | Encoding (before LLM compression) | ~2ms, zero LLM | Semantic near-duplicates (80%+ concept overlap) |
| 3 | Encoding (after embedding) | Unchanged | Remaining semantic duplicates (cosine similarity) |

## Estimated Savings

Based on current data (2,460 raw, 60.8% dedup rate):
- Tier 1 catches ~40-50% of duplicates: ~600 memories, ~300K tokens saved
- Tier 2 catches ~30-40% of remaining: ~300 memories, ~150K tokens saved
- Total: ~450K tokens saved

## Key Design Decisions

- MCP memories (explicit agent input) always get full LLM compression — never skipped by Tier 2
- Tier 1 uses 24h window to avoid unbounded hash table growth
- Tier 2 uses fallback compression (not skip entirely) so the memory still gets encoded — just cheaper

## Test plan

- [x] `make build` + `make test` pass
- [x] `golangci-lint run` — 0 issues
- [x] Migration 014 adds content_hash column + index