### PR TITLE
feat: enrich get_context themes with event types and terminal commands

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -870,6 +870,14 @@ func (srv *MCPServer) handleGetContext(ctx context.Context, args map[string]inte
 			if pathVal, ok := raw.Metadata["path"].(string); ok && pathVal != "" {
 				concepts = conceptsFromPath(pathVal)
 			}
+			// Enrich with the event action (created, modified, deleted).
+			if action := conceptFromEventType(raw.Type); action != "" {
+				concepts = append(concepts, action)
+			}
+		} else if raw.Source == "terminal" {
+			// For terminal events, extract command name and subcommand
+			// rather than treating the full command as natural language.
+			concepts = conceptsFromCommand(raw.Content)
 		} else {
 			concepts = retrieval.ParseQueryConcepts(raw.Content)
 		}
@@ -1008,6 +1016,61 @@ func conceptsFromPath(path string) []string {
 		seen[seg] = true
 		concepts = append(concepts, seg)
 	}
+	return concepts
+}
+
+// conceptFromEventType extracts a meaningful action verb from a watcher event type.
+// e.g. "file_created" → "created", "file_modified" → "modified".
+// Returns empty string for generic types like "dir_activity".
+func conceptFromEventType(eventType string) string {
+	if strings.HasPrefix(eventType, "file_") {
+		action := strings.TrimPrefix(eventType, "file_")
+		if action != "" {
+			return action
+		}
+	}
+	return ""
+}
+
+// conceptsFromCommand extracts concepts from a terminal command string.
+// Returns the command name and subcommand for compound commands (git, docker, etc.).
+// e.g. "git commit -m 'fix'" → ["git", "commit"], "ls -la" → ["ls"].
+func conceptsFromCommand(content string) []string {
+	content = strings.TrimSpace(content)
+	if content == "" {
+		return nil
+	}
+
+	tokens := strings.Fields(content)
+	if len(tokens) == 0 {
+		return nil
+	}
+
+	// First non-flag token is the command.
+	command := strings.ToLower(tokens[0])
+	concepts := []string{command}
+
+	// Compound commands where the subcommand carries meaning.
+	compound := map[string]bool{
+		"git": true, "docker": true, "kubectl": true,
+		"npm": true, "go": true, "cargo": true,
+		"pip": true, "yarn": true, "make": true,
+		"systemctl": true, "brew": true, "apt": true,
+	}
+
+	if compound[command] && len(tokens) > 1 {
+		// Find the first non-flag token after the command.
+		for _, t := range tokens[1:] {
+			if !strings.HasPrefix(t, "-") {
+				sub := strings.ToLower(t)
+				if sub != "" {
+					concepts = append(concepts, sub)
+				}
+				break
+			}
+		}
+	}
+
 	return concepts
 }
 

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -442,3 +442,102 @@ func TestConceptsFromPath(t *testing.T) {
 		})
 	}
 }
+
+// TestConceptFromEventType tests event type to action concept mapping.
+func TestConceptFromEventType(t *testing.T) {
+	tests := []struct {
+		name      string
+		eventType string
+		expected  string
+	}{
+		{"file created", "file_created", "created"},
+		{"file modified", "file_modified", "modified"},
+		{"file deleted", "file_deleted", "deleted"},
+		{"dir activity skipped", "dir_activity", ""},
+		{"empty string", "", ""},
+		{"command executed skipped", "command_executed", ""},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := conceptFromEventType(tc.eventType)
+			if got != tc.expected {
+				t.Fatalf("conceptFromEventType(%q) = %q, want %q", tc.eventType, got, tc.expected)
+			}
+		})
+	}
+}
+
+// TestConceptsFromCommand tests terminal command concept extraction.
+func TestConceptsFromCommand(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected []string
+	}{
+		{
+			name:     "git commit with flags",
+			content:  "git commit -m 'fix bug'",
+			expected: []string{"git", "commit"},
+		},
+		{
+			name:     "git push",
+			content:  "git push origin main",
+			expected: []string{"git", "push"},
+		},
+		{
+			name:     "make build",
+			content:  "make build",
+			expected: []string{"make", "build"},
+		},
+		{
+			name:     "go test with flags",
+			content:  "go test -v ./...",
+			expected: []string{"go", "test"},
+		},
+		{
+			name:     "docker run with flags",
+			content:  "docker -D run --rm ubuntu",
+			expected: []string{"docker", "run"},
+		},
+		{
+			name:     "simple command",
+			content:  "ls -la",
+			expected: []string{"ls"},
+		},
+		{
+			name:     "simple command no flags",
+			content:  "pwd",
+			expected: []string{"pwd"},
+		},
+		{
+			name:     "npm install",
+			content:  "npm install express",
+			expected: []string{"npm", "install"},
+		},
+		{
+			name:     "empty string",
+			content:  "",
+			expected: nil,
+		},
+		{
+			name:     "whitespace only",
+			content:  "   ",
+			expected: nil,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := conceptsFromCommand(tc.content)
+			if len(got) != len(tc.expected) {
+				t.Fatalf("expected %v, got %v", tc.expected, got)
+			}
+			for i := range tc.expected {
+				if got[i] != tc.expected[i] {
+					t.Fatalf("expected[%d] = %q, got %q (full: %v)", i, tc.expected[i], got[i], got)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Filesystem events now include the action verb as a concept (`created`, `modified`, `deleted`) alongside path-derived concepts, so themes reflect *what kind of activity* is happening, not just which files
- Terminal events extract the command name and subcommand (e.g. `git commit -m 'fix'` → `["git", "commit"]`) instead of running `ParseQueryConcepts` on the raw command string
- Added `conceptFromEventType()` and `conceptsFromCommand()` helpers with full test coverage (24 test cases across 3 helpers)

Closes #285, closes #286

## Test plan

- [x] `TestConceptFromEventType` — 6 cases: file_created/modified/deleted, dir_activity (skip), empty, command_executed (skip)
- [x] `TestConceptsFromCommand` — 10 cases: git subcommands, make, go, docker with flags, simple commands, npm, empty/whitespace
- [x] All existing MCP tests pass
- [x] `golangci-lint run` clean
- [ ] Manual: rebuild daemon, call `get_context`, verify themes include action verbs and command names

🤖 Generated with [Claude Code](https://claude.com/claude-code)