### PR TITLE
fix: publish WatcherEvent to bus so retrieval agent receives activity

### DIFF
--- a/internal/agent/perception/agent.go
+++ b/internal/agent/perception/agent.go
@@ -256,6 +256,15 @@ func (pa *PerceptionAgent) processWatcherEvents(
 				Metadata:  event.Metadata,
 			}
 
+			// Publish to bus so other agents (e.g. retrieval) can react to activity.
+			_ = pa.bus.Publish(ctx, events.WatcherEvent{
+				Source:  event.Source,
+				Type:    event.Type,
+				Path:    event.Path,
+				Preview: pa.truncateContent(event.Content, 200),
+				Ts:      event.Timestamp,
+			})
+
 			// Process the event through the pipeline
 			pa.processEvent(ctx, evt)
 		}


### PR DESCRIPTION
## Summary
- The perception agent processes watcher events internally but never published them to the event bus
- The retrieval agent's activity tracker subscribes to `WatcherEvent` but was never receiving any, so `context_boost` was always 0
- Adds `bus.Publish(ctx, events.WatcherEvent{...})` in `processWatcherEvents` before processing each event

Fixes the Phase 2 recall boost from #277 — without this, `context_boost` in recall explain output is always `0.000`.

## Test plan
- [ ] Rebuild and restart daemon
- [ ] Touch files in project directories to generate watcher events
- [ ] Call `recall` with `explain: true` and verify `context_boost > 0`
- [ ] Verify no duplicate event processing or performance regression

🤖 Generated with [Claude Code](https://claude.com/claude-code)