### PR TITLE
fix: sync daemon activity to MCP and filter path noise from themes

### DIFF
--- a/cmd/mnemonic/main.go
+++ b/cmd/mnemonic/main.go
@@ -2610,7 +2610,8 @@ func mcpCommand(configPath string) {
 	retriever := retrieval.NewRetrievalAgent(db, llmProvider, buildRetrievalConfig(cfg), log, bus)
 
 	mcpResolver := config.NewProjectResolver(cfg.Projects)
-	server := mcp.NewMCPServer(db, retriever, bus, log, Version, cfg.Coaching.CoachingFile, cfg.Perception.Filesystem.ExcludePatterns, cfg.Perception.Filesystem.MaxContentBytes, mcpResolver)
+	daemonURL := fmt.Sprintf("http://%s:%d", cfg.API.Host, cfg.API.Port)
+	server := mcp.NewMCPServer(db, retriever, bus, log, Version, cfg.Coaching.CoachingFile, cfg.Perception.Filesystem.ExcludePatterns, cfg.Perception.Filesystem.MaxContentBytes, mcpResolver, daemonURL)
 
 	// Handle signal for graceful shutdown
 	sigChan := make(chan os.Signal, 1)

--- a/internal/agent/retrieval/activity_tracker.go
+++ b/internal/agent/retrieval/activity_tracker.go
@@ -46,6 +46,35 @@ func (at *activityTracker) observe(concepts []string) {
 	}
 }
 
+// snapshot returns a copy of the current concept map, filtered to non-expired entries.
+func (at *activityTracker) snapshot() map[string]time.Time {
+	if at == nil {
+		return nil
+	}
+	at.mu.RLock()
+	defer at.mu.RUnlock()
+
+	now := time.Now()
+	out := make(map[string]time.Time, len(at.concepts))
+	for k, ts := range at.concepts {
+		if now.Sub(ts) < at.window {
+			out[k] = ts
+		}
+	}
+	return out
+}
+
+// loadSnapshot replaces the concept map with the provided snapshot.
+// Used by MCP processes to sync activity state from the daemon.
+func (at *activityTracker) loadSnapshot(snap map[string]time.Time) {
+	if at == nil {
+		return
+	}
+	at.mu.Lock()
+	defer at.mu.Unlock()
+	at.concepts = snap
+}
+
 // boostForMemory computes an additive score boost for a memory based on
 // how many of its concepts overlap with recent watcher activity. The boost
 // scales with overlap fraction and decays linearly over the window.

--- a/internal/agent/retrieval/agent.go
+++ b/internal/agent/retrieval/agent.go
@@ -230,6 +230,25 @@ func NewRetrievalAgent(s store.Store, llmProv llm.Provider, cfg RetrievalConfig,
 	return ra
 }
 
+// ActivitySnapshot returns the current activity tracker state as a map of
+// concept → last-seen time. Returns nil if activity tracking is disabled.
+func (ra *RetrievalAgent) ActivitySnapshot() map[string]time.Time {
+	return ra.activity.snapshot()
+}
+
+// SyncActivity replaces the activity tracker state with the given snapshot.
+// Used by MCP processes to sync activity from the daemon's REST API.
+func (ra *RetrievalAgent) SyncActivity(snap map[string]time.Time) {
+	if ra.activity == nil {
+		// Create a tracker on-the-fly for MCP processes that don't have a bus.
+		ra.activity = newActivityTracker(
+			intOr(ra.config.ContextBoostWindowMin, 30),
+			f32Or(ra.config.ContextBoostMax, 0.2),
+		)
+	}
+	ra.activity.loadSnapshot(snap)
+}
+
 // Query executes a retrieval query and returns ranked results with optional synthesis.
 func (ra *RetrievalAgent) Query(ctx context.Context, req QueryRequest) (QueryResponse, error) {
 	startTime := time.Now()

--- a/internal/api/routes/activity.go
+++ b/internal/api/routes/activity.go
@@ -1,0 +1,30 @@
+package routes
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/appsprout-dev/mnemonic/internal/agent/retrieval"
+)
+
+// ActivityResponse is the JSON response for the activity endpoint.
+type ActivityResponse struct {
+	Concepts map[string]time.Time `json:"concepts"`
+}
+
+// HandleActivity returns the retrieval agent's current activity tracker state.
+// MCP processes poll this to sync watcher-derived context boost data.
+func HandleActivity(retriever *retrieval.RetrievalAgent, log *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		snap := retriever.ActivitySnapshot()
+		if snap == nil {
+			snap = make(map[string]time.Time)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		if err := json.NewEncoder(w).Encode(ActivityResponse{Concepts: snap}); err != nil {
+			log.Warn("failed to encode activity response", "error", err)
+		}
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -101,6 +101,9 @@ func (s *Server) registerRoutes() {
 	// Query and retrieval
 	s.mux.HandleFunc("POST /api/v1/query", routes.HandleQuery(s.deps.Retriever, s.deps.Bus, s.deps.Store, s.deps.Log))
 
+	// Activity (watcher-derived concept tracker for MCP sync)
+	s.mux.HandleFunc("GET /api/v1/activity", routes.HandleActivity(s.deps.Retriever, s.deps.Log))
+
 	// Feedback
 	s.mux.HandleFunc("POST /api/v1/feedback", routes.HandleFeedback(s.deps.Store, s.deps.Log))
 

--- a/internal/concepts/extract.go
+++ b/internal/concepts/extract.go
@@ -6,14 +6,26 @@
 package concepts
 
 import (
+	"os"
 	"path/filepath"
 	"strings"
 )
+
+// homeDir is cached at init to avoid repeated syscalls.
+var homeDir string
+
+func init() {
+	homeDir, _ = os.UserHomeDir()
+}
 
 // FromPath extracts meaningful concept tokens from a file path.
 // Splits on separators, filters short/noisy segments, and deduplicates.
 // e.g. "internal/agent/retrieval/agent.go" → ["agent", "retrieval"].
 func FromPath(path string) []string {
+	// Strip home directory prefix to avoid leaking username and OS path segments.
+	if homeDir != "" {
+		path = strings.TrimPrefix(path, homeDir)
+	}
 	// Strip extension and split into directory/file segments.
 	path = strings.TrimSuffix(path, filepath.Ext(path))
 	// Normalize separators and split.
@@ -21,12 +33,22 @@ func FromPath(path string) []string {
 		return r == '/' || r == '\\' || r == '_' || r == '-' || r == '.'
 	})
 
-	// Filter short/noisy segments.
+	// Filter short/noisy segments: OS paths, common dirs, stop words.
 	skip := map[string]bool{
+		// OS / home directory segments
+		"home": true, "users": true, "user": true, "var": true,
+		"usr": true, "opt": true, "etc": true, "root": true,
+		"volumes": true, "mnt": true, "media": true, "run": true,
+		"projects": true, "documents": true, "desktop": true,
+		"downloads": true, "workspace": true, "workspaces": true,
+		// Go project structure
 		"internal": true, "cmd": true, "pkg": true, "src": true,
 		"lib": true, "bin": true, "tmp": true, "test": true,
 		"main": true, "index": true, "mod": true, "sum": true,
 		"go": true, "the": true, "and": true, "for": true,
+		// Version control / build
+		"git": true, "node_modules": true, "vendor": true,
+		"dist": true, "build": true, "target": true,
 	}
 
 	seen := make(map[string]bool)

--- a/internal/concepts/extract_test.go
+++ b/internal/concepts/extract_test.go
@@ -19,9 +19,14 @@ func TestFromPath(t *testing.T) {
 			expected: []string{"mcp", "server"},
 		},
 		{
-			name:     "absolute path with project",
+			name:     "absolute path filters OS segments",
 			path:     "/home/user/Projects/mnemonic/internal/store/sqlite/sqlite.go",
-			expected: []string{"home", "user", "projects", "mnemonic", "store", "sqlite"},
+			expected: []string{"mnemonic", "store", "sqlite"},
+		},
+		{
+			name:     "absolute path with home dir stripped",
+			path:     homeDir + "/Projects/mnemonic/internal/agent/encoding/agent.go",
+			expected: []string{"mnemonic", "agent", "encoding"},
 		},
 		{
 			name:     "test file with underscores",

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 	"time"
 
+	"io"
+	"net/http"
+
 	"github.com/appsprout-dev/mnemonic/internal/agent/retrieval"
 	"github.com/appsprout-dev/mnemonic/internal/concepts"
 	"github.com/appsprout-dev/mnemonic/internal/events"
@@ -68,10 +71,13 @@ type MCPServer struct {
 	contextAccepted     int                  // count of suggested IDs later recalled/rated
 	contextTotalOffered int                  // total IDs offered across all get_context calls
 	lastSuggestedIDsCSV string               // comma-separated IDs from last get_context (for tool_usage recording)
+
+	// Daemon activity sync (for context_boost in MCP processes)
+	daemonURL string // base URL of daemon API (e.g. "http://127.0.0.1:9999")
 }
 
 // NewMCPServer creates a new MCP server with the given dependencies.
-func NewMCPServer(s store.Store, r *retrieval.RetrievalAgent, bus events.Bus, log *slog.Logger, version string, coachingFile string, excludePatterns []string, maxContentBytes int, resolver ProjectResolver) *MCPServer {
+func NewMCPServer(s store.Store, r *retrieval.RetrievalAgent, bus events.Bus, log *slog.Logger, version string, coachingFile string, excludePatterns []string, maxContentBytes int, resolver ProjectResolver, daemonURL string) *MCPServer {
 	// Auto-detect project from working directory
 	wd, _ := os.Getwd()
 	var project string
@@ -99,6 +105,7 @@ func NewMCPServer(s store.Store, r *retrieval.RetrievalAgent, bus events.Bus, lo
 		coachingFile:        coachingFile,
 		excludePatterns:     excludePatterns,
 		maxContentBytes:     maxContentBytes,
+		daemonURL:           daemonURL,
 		lastContextTime:     time.Now(),
 		sessionRecalledIDs:  make(map[string]bool),
 		contextSuggestedIDs: make(map[string]time.Time),
@@ -447,10 +454,42 @@ func (srv *MCPServer) handleRemember(ctx context.Context, args map[string]interf
 		raw.ID, memType, project, raw.ID, raw.InitialSalience, raw.ID)), nil
 }
 
+// syncActivityFromDaemon fetches the daemon's watcher activity tracker state
+// and loads it into the local retrieval agent. This bridges the gap between
+// the daemon process (which runs watchers) and the MCP process (which doesn't).
+// Errors are logged but never block recall.
+func (srv *MCPServer) syncActivityFromDaemon() {
+	if srv.daemonURL == "" {
+		return
+	}
+	resp, err := http.Get(srv.daemonURL + "/api/v1/activity")
+	if err != nil {
+		srv.log.Debug("activity sync failed", "error", err)
+		return
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode != http.StatusOK {
+		_, _ = io.Copy(io.Discard, resp.Body)
+		return
+	}
+	var body struct {
+		Concepts map[string]time.Time `json:"concepts"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		srv.log.Debug("activity sync decode failed", "error", err)
+		return
+	}
+	if len(body.Concepts) > 0 {
+		srv.retriever.SyncActivity(body.Concepts)
+	}
+}
+
 // handleRecall retrieves memories using semantic search and spread activation.
 // All recall paths (project-scoped, concept-filtered, default) go through the
 // retrieval agent for spread activation and synthesis.
 func (srv *MCPServer) handleRecall(ctx context.Context, args map[string]interface{}) (interface{}, error) {
+	srv.syncActivityFromDaemon()
+
 	query, ok := args["query"].(string)
 	if !ok || query == "" {
 		return nil, fmt.Errorf("query parameter is required and must be a string")
@@ -752,6 +791,8 @@ func formatPatternsJSON(patterns []store.Pattern) []map[string]interface{} {
 
 // handleBatchRecall runs multiple recall queries in parallel and returns combined JSON results.
 func (srv *MCPServer) handleBatchRecall(ctx context.Context, args map[string]interface{}) (interface{}, error) {
+	srv.syncActivityFromDaemon()
+
 	queriesRaw, ok := args["queries"].([]interface{})
 	if !ok || len(queriesRaw) == 0 {
 		return nil, fmt.Errorf("queries parameter is required and must be a non-empty array")
@@ -1314,6 +1355,8 @@ func (srv *MCPServer) handleStatus(ctx context.Context, args map[string]interfac
 // handleRecallProject retrieves project-scoped memories with an activity summary.
 // Routes through the retrieval agent for spread activation and synthesis.
 func (srv *MCPServer) handleRecallProject(ctx context.Context, args map[string]interface{}) (interface{}, error) {
+	srv.syncActivityFromDaemon()
+
 	project := srv.project
 	if p, ok := args["project"].(string); ok && p != "" {
 		project = srv.resolveProjectName(p)

--- a/internal/mcp/server_test.go
+++ b/internal/mcp/server_test.go
@@ -30,7 +30,7 @@ func (m *mockBus) Close() error                      { return nil }
 // TestHandleInitialize tests handleInitialize returns correct protocol version and server info.
 func TestHandleInitialize(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	srv := NewMCPServer(&mockStore{}, nil, &mockBus{}, logger, "test", "", []string{}, 0, nil)
+	srv := NewMCPServer(&mockStore{}, nil, &mockBus{}, logger, "test", "", []string{}, 0, nil, "")
 
 	req := &jsonRPCRequest{
 		JSONRPC: "2.0",
@@ -89,7 +89,7 @@ func TestHandleInitialize(t *testing.T) {
 // TestHandleToolsList tests handleToolsList returns all 10 tools.
 func TestHandleToolsList(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	srv := NewMCPServer(&mockStore{}, nil, &mockBus{}, logger, "test", "", []string{}, 0, nil)
+	srv := NewMCPServer(&mockStore{}, nil, &mockBus{}, logger, "test", "", []string{}, 0, nil, "")
 
 	req := &jsonRPCRequest{
 		JSONRPC: "2.0",
@@ -297,7 +297,7 @@ func TestSuccessResponse(t *testing.T) {
 // TestHandleRequestDispatch tests that handleRequest correctly dispatches to handlers.
 func TestHandleRequestDispatch(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	srv := NewMCPServer(&mockStore{}, nil, &mockBus{}, logger, "test", "", []string{}, 0, nil)
+	srv := NewMCPServer(&mockStore{}, nil, &mockBus{}, logger, "test", "", []string{}, 0, nil, "")
 
 	tests := []struct {
 		method  string
@@ -405,7 +405,7 @@ func TestFormatDuration(t *testing.T) {
 // TestCheckAcceptance tests that suggested IDs are detected in recall results.
 func TestCheckAcceptance(t *testing.T) {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	srv := NewMCPServer(&mockStore{}, nil, &mockBus{}, logger, "test", "", []string{}, 0, nil)
+	srv := NewMCPServer(&mockStore{}, nil, &mockBus{}, logger, "test", "", []string{}, 0, nil, "")
 
 	// Simulate get_context suggesting two memory IDs.
 	srv.contextSuggestedIDs["abc-123"] = time.Now()


### PR DESCRIPTION
## Summary
- **MCP context_boost always 0**: The MCP process has its own isolated event bus with no watchers, so the retrieval agent's activity tracker was always empty. Added `GET /api/v1/activity` endpoint on the daemon that returns the current activity concept map, and `syncActivityFromDaemon()` in the MCP server that fetches this before each recall call.
- **Path segment leakage in themes**: `FromPath()` was extracting OS/home directory segments like "hubcaps", "home", "projects" from absolute paths. Added home directory prefix stripping via `os.UserHomeDir()` and expanded the stopword list.
- **New methods**: `ActivitySnapshot()`, `SyncActivity()`, `snapshot()`, `loadSnapshot()` enable cross-process activity state transfer.

## Test plan
- [x] All existing tests pass (make test, golangci-lint)
- [x] New `TestActivityTracker_SnapshotAndLoad` and `TestActivityTracker_SnapshotNil` tests
- [x] `GET /api/v1/activity` returns concepts from daemon watcher (verified manually)
- [x] Path extraction no longer includes "hubcaps", "home", "projects" 
- [ ] New MCP session shows `context_boost > 0` after file writes (requires session restart to pick up new binary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)