### PR TITLE
docs: fix stale tool count, remove resolved FTS5 bug, add concepts package

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ internal/
   events/              Event bus (in-memory pub/sub)
   config/              Config loading (config.yaml)
   logger/              Structured logging (slog)
+  concepts/            Shared concept extraction (paths, commands, event types)
   backup/              Export/import
   testutil/            Shared test infrastructure (stub LLM provider)
 sdk/                   Python agent SDK (self-evolving assistant)
@@ -74,7 +75,7 @@ scripts/               Utility scripts
 
 - **New agent:** Implement `agent.Agent` interface, register in `cmd/mnemonic/main.go` serve pipeline.
 - **New CLI command:** Add case to the command switch in `cmd/mnemonic/main.go`.
-- **New API route:** Add handler in `internal/api/routes/`, register in `internal/api/server.go`.
+- **New API route:** Add handler in `internal/api/routes/`, register in `internal/api/server.go`. Existing routes include `/api/v1/activity` (watcher concept tracker for MCP sync).
 - **New MCP tool:** Add to `internal/mcp/server.go` tool registration.
 
 ## Platform Support
@@ -103,8 +104,6 @@ Key scripts:
 All experiments must be pre-registered in `training/docs/experiment_registry.md` before running. See `.claude/rules/scientific-method.md` and `.claude/rules/experiment-logging.md`.
 
 ## Known Issues
-
-- **FTS5 scan column mismatch:** `SearchByFullText` fails with "sql: expected 19 destination arguments in Scan, not 21" — the memories table has 2 new columns not reflected in the FTS scan query. Retrieval falls back to embedding search, so functionality is not blocked. Needs a fix in `internal/store/sqlite/sqlite.go`.
 
 See [GitHub Issues](https://github.com/appsprout-dev/mnemonic/issues) for tracked bugs.
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ For the full deep dive, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ## MCP Integration
 
-Mnemonic exposes 19 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) for Claude Code and other AI agents:
+Mnemonic exposes 21 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) for Claude Code and other AI agents:
 
 **Claude Code config** (`~/.claude/settings.local.json`):
 


### PR DESCRIPTION
## Summary
- Fix MCP tool count in README.md from "19 tools" to "21 tools" (accurate since v0.27.0)
- Remove FTS5 scan column mismatch from CLAUDE.md Known Issues — was fixed in v0.25.0 (PR #265)
- Add `internal/concepts/` package to project layout in CLAUDE.md
- Document `GET /api/v1/activity` endpoint in the Adding Things section

Also updated global `~/.claude/CLAUDE.md` to remove hardcoded CGO build instruction (not applicable to mnemonic's pure-Go SQLite driver).

## Test plan
- [x] Docs-only change, no code modifications

🤖 Generated with [Claude Code](https://claude.com/claude-code)