### PR TITLE
ci: add workflow_dispatch trigger to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - "v*"
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Adds `workflow_dispatch` trigger to the release workflow so builds can be manually triggered with `gh workflow run release.yml --ref <tag>`
- Useful when the workflow was disabled during a tag push (like what just happened with v0.29.1)

## Test plan
- [x] Merge this, then run `gh workflow run release.yml --ref v0.29.1` to build the missing assets

🤖 Generated with [Claude Code](https://claude.com/claude-code)