### PR TITLE
feat: bulk forget and exclude_concepts for recall

### DIFF
--- a/internal/agent/retrieval/agent.go
+++ b/internal/agent/retrieval/agent.go
@@ -147,6 +147,7 @@ type QueryRequest struct {
 	Type                string    // if set, filter by memory type (decision, error, insight, learning, general)
 	MinSalience         float32   // if > 0, filter out memories below this salience
 	IncludeSuppressed   bool      // if true, include recall-suppressed memories
+	ExcludeConcepts     []string  // if set, exclude memories containing any of these concepts
 }
 
 // QueryResponse is the output of a retrieval query.
@@ -1144,9 +1145,24 @@ func (ra *RetrievalAgent) applyFilters(results []store.RetrievalResult, req Quer
 		if r.Memory.RecallSuppressed && !req.IncludeSuppressed {
 			continue
 		}
+		if len(req.ExcludeConcepts) > 0 && hasAnyConcept(r.Memory.Concepts, req.ExcludeConcepts) {
+			continue
+		}
 		filtered = append(filtered, r)
 	}
 	return filtered
+}
+
+// hasAnyConcept returns true if any of the memory's concepts match any excluded concept (case-insensitive).
+func hasAnyConcept(memoryConcepts, excluded []string) bool {
+	for _, mc := range memoryConcepts {
+		for _, ec := range excluded {
+			if strings.EqualFold(mc, ec) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // cosineSimilarity computes the cosine similarity between two embedding vectors.

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -535,6 +535,15 @@ func (srv *MCPServer) handleRecall(ctx context.Context, args map[string]interfac
 		}
 	}
 
+	var excludeConcepts []string
+	if c, ok := args["exclude_concepts"].([]interface{}); ok {
+		for _, v := range c {
+			if s, ok := v.(string); ok {
+				excludeConcepts = append(excludeConcepts, s)
+			}
+		}
+	}
+
 	explain := false
 	if e, ok := args["explain"].(bool); ok {
 		explain = e
@@ -563,6 +572,15 @@ func (srv *MCPServer) handleRecall(ctx context.Context, args map[string]interfac
 			return nil, fmt.Errorf("concept recall failed: %w", err)
 		}
 		filtered := filterMemories(memories, source, state, memType, minSalience)
+		if len(excludeConcepts) > 0 {
+			var kept []store.Memory
+			for _, m := range filtered {
+				if !conceptOverlap(m.Concepts, excludeConcepts) {
+					kept = append(kept, m)
+				}
+			}
+			filtered = kept
+		}
 		text := fmt.Sprintf("Found %d memories matching concepts %v:\n\n", len(filtered), concepts)
 		for i, mem := range filtered {
 			text += fmt.Sprintf("%d. %s\n   Summary: %s\n   Concepts: %v\n\n",
@@ -584,6 +602,7 @@ func (srv *MCPServer) handleRecall(ctx context.Context, args map[string]interfac
 		State:               state,
 		Type:                memType,
 		MinSalience:         minSalience,
+		ExcludeConcepts:     excludeConcepts,
 	}
 
 	result, err := srv.retriever.Query(ctx, queryReq)
@@ -1231,19 +1250,51 @@ func formatDuration(d time.Duration) string {
 
 // handleForget archives a memory by ID.
 func (srv *MCPServer) handleForget(ctx context.Context, args map[string]interface{}) (interface{}, error) {
-	memoryID, ok := args["memory_id"].(string)
-	if !ok || memoryID == "" {
-		return nil, fmt.Errorf("memory_id parameter is required and must be a string")
+	// Collect IDs from memory_id (string) and/or memory_ids (array).
+	var ids []string
+	if singleID, ok := args["memory_id"].(string); ok && singleID != "" {
+		ids = append(ids, singleID)
+	}
+	if rawIDs, ok := args["memory_ids"].([]interface{}); ok {
+		for _, raw := range rawIDs {
+			if id, ok := raw.(string); ok && id != "" {
+				ids = append(ids, id)
+			}
+		}
+	}
+	if len(ids) == 0 {
+		return nil, fmt.Errorf("either memory_id or memory_ids is required")
 	}
 
-	if err := srv.store.UpdateState(ctx, memoryID, "archived"); err != nil {
-		srv.log.Error("failed to archive memory", "id", memoryID, "error", err)
-		return nil, fmt.Errorf("failed to archive memory: %w", err)
+	// Deduplicate.
+	seen := make(map[string]bool, len(ids))
+	var unique []string
+	for _, id := range ids {
+		if !seen[id] {
+			seen[id] = true
+			unique = append(unique, id)
+		}
 	}
 
-	srv.log.Info("memory archived", "id", memoryID)
+	var archived, failed int
+	var failedIDs []string
+	for _, id := range unique {
+		if err := srv.store.UpdateState(ctx, id, "archived"); err != nil {
+			srv.log.Warn("failed to archive memory", "id", id, "error", err)
+			failed++
+			failedIDs = append(failedIDs, id)
+		} else {
+			archived++
+		}
+	}
 
-	return toolResult(fmt.Sprintf("Memory %s archived", memoryID)), nil
+	srv.log.Info("memories archived", "archived", archived, "failed", failed)
+
+	msg := fmt.Sprintf("Archived %d memories", archived)
+	if failed > 0 {
+		msg += fmt.Sprintf(", %d failed: %v", failed, failedIDs)
+	}
+	return toolResult(msg), nil
 }
 
 // handleStatus returns system statistics and health information.
@@ -2190,6 +2241,18 @@ func filterMemories(memories []store.Memory, source, state, memType string, minS
 		filtered = append(filtered, m)
 	}
 	return filtered
+}
+
+// conceptOverlap returns true if any memory concept matches any excluded concept (case-insensitive).
+func conceptOverlap(memoryConcepts, excluded []string) bool {
+	for _, mc := range memoryConcepts {
+		for _, ec := range excluded {
+			if strings.EqualFold(mc, ec) {
+				return true
+			}
+		}
+	}
+	return false
 }
 
 // onSessionEnd is called when stdin closes (Claude Code disconnected) or context is cancelled.

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -57,6 +57,11 @@ func recallToolDef() ToolDefinition {
 					"items":       map[string]interface{}{"type": "string"},
 					"description": "Filter by specific concepts",
 				},
+				"exclude_concepts": map[string]interface{}{
+					"type":        "array",
+					"items":       map[string]interface{}{"type": "string"},
+					"description": "Exclude memories containing any of these concepts",
+				},
 				"source": map[string]interface{}{
 					"type":        "string",
 					"description": "Filter by memory source: mcp, filesystem, terminal, clipboard",
@@ -174,16 +179,20 @@ func getContextToolDef() ToolDefinition {
 func forgetToolDef() ToolDefinition {
 	return ToolDefinition{
 		Name:        "forget",
-		Description: "Archive a memory by ID",
+		Description: "Archive one or more memories by ID. Supports single memory_id or bulk memory_ids array.",
 		InputSchema: map[string]interface{}{
 			"type": "object",
 			"properties": map[string]interface{}{
 				"memory_id": map[string]interface{}{
 					"type":        "string",
-					"description": "The ID of the memory to archive",
+					"description": "Single memory ID to archive",
+				},
+				"memory_ids": map[string]interface{}{
+					"type":        "array",
+					"items":       map[string]interface{}{"type": "string"},
+					"description": "Array of memory IDs to archive in bulk",
 				},
 			},
-			"required": []string{"memory_id"},
 		},
 	}
 }


### PR DESCRIPTION
## Summary
- **Bulk forget**: `forget` tool now accepts `memory_ids` (array) alongside existing `memory_id` (string). Deduplicates, archives each individually, reports successes/failures.
- **Exclude concepts**: `recall` tool now accepts `exclude_concepts` (array of strings). Memories containing any excluded concept are filtered out. Works in both the retrieval agent path (via `applyFilters`) and the concept-only search path.

## Test plan
- [x] All existing tests pass
- [x] `make build && make check` clean
- [x] Full `go test ./...` green

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)