### PR TITLE
fix: prevent dismissed pattern reactivation + filter exclude_concepts on patterns

### DIFF
--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -637,6 +637,25 @@ func (srv *MCPServer) handleRecall(ctx context.Context, args map[string]interfac
 		return nil, fmt.Errorf("retrieval failed: %w", err)
 	}
 
+	// Filter patterns and abstractions by exclude_concepts
+	if len(excludeConcepts) > 0 {
+		var filteredPatterns []store.Pattern
+		for _, p := range result.Patterns {
+			if !conceptOverlap(p.Concepts, excludeConcepts) {
+				filteredPatterns = append(filteredPatterns, p)
+			}
+		}
+		result.Patterns = filteredPatterns
+
+		var filteredAbstractions []store.Abstraction
+		for _, a := range result.Abstractions {
+			if !conceptOverlap(a.Concepts, excludeConcepts) {
+				filteredAbstractions = append(filteredAbstractions, a)
+			}
+		}
+		result.Abstractions = filteredAbstractions
+	}
+
 	// Save traversal data and access snapshot for feedback loop
 	var retrievedIDs []string
 	var snapshot []store.AccessSnapshotEntry

--- a/internal/store/sqlite/patterns.go
+++ b/internal/store/sqlite/patterns.go
@@ -67,7 +67,7 @@ func (s *SQLiteStore) UpdatePattern(ctx context.Context, p store.Pattern) error 
 		SET pattern_type = ?, title = ?, description = ?, evidence_ids = ?, strength = ?,
 		    project = ?, concepts = ?, embedding = ?, access_count = ?, last_accessed = ?,
 		    state = ?, updated_at = ?
-		WHERE id = ?`,
+		WHERE id = ? AND state != 'archived'`,
 		p.PatternType,
 		p.Title,
 		p.Description,
@@ -88,6 +88,16 @@ func (s *SQLiteStore) UpdatePattern(ctx context.Context, p store.Pattern) error 
 
 	rowsAffected, _ := result.RowsAffected()
 	if rowsAffected == 0 {
+		// Check if the pattern exists but is archived (dismissed by user).
+		// In that case, the WHERE state != 'archived' guard prevented the update — this is expected.
+		var state string
+		row := s.db.QueryRowContext(ctx, `SELECT state FROM patterns WHERE id = ?`, p.ID)
+		if err := row.Scan(&state); err != nil {
+			return fmt.Errorf("pattern with id %s: %w", p.ID, store.ErrNotFound)
+		}
+		if state == "archived" {
+			return nil // silently skip — pattern was dismissed
+		}
 		return fmt.Errorf("pattern with id %s: %w", p.ID, store.ErrNotFound)
 	}
 	return nil


### PR DESCRIPTION
## Summary
- **#319**: `UpdatePattern` now guards with `WHERE state != 'archived'` so consolidation cycles can't overwrite a user-dismissed pattern back to active. Root cause: consolidation reads patterns, updates strength, and writes back the full struct — overwriting any state change made between the read and write.
- **#318**: `exclude_concepts` on `recall` now filters patterns and abstractions in addition to memories, using the same `conceptOverlap` helper.

Also closed #320 (feedback schema mismatch) — was a stale tool metadata cache in Claude Code, not a code bug.

## Test plan
- [x] `go test ./...` all passing
- [x] Build clean, vet clean
- [x] Verified dismissed Felix-LM pattern stays archived after daemon restart
- [x] Manual test: `recall` with `exclude_concepts: ["training"]` no longer shows training patterns

Closes #318, closes #319

🤖 Generated with [Claude Code](https://claude.com/claude-code)