### PR TITLE
feat: dynamic tool count, associate_with validation, session timeline polish

### DIFF
--- a/cmd/mnemonic/main.go
+++ b/cmd/mnemonic/main.go
@@ -1651,6 +1651,7 @@ func serveCommand(configPath string) {
 			ConfigPath:            configPath,
 			ServiceRestarter:      daemon.NewServiceManager(),
 			PIDRestart:            daemon.PIDRestart,
+			MCPToolCount:          mcp.ToolCount(),
 			Log:                   log,
 		}
 		// Only set Consolidator if it's non-nil (avoids Go nil-interface trap)

--- a/internal/api/routes/routes_test.go
+++ b/internal/api/routes/routes_test.go
@@ -590,7 +590,7 @@ func TestHandleHealthCheck(t *testing.T) {
 			},
 		}
 		llmProv := &mockLLMProvider{}
-		handler := HandleHealth(ms, llmProv, "test", testLogger())
+		handler := HandleHealth(ms, llmProv, "test", 23, testLogger())
 
 		req := httptest.NewRequest(http.MethodGet, "/health", nil)
 		rr := httptest.NewRecorder()
@@ -629,7 +629,7 @@ func TestHandleHealthCheck(t *testing.T) {
 			},
 		}
 		llmProv := &failingLLMProvider{}
-		handler := HandleHealth(ms, llmProv, "test", testLogger())
+		handler := HandleHealth(ms, llmProv, "test", 23, testLogger())
 
 		req := httptest.NewRequest(http.MethodGet, "/health", nil)
 		rr := httptest.NewRecorder()
@@ -662,7 +662,7 @@ func TestHandleHealthCheck(t *testing.T) {
 			},
 		}
 		llmProv := &mockLLMProvider{}
-		handler := HandleHealth(ms, llmProv, "test", testLogger())
+		handler := HandleHealth(ms, llmProv, "test", 23, testLogger())
 
 		req := httptest.NewRequest(http.MethodGet, "/health", nil)
 		rr := httptest.NewRecorder()

--- a/internal/api/routes/system.go
+++ b/internal/api/routes/system.go
@@ -18,13 +18,14 @@ type HealthResponse struct {
 	LLMModel     string `json:"llm_model,omitempty"`
 	StoreHealthy bool   `json:"store_healthy"`
 	MemoryCount  int    `json:"memory_count"`
+	ToolCount    int    `json:"tool_count"`
 	Timestamp    string `json:"timestamp"`
 }
 
 // HandleHealth returns an HTTP handler that performs a health check.
 // Checks LLM availability with 2s timeout and store health.
 // Returns 200 with health status JSON.
-func HandleHealth(s store.Store, llmProv llm.Provider, version string, log *slog.Logger) http.HandlerFunc {
+func HandleHealth(s store.Store, llmProv llm.Provider, version string, toolCount int, log *slog.Logger) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
 		log.Debug("health check requested")
 
@@ -70,6 +71,7 @@ func HandleHealth(s store.Store, llmProv llm.Provider, version string, log *slog
 			LLMModel:     llmModel,
 			StoreHealthy: storeHealthy,
 			MemoryCount:  memoryCount,
+			ToolCount:    toolCount,
 			Timestamp:    time.Now().UTC().Format(time.RFC3339),
 		}
 

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -40,6 +40,7 @@ type ServerDeps struct {
 	ConfigPath            string                  // config file path for PID-based restart
 	ServiceRestarter      routes.ServiceRestarter // can be nil if not installed as service
 	PIDRestart            routes.PIDRestartFunc   // fallback restart when service manager unavailable
+	MCPToolCount          int                     // number of registered MCP tools
 	Log                   *slog.Logger
 }
 
@@ -78,7 +79,7 @@ func NewServer(cfg ServerConfig, deps ServerDeps) *Server {
 // registerRoutes registers all API routes with the mux.
 func (s *Server) registerRoutes() {
 	// Health and stats
-	s.mux.HandleFunc("GET /api/v1/health", routes.HandleHealth(s.deps.Store, s.deps.LLM, s.deps.Version, s.deps.Log))
+	s.mux.HandleFunc("GET /api/v1/health", routes.HandleHealth(s.deps.Store, s.deps.LLM, s.deps.Version, s.deps.MCPToolCount, s.deps.Log))
 	s.mux.HandleFunc("GET /api/v1/stats", routes.HandleStats(s.deps.Store, s.deps.Log))
 
 	// Self-update

--- a/internal/mcp/server.go
+++ b/internal/mcp/server.go
@@ -409,12 +409,18 @@ func (srv *MCPServer) handleRemember(ctx context.Context, args map[string]interf
 
 	// Parse optional explicit associations.
 	var explicitAssoc []map[string]string
+	var invalidAssocIDs []string
 	if rawAssoc, ok := args["associate_with"].([]interface{}); ok {
 		for _, entry := range rawAssoc {
 			if m, ok := entry.(map[string]interface{}); ok {
 				memID, _ := m["memory_id"].(string)
 				relation, _ := m["relation"].(string)
 				if memID != "" && relation != "" {
+					// Validate that the target memory exists.
+					if _, err := srv.store.GetMemory(ctx, memID); err != nil {
+						invalidAssocIDs = append(invalidAssocIDs, memID)
+						continue
+					}
 					explicitAssoc = append(explicitAssoc, map[string]string{
 						"memory_id": memID,
 						"relation":  relation,
@@ -476,8 +482,13 @@ func (srv *MCPServer) handleRemember(ctx context.Context, args map[string]interf
 
 	srv.log.Info("memory stored", "id", raw.ID, "source", source, "type", memType, "project", project)
 
-	return toolResult(fmt.Sprintf("Stored memory %s (type: %s, project: %s)\n  Raw ID: %s\n  Initial salience: %.2f\n  Encoding: queued (async)\n\nTip: Use check_memory with raw_id %q to verify encoding status. Dedup protections: same-type, same-project, source-aware thresholds.",
-		raw.ID, memType, project, raw.ID, raw.InitialSalience, raw.ID)), nil
+	msg := fmt.Sprintf("Stored memory %s (type: %s, project: %s)\n  Raw ID: %s\n  Initial salience: %.2f\n  Encoding: queued (async)\n\nTip: Use check_memory with raw_id %q to verify encoding status. Dedup protections: same-type, same-project, source-aware thresholds.",
+		raw.ID, memType, project, raw.ID, raw.InitialSalience, raw.ID)
+	if len(invalidAssocIDs) > 0 {
+		msg += fmt.Sprintf("\n\nWarning: %d association target(s) not found and skipped: %s",
+			len(invalidAssocIDs), strings.Join(invalidAssocIDs, ", "))
+	}
+	return toolResult(msg), nil
 }
 
 // syncActivityFromDaemon fetches the daemon's watcher activity tracker state

--- a/internal/mcp/tools.go
+++ b/internal/mcp/tools.go
@@ -631,6 +631,11 @@ func createHandoffToolDef() ToolDefinition {
 	}
 }
 
+// ToolCount returns the number of registered MCP tools.
+func ToolCount() int {
+	return len(allToolDefs())
+}
+
 // allToolDefs returns the complete list of MCP tool definitions.
 func allToolDefs() []ToolDefinition {
 	return []ToolDefinition{

--- a/internal/store/sqlite/scoped.go
+++ b/internal/store/sqlite/scoped.go
@@ -3,6 +3,7 @@ package sqlite
 import (
 	"context"
 	"fmt"
+	"strings"
 	"time"
 
 	store "github.com/appsprout-dev/mnemonic/internal/store"
@@ -71,7 +72,21 @@ func (s *SQLiteStore) ListMemoriesBySession(ctx context.Context, sessionID strin
 // ListSessions returns recent sessions with metadata.
 func (s *SQLiteStore) ListSessions(ctx context.Context, since time.Time, limit int) ([]store.SessionSummary, error) {
 	query := `
-	SELECT session_id, MIN(created_at), MAX(created_at), COUNT(*)
+	SELECT session_id, MIN(created_at), MAX(created_at), COUNT(*),
+		COALESCE((
+			SELECT GROUP_CONCAT(topic, ',')
+			FROM (
+				SELECT json_extract(je.value, '$.label') AS topic, COUNT(*) AS cnt
+				FROM memories m2
+				JOIN concept_sets cs ON cs.memory_id = m2.id
+				, json_each(cs.topics) je
+				WHERE m2.session_id = memories.session_id
+				  AND json_extract(je.value, '$.label') IS NOT NULL
+				GROUP BY topic
+				ORDER BY cnt DESC
+				LIMIT 5
+			)
+		), '') AS top_concepts
 	FROM memories
 	WHERE session_id IS NOT NULL AND session_id != '' AND created_at >= ?
 	GROUP BY session_id
@@ -87,12 +102,15 @@ func (s *SQLiteStore) ListSessions(ctx context.Context, since time.Time, limit i
 	var sessions []store.SessionSummary
 	for rows.Next() {
 		var ss store.SessionSummary
-		var startStr, endStr string
-		if err := rows.Scan(&ss.SessionID, &startStr, &endStr, &ss.MemoryCount); err != nil {
+		var startStr, endStr, conceptsStr string
+		if err := rows.Scan(&ss.SessionID, &startStr, &endStr, &ss.MemoryCount, &conceptsStr); err != nil {
 			continue
 		}
 		ss.StartTime, _ = time.Parse(time.RFC3339, startStr)
 		ss.EndTime, _ = time.Parse(time.RFC3339, endStr)
+		if conceptsStr != "" {
+			ss.TopConcepts = strings.Split(conceptsStr, ",")
+		}
 		sessions = append(sessions, ss)
 	}
 	return sessions, rows.Err()

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -1595,7 +1595,7 @@
                 <div class="llm-view">
                     <div class="llm-header">
                         <div class="llm-header-title">MCP Tool Usage</div>
-                        <div class="llm-header-sub">recall &middot; remember &middot; get_context &middot; 21 tools</div>
+                        <div class="llm-header-sub" id="toolHeaderSub">recall &middot; remember &middot; get_context &middot; &hellip; tools</div>
                         <div class="llm-header-meta">
                             <div class="llm-range-tabs" id="toolRangeTabs">
                                 <button class="llm-range-tab" data-range="1h" onclick="setToolRange('1h')">1h</button>
@@ -2890,6 +2890,9 @@
                 vEl.textContent = 'v' + health.version;
                 vEl.href = 'https://github.com/AppSprout-dev/mnemonic/releases/tag/v' + health.version;
             }
+            if (health.tool_count) {
+                document.getElementById('toolHeaderSub').textContent = 'recall \u00b7 remember \u00b7 get_context \u00b7 ' + health.tool_count + ' tools';
+            }
             state.previousStats = stats;
         } catch (e) {
             document.getElementById('navHealth').className = 'nav-health down';
@@ -3584,6 +3587,16 @@
     }
 
     // Session Timeline — swimlane visualization
+    function _fmtTimelineAxis(d) {
+        var now = new Date();
+        if (d.toDateString() === now.toDateString()) {
+            return String(d.getHours()).padStart(2, '0') + ':' + String(d.getMinutes()).padStart(2, '0');
+        }
+        var months = ['Jan','Feb','Mar','Apr','May','Jun','Jul','Aug','Sep','Oct','Nov','Dec'];
+        return months[d.getMonth()] + ' ' + d.getDate() + ' ' +
+            String(d.getHours()).padStart(2, '0') + ':' + String(d.getMinutes()).padStart(2, '0');
+    }
+
     async function loadSessionTimeline() {
         try {
             var resp = await fetch(CONFIG.API_BASE + '/sessions?days=7&limit=15');
@@ -3596,9 +3609,16 @@
                 return;
             }
 
+            // Filter out sessions with no memories
+            var activeSessions = sessions.filter(function(s) { return s.memory_count > 0; });
+            if (activeSessions.length === 0) {
+                el.innerHTML = '<span class="llm-empty" style="font-size:0.75rem">No sessions with memories</span>';
+                return;
+            }
+
             // Find time range across all sessions
             var minT = Infinity, maxT = -Infinity;
-            sessions.forEach(function(s) {
+            activeSessions.forEach(function(s) {
                 var st = new Date(s.start_time).getTime();
                 var et = new Date(s.end_time).getTime();
                 if (st < minT) minT = st;
@@ -3608,7 +3628,7 @@
 
             var colors = ['var(--accent-cyan)', 'var(--accent-green)', 'var(--accent-violet)', 'var(--accent-blue)', 'var(--accent-pink)', 'var(--accent-yellow)'];
 
-            el.innerHTML = sessions.map(function(s, i) {
+            var html = activeSessions.map(function(s, i) {
                 var st = new Date(s.start_time).getTime();
                 var et = new Date(s.end_time).getTime();
                 var left = ((st - minT) / rangeMs) * 100;
@@ -3616,13 +3636,27 @@
                 var label = s.session_id.replace('mcp-', '').substring(0, 8);
                 var dur = Math.round((et - st) / 60000);
                 var color = colors[i % colors.length];
+                var concepts = (s.top_concepts && s.top_concepts.length > 0) ? ' \u00b7 ' + s.top_concepts.slice(0, 3).join(', ') : '';
                 return '<div class="session-lane">' +
                     '<span class="session-label" title="' + escapeHtml(s.session_id) + '">' + escapeHtml(label) + '</span>' +
                     '<div class="session-bar-track">' +
                     '<div class="session-bar" style="left:' + left.toFixed(1) + '%;width:' + width.toFixed(1) + '%;background:' + color + '">' +
-                    (s.memory_count > 0 ? s.memory_count : '') + '</div></div>' +
-                    '<span class="session-meta">' + dur + 'm / ' + s.memory_count + '</span></div>';
+                    s.memory_count + '</div></div>' +
+                    '<span class="session-meta">' + dur + 'm / ' + s.memory_count + concepts + '</span></div>';
             }).join('');
+
+            // Time axis labels
+            var tickCount = Math.min(5, activeSessions.length);
+            var axisHtml = '<div style="position:relative;height:18px;margin-top:4px;font-size:0.65rem;color:var(--text-dim)">';
+            for (var ti = 0; ti < tickCount; ti++) {
+                var pct = tickCount > 1 ? (ti / (tickCount - 1)) * 100 : 50;
+                var tickMs = minT + (pct / 100) * rangeMs;
+                var tickLabel = _fmtTimelineAxis(new Date(tickMs));
+                axisHtml += '<span style="position:absolute;left:' + pct.toFixed(1) + '%;transform:translateX(-50%);white-space:nowrap">' + tickLabel + '</span>';
+            }
+            axisHtml += '</div>';
+
+            el.innerHTML = html + axisHtml;
         } catch(e) { /* ignore */ }
     }
 


### PR DESCRIPTION
## Summary
- **#321**: Dashboard tool count now derived from `mcp.ToolCount()` via the health API instead of hardcoded
- **#322**: `associate_with` on `remember` validates target memory IDs exist — invalid ones skipped with warning
- **#323**: Session timeline: `top_concepts` populated from concept_sets, time axis labels added, empty sessions filtered

## Test plan
- [x] `go test ./...` all passing
- [x] `tool_count: 23` in health API response
- [x] `top_concepts` populated in sessions endpoint (verified: "Filesystem Monitoring", "Memory Retrieval Optimization", etc.)
- [x] Dashboard renders updated tool count and timeline labels

Closes #321, closes #322, closes #323

🤖 Generated with [Claude Code](https://claude.com/claude-code)