### PR TITLE
docs: fix outdated tool counts and missing git watcher

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -111,10 +111,11 @@ type EventBus interface {
 
 ### Layer 1 — Perception (Full Ingestion)
 
-**Three watchers active from v1:**
+**Four watchers active from v1:**
 - **Filesystem**: Watch configured dirs, track create/modify/delete
 - **Terminal**: Poll shell history, detect new entries
 - **Clipboard**: Poll for text changes
+- **Git**: Watch repositories for commits, branches, and diffs
 
 **Heuristic pre-filter pipeline** (before any LLM call):
 ```
@@ -532,7 +533,8 @@ mnemonic/
 │   │   ├── watcher.go                     # Watcher interface
 │   │   ├── filesystem/                    # FSEvents (macOS) + fsnotify (Linux)
 │   │   ├── terminal/watcher.go            # Shell history polling
-│   │   └── clipboard/watcher.go           # Cross-platform clipboard
+│   │   ├── clipboard/watcher.go           # Cross-platform clipboard
+│   │   └── git/                           # Git repository watcher
 │   ├── agent/
 │   │   ├── agent.go                       # Agent interface
 │   │   ├── perception/                    # Layer 1: Watch + heuristic filter
@@ -552,7 +554,7 @@ mnemonic/
 │   │   ├── server.go                      # Static file serving (go:embed)
 │   │   └── static/index.html              # Dashboard (D3.js graph, live feed, query tester)
 │   ├── ingest/                            # Project ingestion engine
-│   ├── mcp/server.go                      # MCP server (19 tools for Claude Code)
+│   ├── mcp/server.go                      # MCP server (23 tools for Claude Code)
 │   ├── backup/                            # Export/import logic
 │   ├── daemon/                            # Service management (macOS LaunchAgent + Linux systemd)
 │   ├── config/config.go                   # Configuration loading

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A local-first semantic memory daemon that watches your work, learns from it, and
 - **Autonomous** — Watches your filesystem, terminal, and clipboard. Encodes memories without you lifting a finger.
 - **Biological** — Memories consolidate, decay, form patterns, and become principles. It doesn't just store — it *processes*.
 - **Local-first** — Air-gapped, SQLite-backed, never phones home. Your data stays on your machine.
-- **22 MCP tools** — Drop-in memory layer for Claude Code and other AI agents.
+- **23 MCP tools** — Drop-in memory layer for Claude Code and other AI agents.
 - **Self-updating** — Built-in update mechanism checks GitHub Releases and applies updates in-place.
 - **Cross-platform** — macOS, Linux, and Windows. Daemon management via launchd, systemd, or Windows Services.
 
@@ -106,7 +106,7 @@ For the full deep dive, see [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ## MCP Integration
 
-Mnemonic exposes 22 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) for Claude Code and other AI agents:
+Mnemonic exposes 23 tools via the [Model Context Protocol](https://modelcontextprotocol.io/) for Claude Code and other AI agents:
 
 **Claude Code config** (`~/.claude/settings.local.json`):
 
@@ -222,7 +222,7 @@ internal/
   agent/            8 cognitive agents + orchestrator + reactor
   api/              HTTP + WebSocket server
   web/              Embedded dashboard (single-page app)
-  mcp/              MCP server (22 tools)
+  mcp/              MCP server (23 tools)
   store/            Store interface + SQLite (FTS5 + vector search)
   llm/              LLM provider interface (LM Studio, Gemini, cloud APIs)
   ingest/           Project ingestion engine


### PR DESCRIPTION
## Summary

- ARCHITECTURE.md: fix MCP tool count (19 -> 23), add git watcher as 4th watcher, update project structure tree
- README.md: fix MCP tool count (22 -> 23) in three locations

## Test plan

- [x] Docs-only change, no code impact

🤖 Generated with [Claude Code](https://claude.com/claude-code)