### PR TITLE
feat: Model Control Center with embedded LLM inference

### DIFF
--- a/cmd/mnemonic/runtime.go
+++ b/cmd/mnemonic/runtime.go
@@ -187,9 +187,26 @@ func buildEncodingConfig(cfg *config.Config) encoding.EncodingConfig {
 	}
 }
 
+// newAPIProvider creates an API-based LLM provider from config.
+func newAPIProvider(cfg *config.Config) llm.Provider {
+	timeout := time.Duration(cfg.LLM.TimeoutSec) * time.Second
+	if timeout == 0 {
+		timeout = 30 * time.Second
+	}
+	return llm.NewLMStudioProvider(
+		cfg.LLM.Endpoint,
+		cfg.LLM.ChatModel,
+		cfg.LLM.EmbeddingModel,
+		cfg.LLM.APIKey,
+		timeout,
+		cfg.LLM.MaxConcurrent,
+	)
+}
+
 // newLLMProvider creates the appropriate LLM provider based on config.
 // For "api" (default), it creates an LMStudioProvider for OpenAI-compatible APIs.
-// For "embedded", it creates an EmbeddedProvider for in-process llama.cpp inference.
+// For "embedded", it creates a SwitchableProvider with embedded as primary
+// and API as a fallback that can be toggled at runtime.
 func newLLMProvider(cfg *config.Config) llm.Provider {
 	switch cfg.LLM.Provider {
 	case "embedded":
@@ -215,19 +232,15 @@ func newLLMProvider(cfg *config.Config) llm.Provider {
 		} else {
 			slog.Warn("embedded provider selected but llama.cpp not compiled in (build with: make build-embedded)")
 		}
-		return ep
-	default: // "api" or ""
-		timeout := time.Duration(cfg.LLM.TimeoutSec) * time.Second
-		if timeout == 0 {
-			timeout = 30 * time.Second
+
+		// Create API provider as runtime fallback (Gemini, etc.)
+		var apiProvider llm.Provider
+		if cfg.LLM.Endpoint != "" {
+			apiProvider = newAPIProvider(cfg)
 		}
-		return llm.NewLMStudioProvider(
-			cfg.LLM.Endpoint,
-			cfg.LLM.ChatModel,
-			cfg.LLM.EmbeddingModel,
-			cfg.LLM.APIKey,
-			timeout,
-			cfg.LLM.MaxConcurrent,
-		)
+
+		return llm.NewSwitchableProvider(ep, apiProvider, cfg.LLM.ChatModel)
+	default: // "api" or ""
+		return newAPIProvider(cfg)
 	}
 }

--- a/cmd/mnemonic/serve.go
+++ b/cmd/mnemonic/serve.go
@@ -663,6 +663,12 @@ func serveCommand(configPath string) {
 			StartTime:             time.Now(),
 			Log:                   log,
 		}
+		// Wire model manager if using switchable/embedded provider
+		if sp, ok := llmProvider.(*llm.SwitchableProvider); ok {
+			apiDeps.ModelManager = sp
+		} else if ep, ok := llmProvider.(*llm.EmbeddedProvider); ok {
+			apiDeps.ModelManager = ep
+		}
 		// Only set Consolidator if it's non-nil (avoids Go nil-interface trap)
 		if consolidator != nil {
 			apiDeps.Consolidator = consolidator

--- a/internal/api/routes/models.go
+++ b/internal/api/routes/models.go
@@ -1,0 +1,119 @@
+package routes
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+
+	"github.com/appsprout-dev/mnemonic/internal/llm"
+)
+
+// HandleListModels returns available GGUF models in the models directory.
+func HandleListModels(mgr llm.ModelManager, log *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if mgr == nil {
+			writeJSON(w, http.StatusOK, map[string]interface{}{
+				"models":  []interface{}{},
+				"enabled": false,
+				"message": "embedded provider not active",
+			})
+			return
+		}
+
+		models, err := mgr.ListAvailableModels()
+		if err != nil {
+			log.Error("failed to list models", "error", err)
+			writeError(w, http.StatusInternalServerError, "failed to list models: "+err.Error(), "MODEL_ERROR")
+			return
+		}
+
+		active := mgr.ActiveModel()
+
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"models":  models,
+			"active":  active,
+			"enabled": true,
+			"mode":    mgr.ProviderMode(),
+		})
+	}
+}
+
+// HandleActiveModel returns the currently loaded model status.
+func HandleActiveModel(mgr llm.ModelManager, log *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if mgr == nil {
+			writeJSON(w, http.StatusOK, map[string]interface{}{
+				"enabled": false,
+				"message": "embedded provider not active",
+			})
+			return
+		}
+
+		active := mgr.ActiveModel()
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"active":  active,
+			"enabled": true,
+		})
+	}
+}
+
+// swapModelRequest is the JSON body for POST /api/v1/models/active.
+type swapModelRequest struct {
+	ChatModel  string `json:"chat_model"`
+	EmbedModel string `json:"embed_model"`
+	Mode       string `json:"mode"` // "embedded" or "api" — switches provider
+}
+
+// HandleSwapModel hot-swaps the active chat or embedding model.
+func HandleSwapModel(mgr llm.ModelManager, log *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if mgr == nil {
+			writeError(w, http.StatusBadRequest, "embedded provider not active — model swap unavailable", "MODEL_ERROR")
+			return
+		}
+
+		var req swapModelRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON body: "+err.Error(), "INVALID_PARAM")
+			return
+		}
+
+		if req.ChatModel == "" && req.EmbedModel == "" && req.Mode == "" {
+			writeError(w, http.StatusBadRequest, "specify chat_model, embed_model, or mode", "INVALID_PARAM")
+			return
+		}
+
+		if req.Mode != "" {
+			log.Info("switching provider mode", "mode", req.Mode)
+			if err := mgr.SetProviderMode(req.Mode); err != nil {
+				log.Error("failed to switch provider mode", "error", err)
+				writeError(w, http.StatusBadRequest, "failed to switch mode: "+err.Error(), "MODEL_ERROR")
+				return
+			}
+		}
+
+		if req.ChatModel != "" {
+			log.Info("swapping chat model", "model", req.ChatModel)
+			if err := mgr.SwapChatModel(req.ChatModel); err != nil {
+				log.Error("failed to swap chat model", "error", err)
+				writeError(w, http.StatusInternalServerError, "failed to swap chat model: "+err.Error(), "MODEL_ERROR")
+				return
+			}
+		}
+
+		if req.EmbedModel != "" {
+			log.Info("swapping embed model", "model", req.EmbedModel)
+			if err := mgr.SwapEmbedModel(req.EmbedModel); err != nil {
+				log.Error("failed to swap embed model", "error", err)
+				writeError(w, http.StatusInternalServerError, "failed to swap embed model: "+err.Error(), "MODEL_ERROR")
+				return
+			}
+		}
+
+		active := mgr.ActiveModel()
+		writeJSON(w, http.StatusOK, map[string]interface{}{
+			"status": "ok",
+			"active": active,
+		})
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -30,6 +30,7 @@ type ServerConfig struct {
 type ServerDeps struct {
 	Store                 store.Store
 	LLM                   llm.Provider
+	ModelManager          llm.ModelManager        // can be nil if not using embedded provider
 	Bus                   events.Bus
 	Retriever             *retrieval.RetrievalAgent
 	Consolidator          routes.ConsolidationRunner // can be nil if disabled
@@ -131,6 +132,11 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("PATCH /api/v1/patterns/{id}", routes.HandleArchivePattern(s.deps.Store, s.deps.Log))
 	s.mux.HandleFunc("GET /api/v1/abstractions", routes.HandleListAbstractions(s.deps.Store, s.deps.Log))
 	s.mux.HandleFunc("GET /api/v1/projects", routes.HandleListProjects(s.deps.Store, s.deps.Log))
+
+	// Model management (control center)
+	s.mux.HandleFunc("GET /api/v1/models", routes.HandleListModels(s.deps.ModelManager, s.deps.Log))
+	s.mux.HandleFunc("GET /api/v1/models/active", routes.HandleActiveModel(s.deps.ModelManager, s.deps.Log))
+	s.mux.HandleFunc("POST /api/v1/models/active", routes.HandleSwapModel(s.deps.ModelManager, s.deps.Log))
 
 	// LLM usage monitoring
 	s.mux.HandleFunc("GET /api/v1/llm/usage", routes.HandleLLMUsage(s.deps.Store, s.deps.Log))

--- a/internal/llm/embedded.go
+++ b/internal/llm/embedded.go
@@ -56,6 +56,26 @@ type BackendCompletionResponse struct {
 	MinProb          float32 // minimum probability of any chosen token (0-1)
 }
 
+// AvailableModel describes a GGUF model available for loading.
+type AvailableModel struct {
+	Filename string `json:"filename"`
+	Path     string `json:"path"`
+	SizeMB   int64  `json:"size_mb"`
+	Role     string `json:"role,omitempty"`     // "chat" or "embedding"
+	Version  string `json:"version,omitempty"`  // model version
+	Quantize string `json:"quantize,omitempty"` // quantization type
+}
+
+// ModelStatus reports the currently loaded model state.
+type ModelStatus struct {
+	ChatModel  string `json:"chat_model"`
+	EmbedModel string `json:"embed_model"`
+	Loaded     bool   `json:"loaded"`
+	ModelsDir  string `json:"models_dir"`
+	Mode       string `json:"mode,omitempty"`      // "embedded" or "api"
+	APIModel   string `json:"api_model,omitempty"` // cloud model name when in API mode
+}
+
 // EmbeddedProvider implements the Provider interface using in-process inference
 // via a Backend (llama.cpp CGo bindings). This allows mnemonic to run its own
 // GGUF models without an external API server.
@@ -67,10 +87,11 @@ type EmbeddedProvider struct {
 	maxTokens      int
 	temperature    float32
 
-	mu           sync.RWMutex
-	chatBackend  Backend
-	embedBackend Backend
-	sem          chan struct{}
+	mu             sync.RWMutex
+	chatBackend    Backend
+	embedBackend   Backend
+	sem            chan struct{}
+	backendFactory func() Backend
 }
 
 // EmbeddedProviderConfig holds the configuration for creating an EmbeddedProvider.
@@ -117,9 +138,12 @@ func NewEmbeddedProvider(cfg EmbeddedProviderConfig) *EmbeddedProvider {
 
 // LoadModels loads the configured GGUF model files using the given backend factory.
 // backendFactory creates a new Backend instance for each model.
+// The factory is retained for later hot-swap operations.
 func (p *EmbeddedProvider) LoadModels(backendFactory func() Backend) error {
 	p.mu.Lock()
 	defer p.mu.Unlock()
+
+	p.backendFactory = backendFactory
 
 	// Load chat model
 	chatPath := filepath.Join(p.modelsDir, p.chatModelFile)
@@ -167,18 +191,26 @@ func (p *EmbeddedProvider) release() {
 	<-p.sem
 }
 
-// formatPrompt converts a slice of Messages into a single prompt string.
-// Uses the Felix-LM fine-tuning format: <|system|>\n...\n<|user|>\n...\n<|assistant|>\n
+// formatPrompt converts a slice of Messages into a prompt string.
+// Uses ChatML format (Qwen 3.5, Gemma-it, etc.):
+//
+//	<|im_start|>system\n...<|im_end|>\n<|im_start|>user\n...<|im_end|>\n<|im_start|>assistant\n
+//
+// Appends /no_think to the system message to disable Qwen's thinking mode,
+// which interferes with GBNF grammar-constrained generation.
 func formatPrompt(messages []Message) string {
 	var b strings.Builder
 	for _, msg := range messages {
-		b.WriteString("<|")
+		b.WriteString("<|im_start|>")
 		b.WriteString(msg.Role)
-		b.WriteString("|>\n")
-		b.WriteString(msg.Content)
 		b.WriteByte('\n')
+		b.WriteString(msg.Content)
+		if msg.Role == "system" {
+			b.WriteString(" /no_think")
+		}
+		b.WriteString("<|im_end|>\n")
 	}
-	b.WriteString("<|assistant|>\n")
+	b.WriteString("<|im_start|>assistant\n")
 	return b.String()
 }
 
@@ -233,12 +265,25 @@ func (p *EmbeddedProvider) Complete(ctx context.Context, req CompletionRequest) 
 			"prompt_chars", len(prompt))
 	}
 
+	// Ensure <|im_end|> is a stop sequence so the model stops at turn boundary.
+	stop := req.Stop
+	hasIMEnd := false
+	for _, s := range stop {
+		if s == "<|im_end|>" {
+			hasIMEnd = true
+			break
+		}
+	}
+	if !hasIMEnd {
+		stop = append(stop, "<|im_end|>")
+	}
+
 	backendReq := BackendCompletionRequest{
 		Prompt:      prompt,
 		MaxTokens:   maxTokens,
 		Temperature: temp,
 		TopP:        req.TopP,
-		Stop:        req.Stop,
+		Stop:        stop,
 		Grammar:     grammar,
 	}
 
@@ -247,8 +292,11 @@ func (p *EmbeddedProvider) Complete(ctx context.Context, req CompletionRequest) 
 		return CompletionResponse{}, fmt.Errorf("embedded completion: %w", err)
 	}
 
+	// Strip Qwen-style <think>...</think> wrapper if present.
+	content := stripThinkingTokens(backendResp.Text)
+
 	return CompletionResponse{
-		Content:          backendResp.Text,
+		Content:          content,
 		StopReason:       "stop",
 		TokensUsed:       backendResp.PromptTokens + backendResp.CompletionTokens,
 		PromptTokens:     backendResp.PromptTokens,
@@ -332,6 +380,211 @@ func (p *EmbeddedProvider) ModelInfo(ctx context.Context) (ModelMetadata, error)
 		SupportsEmbedding: p.embedBackend != nil || p.embedModelFile == "",
 		MaxTokens:         p.maxTokens,
 	}, nil
+}
+
+// ListAvailableModels returns models registered in models.json.
+// Only curated, production-ready models appear — not every GGUF file on disk.
+func (p *EmbeddedProvider) ListAvailableModels() ([]AvailableModel, error) {
+	p.mu.RLock()
+	dir := p.modelsDir
+	p.mu.RUnlock()
+
+	manifest, err := LoadManifest(dir)
+	if err != nil {
+		return nil, fmt.Errorf("loading model manifest: %w", err)
+	}
+
+	var models []AvailableModel
+	for _, entry := range manifest.Models {
+		models = append(models, AvailableModel{
+			Filename: entry.Filename,
+			Path:     filepath.Join(dir, entry.Filename),
+			SizeMB:   entry.SizeBytes / (1024 * 1024),
+			Role:     entry.Role,
+			Version:  entry.Version,
+			Quantize: entry.Quantize,
+		})
+	}
+	return models, nil
+}
+
+// ActiveModel returns the currently loaded model status.
+func (p *EmbeddedProvider) ActiveModel() ModelStatus {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return ModelStatus{
+		ChatModel:  p.chatModelFile,
+		EmbedModel: p.embedModelFile,
+		Loaded:     p.chatBackend != nil,
+		ModelsDir:  p.modelsDir,
+	}
+}
+
+// SwapChatModel hot-swaps the chat model to a different GGUF file.
+// The old backend is closed after the new one is loaded successfully.
+func (p *EmbeddedProvider) SwapChatModel(filename string) error {
+	p.mu.RLock()
+	factory := p.backendFactory
+	dir := p.modelsDir
+	opts := p.opts
+	p.mu.RUnlock()
+
+	if factory == nil {
+		return fmt.Errorf("no backend factory configured — cannot swap models")
+	}
+
+	modelPath := filepath.Join(dir, filename)
+	if _, err := os.Stat(modelPath); err != nil {
+		return fmt.Errorf("model not found at %s: %w", modelPath, err)
+	}
+
+	// Load new model before acquiring write lock
+	newBackend := factory()
+	if err := newBackend.LoadModel(modelPath, opts); err != nil {
+		return fmt.Errorf("loading new chat model %s: %w", filename, err)
+	}
+	slog.Info("loaded new chat model for swap", "path", modelPath)
+
+	// Swap under write lock
+	p.mu.Lock()
+	oldBackend := p.chatBackend
+	p.chatBackend = newBackend
+	p.chatModelFile = filename
+	p.mu.Unlock()
+
+	// Close old backend outside the lock
+	if oldBackend != nil {
+		if err := oldBackend.Close(); err != nil {
+			slog.Warn("error closing old chat backend during swap", "error", err)
+		}
+	}
+
+	slog.Info("chat model swapped", "model", filename)
+	return nil
+}
+
+// SwapEmbedModel hot-swaps the embedding model to a different GGUF file.
+// Pass empty string to clear the dedicated embedding model (falls back to chat backend).
+func (p *EmbeddedProvider) SwapEmbedModel(filename string) error {
+	if filename == "" {
+		p.mu.Lock()
+		oldBackend := p.embedBackend
+		p.embedBackend = nil
+		p.embedModelFile = ""
+		p.mu.Unlock()
+		if oldBackend != nil {
+			if err := oldBackend.Close(); err != nil {
+				slog.Warn("error closing old embed backend during swap", "error", err)
+			}
+		}
+		slog.Info("embed model cleared, using chat backend for embeddings")
+		return nil
+	}
+
+	p.mu.RLock()
+	factory := p.backendFactory
+	dir := p.modelsDir
+	opts := p.opts
+	p.mu.RUnlock()
+
+	if factory == nil {
+		return fmt.Errorf("no backend factory configured — cannot swap models")
+	}
+
+	modelPath := filepath.Join(dir, filename)
+	if _, err := os.Stat(modelPath); err != nil {
+		return fmt.Errorf("embed model not found at %s: %w", modelPath, err)
+	}
+
+	newBackend := factory()
+	if err := newBackend.LoadModel(modelPath, opts); err != nil {
+		return fmt.Errorf("loading new embed model %s: %w", filename, err)
+	}
+
+	p.mu.Lock()
+	oldBackend := p.embedBackend
+	p.embedBackend = newBackend
+	p.embedModelFile = filename
+	p.mu.Unlock()
+
+	if oldBackend != nil {
+		if err := oldBackend.Close(); err != nil {
+			slog.Warn("error closing old embed backend during swap", "error", err)
+		}
+	}
+
+	slog.Info("embed model swapped", "model", filename)
+	return nil
+}
+
+// Unload releases all backend resources without destroying the provider config.
+// The provider can be reloaded later with Reload().
+func (p *EmbeddedProvider) Unload() {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+
+	if p.chatBackend != nil {
+		if err := p.chatBackend.Close(); err != nil {
+			slog.Warn("error closing chat backend during unload", "error", err)
+		}
+		p.chatBackend = nil
+		slog.Info("unloaded chat model", "model", p.chatModelFile)
+	}
+	if p.embedBackend != nil {
+		if err := p.embedBackend.Close(); err != nil {
+			slog.Warn("error closing embed backend during unload", "error", err)
+		}
+		p.embedBackend = nil
+		slog.Info("unloaded embed model", "model", p.embedModelFile)
+	}
+}
+
+// Reload reloads models using the stored backend factory.
+// Called after Unload() to restore embedded inference.
+func (p *EmbeddedProvider) Reload() error {
+	p.mu.RLock()
+	factory := p.backendFactory
+	p.mu.RUnlock()
+
+	if factory == nil {
+		return fmt.Errorf("no backend factory configured — cannot reload")
+	}
+	return p.LoadModels(factory)
+}
+
+// SetProviderMode on a bare EmbeddedProvider only supports "embedded".
+func (p *EmbeddedProvider) SetProviderMode(mode string) error {
+	if mode == "embedded" {
+		return nil
+	}
+	return fmt.Errorf("API provider not configured — only embedded mode available")
+}
+
+// ProviderMode always returns "embedded" for a bare EmbeddedProvider.
+func (p *EmbeddedProvider) ProviderMode() string {
+	return "embedded"
+}
+
+// stripThinkingTokens removes <think>...</think> blocks from model output.
+// Qwen 3.5 and similar models prepend reasoning tokens before the actual response.
+func stripThinkingTokens(text string) string {
+	const openTag = "<think>"
+	const closeTag = "</think>"
+
+	for {
+		start := strings.Index(text, openTag)
+		if start == -1 {
+			break
+		}
+		end := strings.Index(text[start:], closeTag)
+		if end == -1 {
+			// Unclosed think tag — strip from start to end of text
+			text = strings.TrimSpace(text[:start])
+			break
+		}
+		text = text[:start] + text[start+end+len(closeTag):]
+	}
+	return strings.TrimSpace(text)
 }
 
 // Close releases all backend resources.

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -111,6 +111,28 @@ type Provider interface {
 	ModelInfo(ctx context.Context) (ModelMetadata, error)
 }
 
+// ModelManager is the interface for runtime model management.
+// Implemented by SwitchableProvider (embedded + API) or EmbeddedProvider alone.
+type ModelManager interface {
+	// ListAvailableModels returns models from the manifest.
+	ListAvailableModels() ([]AvailableModel, error)
+
+	// ActiveModel returns the currently loaded model status.
+	ActiveModel() ModelStatus
+
+	// SwapChatModel hot-swaps the chat model to a different GGUF file.
+	SwapChatModel(filename string) error
+
+	// SwapEmbedModel hot-swaps the embedding model. Empty string clears it.
+	SwapEmbedModel(filename string) error
+
+	// SetProviderMode switches between "embedded" and "api" at runtime.
+	SetProviderMode(mode string) error
+
+	// ProviderMode returns the current mode ("embedded" or "api").
+	ProviderMode() string
+}
+
 // ErrProviderUnavailable is returned when the LLM backend is not reachable.
 type ErrProviderUnavailable struct {
 	Endpoint string

--- a/internal/llm/switchable.go
+++ b/internal/llm/switchable.go
@@ -1,0 +1,150 @@
+package llm
+
+import (
+	"context"
+	"fmt"
+	"sync"
+)
+
+// SwitchableProvider wraps an embedded provider and an API provider,
+// allowing runtime switching between local inference and cloud API.
+// All agents hold references to this provider, so switching takes effect
+// immediately across the entire daemon.
+type SwitchableProvider struct {
+	mu       sync.RWMutex
+	embedded *EmbeddedProvider
+	api      Provider
+	useAPI   bool
+	apiModel string // model name for display (e.g. "gemini-3-flash-preview")
+}
+
+// NewSwitchableProvider creates a provider that can toggle between embedded and API.
+// Starts in embedded mode.
+func NewSwitchableProvider(embedded *EmbeddedProvider, api Provider, apiModel string) *SwitchableProvider {
+	return &SwitchableProvider{
+		embedded: embedded,
+		api:      api,
+		apiModel: apiModel,
+	}
+}
+
+func (s *SwitchableProvider) active() Provider {
+	if s.useAPI {
+		return s.api
+	}
+	return s.embedded
+}
+
+// Complete delegates to the active provider.
+func (s *SwitchableProvider) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	s.mu.RLock()
+	p := s.active()
+	s.mu.RUnlock()
+	return p.Complete(ctx, req)
+}
+
+// Embed delegates to the active provider.
+func (s *SwitchableProvider) Embed(ctx context.Context, text string) ([]float32, error) {
+	s.mu.RLock()
+	p := s.active()
+	s.mu.RUnlock()
+	return p.Embed(ctx, text)
+}
+
+// BatchEmbed delegates to the active provider.
+func (s *SwitchableProvider) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
+	s.mu.RLock()
+	p := s.active()
+	s.mu.RUnlock()
+	return p.BatchEmbed(ctx, texts)
+}
+
+// Health delegates to the active provider.
+func (s *SwitchableProvider) Health(ctx context.Context) error {
+	s.mu.RLock()
+	p := s.active()
+	s.mu.RUnlock()
+	return p.Health(ctx)
+}
+
+// ModelInfo delegates to the active provider.
+func (s *SwitchableProvider) ModelInfo(ctx context.Context) (ModelMetadata, error) {
+	s.mu.RLock()
+	p := s.active()
+	s.mu.RUnlock()
+	return p.ModelInfo(ctx)
+}
+
+// --- ModelManager implementation ---
+
+// ListAvailableModels delegates to the embedded provider.
+func (s *SwitchableProvider) ListAvailableModels() ([]AvailableModel, error) {
+	return s.embedded.ListAvailableModels()
+}
+
+// ActiveModel returns the current model status including provider mode.
+func (s *SwitchableProvider) ActiveModel() ModelStatus {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	status := s.embedded.ActiveModel()
+	if s.useAPI {
+		status.Mode = "api"
+		status.APIModel = s.apiModel
+	} else {
+		status.Mode = "embedded"
+	}
+	return status
+}
+
+// SwapChatModel delegates to the embedded provider.
+func (s *SwitchableProvider) SwapChatModel(filename string) error {
+	return s.embedded.SwapChatModel(filename)
+}
+
+// SwapEmbedModel delegates to the embedded provider.
+func (s *SwitchableProvider) SwapEmbedModel(filename string) error {
+	return s.embedded.SwapEmbedModel(filename)
+}
+
+// SetProviderMode switches between "embedded" and "api" at runtime.
+// Switching to API unloads embedded models to free VRAM.
+// Switching back to embedded reloads them.
+func (s *SwitchableProvider) SetProviderMode(mode string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	switch mode {
+	case "embedded":
+		if !s.useAPI {
+			return nil // already in embedded mode
+		}
+		// Reload models
+		if err := s.embedded.Reload(); err != nil {
+			return fmt.Errorf("reloading embedded models: %w", err)
+		}
+		s.useAPI = false
+	case "api":
+		if s.api == nil {
+			return fmt.Errorf("API provider not configured")
+		}
+		if s.useAPI {
+			return nil // already in API mode
+		}
+		s.useAPI = true
+		// Unload models to free VRAM
+		s.embedded.Unload()
+	default:
+		return fmt.Errorf("unknown provider mode: %q (use \"embedded\" or \"api\")", mode)
+	}
+	return nil
+}
+
+// ProviderMode returns the current mode ("embedded" or "api").
+func (s *SwitchableProvider) ProviderMode() string {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	if s.useAPI {
+		return "api"
+	}
+	return "embedded"
+}

--- a/internal/web/static/index.html
+++ b/internal/web/static/index.html
@@ -1109,6 +1109,7 @@
                     <button class="ntab" data-view="agent" onclick="switchView('agent')">SDK</button>
                     <button class="ntab" data-view="llm" onclick="switchView('llm')">LLM</button>
                     <button class="ntab" data-view="tools" onclick="switchView('tools')">Tools</button>
+                    <button class="ntab" data-view="models" onclick="switchView('models')">Models</button>
                 </div>
                 <div class="navbar-right">
                     <span class="nav-health" id="healthDot"></span>
@@ -1551,6 +1552,47 @@
                     <div class="llm-panel" style="margin-bottom:16px">
                         <div class="llm-panel-title">Session Activity</div>
                         <div id="sessionTimeline" style="padding:4px 0"></div>
+                    </div>
+                </div>
+            </section>
+
+            <!-- Models Control Center View -->
+            <section class="view" id="view-models">
+                <div class="llm-view" style="padding-top:0">
+                    <div class="llm-header">
+                        <div class="forabg-title">Model Control Center</div>
+                        <div class="llm-header-sub" style="font-size:0.85rem;color:var(--text-dim)">Embedded GGUF model management</div>
+                        <div class="llm-header-meta">
+                            <span class="llm-updated" id="modelsUpdated"></span>
+                            <button class="agent-refresh-btn" onclick="loadModels()">
+                                <svg viewBox="0 0 24 24" width="12" height="12" fill="none" stroke="currentColor" stroke-width="2"><path d="M1 4v6h6M23 20v-6h-6"/><path d="M20.49 9A9 9 0 005.64 5.64L1 10m22 4l-4.64 4.36A9 9 0 013.51 15"/></svg>
+                                Refresh
+                            </button>
+                        </div>
+                    </div>
+
+                    <!-- Active Model Status -->
+                    <div class="llm-cards" id="modelStatusCards">
+                        <div class="llm-card"><div class="llm-card-label">Chat Model</div><div class="llm-card-value" id="modelChatName" style="font-size:0.85rem">-</div></div>
+                        <div class="llm-card"><div class="llm-card-label">Embed Model</div><div class="llm-card-value" id="modelEmbedName" style="font-size:0.85rem">-</div></div>
+                        <div class="llm-card"><div class="llm-card-label">Status</div><div class="llm-card-value" id="modelStatus">-</div></div>
+                        <div class="llm-card"><div class="llm-card-label">Models Dir</div><div class="llm-card-value" id="modelDir" style="font-size:0.75rem">-</div></div>
+                        <div class="llm-card"><div class="llm-card-label">Provider</div><div class="llm-card-value" id="modelModeToggle"></div></div>
+                    </div>
+
+                    <!-- Available Models Table -->
+                    <div class="llm-panel" style="margin-bottom:16px">
+                        <div class="llm-panel-title">Available Models</div>
+                        <table class="llm-table" id="modelsTable">
+                            <thead><tr><th>Model</th><th>Role</th><th>Size</th><th>Status</th><th>Action</th></tr></thead>
+                            <tbody id="modelsTableBody"><tr><td colspan="5" class="llm-empty">Loading...</td></tr></tbody>
+                        </table>
+                    </div>
+
+                    <!-- Swap Status -->
+                    <div class="llm-panel" id="modelSwapStatus" style="margin-bottom:16px;display:none">
+                        <div class="llm-panel-title">Swap Log</div>
+                        <div id="modelSwapLog" style="font-family:var(--mono);font-size:0.8rem;white-space:pre-wrap;max-height:200px;overflow-y:auto;padding:8px;background:var(--bg-deep);border-radius:4px"></div>
                     </div>
                 </div>
             </section>

--- a/internal/web/static/js/app.js
+++ b/internal/web/static/js/app.js
@@ -28,6 +28,7 @@ import { loadAgentData, refreshAgentData, renderAgentDashboard, sendChatMessage,
          toggleChatHistory, startNewConversation, onModelChange,
          checkForUpdate, triggerUpdate, renderMarkdown } from './agent.js';
 import { formatBytes } from './llm.js';
+import { loadModels, swapChatModel, swapEmbedModel, switchProviderMode } from './models.js';
 
 // ── Wire to window for HTML onclick handlers ──
 Object.assign(window, {
@@ -58,6 +59,8 @@ Object.assign(window, {
     loadAgentData, refreshAgentData, renderAgentDashboard, sendChatMessage,
     toggleChatHistory, startNewConversation, onModelChange,
     checkForUpdate, triggerUpdate,
+    // Models
+    loadModels, swapChatModel, swapEmbedModel, switchProviderMode,
     // Utils (used by some inline HTML)
     escapeHtml, showToast, relativeTime, simpleMarkdown, toggleToolDetail,
     agentProfile, memoryType, safeSalience, renderMarkdown, formatBytes,

--- a/internal/web/static/js/models.js
+++ b/internal/web/static/js/models.js
@@ -1,0 +1,161 @@
+import { state } from './state.js';
+import { fetchJSON, escapeHtml } from './utils.js';
+
+var _swapLog = [];
+
+function appendSwapLog(msg) {
+    _swapLog.push('[' + new Date().toLocaleTimeString() + '] ' + msg);
+    var el = document.getElementById('modelSwapLog');
+    var panel = document.getElementById('modelSwapStatus');
+    if (el && panel) {
+        panel.style.display = '';
+        el.textContent = _swapLog.join('\n');
+        el.scrollTop = el.scrollHeight;
+    }
+}
+
+export async function loadModels() {
+    try {
+        var data = await fetchJSON('/models');
+        state.modelsLoaded = true;
+
+        if (!data.enabled) {
+            document.getElementById('modelChatName').textContent = 'N/A';
+            document.getElementById('modelEmbedName').textContent = 'N/A';
+            document.getElementById('modelStatus').textContent = 'Not available';
+            document.getElementById('modelStatus').style.color = 'var(--text-dim)';
+            document.getElementById('modelDir').textContent = '-';
+            document.getElementById('modelModeToggle').innerHTML = '';
+            document.getElementById('modelsTableBody').innerHTML = '<tr><td colspan="5" class="llm-empty">Embedded provider not active. Set llm.provider: "embedded" in config.yaml and rebuild with make build-embedded</td></tr>';
+            document.getElementById('modelsUpdated').textContent = 'Updated ' + new Date().toLocaleTimeString();
+            return;
+        }
+
+        var active = data.active || {};
+        var mode = data.mode || active.mode || 'embedded';
+        var isAPI = mode === 'api';
+
+        // Mode toggle button
+        var toggleEl = document.getElementById('modelModeToggle');
+        if (isAPI) {
+            document.getElementById('modelChatName').textContent = active.api_model || 'Gemini';
+            document.getElementById('modelEmbedName').textContent = 'API';
+            document.getElementById('modelStatus').textContent = 'Cloud API';
+            document.getElementById('modelStatus').style.color = 'var(--accent-cyan)';
+            toggleEl.innerHTML = '<button class="agent-refresh-btn" style="padding:4px 12px" onclick="switchProviderMode(\'embedded\')">Switch to Local Model</button>';
+        } else {
+            document.getElementById('modelChatName').textContent = active.chat_model || 'none';
+            document.getElementById('modelEmbedName').textContent = active.embed_model || '(using chat model)';
+            if (active.loaded) {
+                document.getElementById('modelStatus').textContent = 'Loaded';
+                document.getElementById('modelStatus').style.color = 'var(--accent-green)';
+            } else {
+                document.getElementById('modelStatus').textContent = 'Not loaded';
+                document.getElementById('modelStatus').style.color = 'var(--accent-red)';
+            }
+            toggleEl.innerHTML = '<button class="agent-refresh-btn" style="padding:4px 12px" onclick="switchProviderMode(\'api\')">Switch to Gemini</button>';
+        }
+        document.getElementById('modelDir').textContent = active.models_dir || '-';
+
+        var models = data.models || [];
+        var tbody = document.getElementById('modelsTableBody');
+
+        if (models.length === 0) {
+            tbody.innerHTML = '<tr><td colspan="5" class="llm-empty">No models in models.json.</td></tr>';
+        } else {
+            tbody.innerHTML = models.map(function(m) {
+                var isChatActive = !isAPI && m.filename === active.chat_model;
+                var isEmbedActive = !isAPI && m.filename === active.embed_model;
+                var status = '';
+                if (isChatActive) status = '<span style="color:var(--accent-green);font-weight:bold">active</span>';
+                else if (isEmbedActive) status = '<span style="color:var(--accent-cyan);font-weight:bold">active</span>';
+                else if (isAPI) status = '<span style="color:var(--text-dim)">standby</span>';
+
+                var roleLabel = m.role || '-';
+                var detail = [m.quantize, m.version].filter(Boolean).join(' / ');
+
+                var actions = '';
+                if (!isAPI && m.role === 'chat' && !isChatActive) {
+                    actions += '<button class="agent-refresh-btn" style="font-size:0.7rem;padding:2px 8px" onclick="swapChatModel(\'' + escapeHtml(m.filename) + '\')">Load</button>';
+                }
+                if (!isAPI && m.role === 'embedding' && !isEmbedActive) {
+                    actions += '<button class="agent-refresh-btn" style="font-size:0.7rem;padding:2px 8px" onclick="swapEmbedModel(\'' + escapeHtml(m.filename) + '\')">Load</button>';
+                }
+                if (isChatActive || isEmbedActive) actions = '-';
+
+                return '<tr>' +
+                    '<td><strong>' + escapeHtml(m.filename) + '</strong>' + (detail ? '<br><span style="font-size:0.75rem;color:var(--text-dim)">' + escapeHtml(detail) + '</span>' : '') + '</td>' +
+                    '<td>' + roleLabel + '</td>' +
+                    '<td>' + m.size_mb + ' MB</td>' +
+                    '<td>' + status + '</td>' +
+                    '<td>' + actions + '</td>' +
+                    '</tr>';
+            }).join('');
+        }
+
+        document.getElementById('modelsUpdated').textContent = 'Updated ' + new Date().toLocaleTimeString();
+    } catch (e) {
+        document.getElementById('modelsTableBody').innerHTML = '<tr><td colspan="5" class="llm-empty">Error: ' + escapeHtml(e.message) + '</td></tr>';
+    }
+}
+
+export async function switchProviderMode(mode) {
+    var label = mode === 'api' ? 'Gemini (API)' : 'Embedded (local)';
+    appendSwapLog('Switching to ' + label + '...');
+    try {
+        var resp = await fetch('/api/v1/models/active', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ mode: mode })
+        });
+        var data = await resp.json();
+        if (!resp.ok) {
+            appendSwapLog('ERROR: ' + (data.error || 'unknown error'));
+            return;
+        }
+        appendSwapLog('Switched to ' + label);
+        loadModels();
+    } catch (e) {
+        appendSwapLog('ERROR: ' + e.message);
+    }
+}
+
+export async function swapChatModel(filename) {
+    appendSwapLog('Swapping chat model to ' + filename + '...');
+    try {
+        var resp = await fetch('/api/v1/models/active', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ chat_model: filename })
+        });
+        var data = await resp.json();
+        if (!resp.ok) {
+            appendSwapLog('ERROR: ' + (data.error || 'unknown error'));
+            return;
+        }
+        appendSwapLog('Chat model swapped to ' + filename);
+        loadModels();
+    } catch (e) {
+        appendSwapLog('ERROR: ' + e.message);
+    }
+}
+
+export async function swapEmbedModel(filename) {
+    appendSwapLog('Swapping embed model to ' + filename + '...');
+    try {
+        var resp = await fetch('/api/v1/models/active', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ embed_model: filename })
+        });
+        var data = await resp.json();
+        if (!resp.ok) {
+            appendSwapLog('ERROR: ' + (data.error || 'unknown error'));
+            return;
+        }
+        appendSwapLog('Embed model swapped to ' + filename);
+        loadModels();
+    } catch (e) {
+        appendSwapLog('ERROR: ' + e.message);
+    }
+}

--- a/internal/web/static/js/nav.js
+++ b/internal/web/static/js/nav.js
@@ -18,7 +18,7 @@ export function switchView(name) {
     if (tab) tab.classList.add('active');
     window.location.hash = name;
     // Update breadcrumbs
-    var crumbMap = { recall: 'Search', explore: 'Forum', timeline: 'Timeline', agent: 'SDK', llm: 'LLM Usage', tools: 'Tools' };
+    var crumbMap = { recall: 'Search', explore: 'Forum', timeline: 'Timeline', agent: 'SDK', llm: 'LLM Usage', tools: 'Tools', models: 'Models' };
     var bc = document.getElementById('breadcrumbs');
     if (bc && crumbMap[name]) bc.innerHTML = '<a href="#" onclick="switchView(\'explore\')">mnemonic</a><span class="sep"> › </span>' + crumbMap[name];
     if (name === 'explore') {
@@ -30,6 +30,7 @@ export function switchView(name) {
     if (name === 'agent' && !state.agentLoaded) window.loadAgentData();
     if (name === 'llm' && !state.llmLoaded) window.loadLLMUsage();
     if (name === 'tools' && !state.toolsLoaded) window.loadToolUsage();
+    if (name === 'models' && !state.modelsLoaded) window.loadModels();
 }
 
 export function switchExploreTab(tab) {
@@ -67,7 +68,7 @@ export function handleHash() {
         if (catId) window.loadForumCategory(catId, catId);
         return;
     }
-    if (['recall', 'explore', 'timeline', 'agent', 'llm', 'tools'].includes(hash)) switchView(hash);
+    if (['recall', 'explore', 'timeline', 'agent', 'llm', 'tools', 'models'].includes(hash)) switchView(hash);
 }
 window.addEventListener('hashchange', handleHash);
 
@@ -84,6 +85,7 @@ document.addEventListener('keydown', function(e) {
         case '4': switchView('agent'); break;
         case '5': switchView('llm'); break;
         case '6': switchView('tools'); break;
+        case '7': switchView('models'); break;
     }
 });
 

--- a/training/scripts/export_qwen35_spokes.py
+++ b/training/scripts/export_qwen35_spokes.py
@@ -154,6 +154,37 @@ def main():
         for layer_idx in norm_layers:
             spoke_tensors[f"blk.{layer_idx}.spoke.norm.weight"] = torch.ones(d_model, dtype=torch.float32)
 
+    # Build fused spoke matrices for fewer GPU kernel launches
+    # w_down_fused = cat([w_down[0], ..., w_down[n-1]], dim=0) -> (rank*n_spokes, d_model)
+    # w_up_fused   = cat([w_up[0],   ..., w_up[n-1]],   dim=1) -> (d_model, rank*n_spokes)
+    n_spokes = spoke_config.num_spokes
+    fused_count = 0
+    for layer_idx in sorted(norm_layers):
+        w_downs = []
+        w_ups = []
+        for s in range(n_spokes):
+            down_key = f"blk.{layer_idx}.spoke.w_down.{s}.weight"
+            up_key = f"blk.{layer_idx}.spoke.w_up.{s}.weight"
+            if down_key in spoke_tensors and up_key in spoke_tensors:
+                w_downs.append(spoke_tensors[down_key])
+                w_ups.append(spoke_tensors[up_key])
+
+        if len(w_downs) == n_spokes:
+            # w_down[s] shape: (rank, d_model) -> concat along dim 0 -> (rank*n_spokes, d_model)
+            w_down_fused = torch.cat(w_downs, dim=0)
+            # w_up[s] shape: (d_model, rank) -> concat along dim 1 -> (d_model, rank*n_spokes)
+            w_up_fused = torch.cat(w_ups, dim=1)
+            spoke_tensors[f"blk.{layer_idx}.spoke.w_down_fused.weight"] = w_down_fused
+            spoke_tensors[f"blk.{layer_idx}.spoke.w_up_fused.weight"] = w_up_fused
+            # Remove individual spoke tensors (fused replaces them)
+            for s in range(n_spokes):
+                spoke_tensors.pop(f"blk.{layer_idx}.spoke.w_down.{s}.weight", None)
+                spoke_tensors.pop(f"blk.{layer_idx}.spoke.w_up.{s}.weight", None)
+            fused_count += 1
+
+    if fused_count > 0:
+        print(f"  Created {fused_count} fused spoke matrix pairs (2 matmuls/layer instead of {2 * n_spokes})")
+
     print(f"  Prepared {len(spoke_tensors)} spoke tensors ({len(norm_layers)} layers)")
 
     # --- Phase 3: Copy base GGUF and patch with spokes ---

--- a/training/scripts/quantize_rq4.py
+++ b/training/scripts/quantize_rq4.py
@@ -171,9 +171,13 @@ def main():
         # Skip only norms, biases, embeddings, and individual (non-fused) spoke matrices.
         is_individual_spoke = ("spoke" in t.name and "fused" not in t.name
                                and ("w_down" in t.name or "w_up" in t.name))
+        # Inner dim (ne[0] in GGUF) must be >= QK_RQ4 to form valid blocks.
+        # Qwen 3.5 hybrid has ssm_conv1d with ne[0]=4 which can't be quantized.
+        inner_dim_ok = int(t.shape[0]) >= QK_RQ4
         should_quantize = (
             len(t.shape) == 2
             and t.n_elements >= args.min_elements
+            and inner_dim_ok
             and not any(p in t.name for p in skip_patterns)
             and not is_individual_spoke
         )


### PR DESCRIPTION
## Summary

- **Self-contained embedded inference**: mnemonic binary runs its own LLM via llama.cpp with ROCm GPU acceleration. No LM Studio, no external servers, no API dependencies required.
- **Model Control Center dashboard**: new Models tab with runtime model management — hot-swap GGUF models, toggle between embedded and Gemini API, view model status and swap logs.
- **SwitchableProvider**: wraps embedded + API providers with runtime toggle. Switching to API unloads models from VRAM; switching back reloads them.
- **ChatML compatibility**: fixed prompt formatting for Qwen 3.5 (was using Felix-LM format), added `/no_think` to disable reasoning tokens, `<think>` stripping, `<|im_end|>` stop sequences.
- **Qwen spoke fusion**: export script now fuses spoke matrices for fewer GPU kernel launches, RQ4 quantizer inner-dim fix for ssm_conv1d.

## Files Changed

| Area | Files | What |
|------|-------|------|
| Provider | `embedded.go`, `switchable.go`, `provider.go` | Hot-swap, Unload/Reload, manifest listing, SwitchableProvider, ModelManager interface |
| API | `routes/models.go`, `server.go` | GET/POST /api/v1/models, /api/v1/models/active |
| Dashboard | `models.js`, `index.html`, `nav.js`, `app.js` | Models tab, status cards, swap UI, provider toggle |
| Startup | `runtime.go`, `serve.go` | SwitchableProvider wiring, ModelManager injection |
| Training | `export_qwen35_spokes.py`, `quantize_rq4.py` | Spoke fusion, inner-dim quantization fix |

## Test plan

- [x] `go vet ./...` clean
- [x] `go test ./...` all pass
- [x] `golangci-lint run` zero issues in changed packages
- [x] API endpoints respond correctly (embedded and API modes)
- [x] Dashboard Models tab renders, swap buttons work
- [x] VRAM released on Gemini switch, reloaded on embedded switch
- [x] Dreaming/consolidation/abstraction agents produce content with ChatML fix
- [ ] Full lifecycle test with fused RQ4 spokes

🤖 Generated with [Claude Code](https://claude.com/claude-code)