### PR TITLE
feat: EXP-29 candidate model evaluation + faithful prompt

### DIFF
--- a/.claude/rules/llm-inference.md
+++ b/.claude/rules/llm-inference.md
@@ -1,0 +1,31 @@
+# LLM Inference — llama-server Usage
+
+## Chat Template Is Required
+
+All models need their chat template applied for instruction following. Use `/v1/chat/completions` (not `/completion`) for any model that hasn't been specifically trained on our raw prompt format (only Qwen + spokes qualifies).
+
+- **`/v1/chat/completions`** — applies model's native template. Use for all evaluations and new model testing.
+- **`/completion`** — raw text, no template. Only for production with spoke-trained models.
+
+## Thinking Mode
+
+Qwen 3.5 models default to thinking mode, which consumes the entire token budget on reasoning before producing output. Disable it for structured output tasks:
+
+```json
+{"chat_template_kwargs": {"enable_thinking": false}}
+```
+
+Test with thinking enabled as a separate condition — reasoning may improve faithfulness at the cost of latency.
+
+## Server Configuration
+
+- **`--parallel 1`** — use single slot for evaluation to avoid 500 errors on chat completions
+- **`--flash-attn on`** — requires explicit `on` value (bare flag fails)
+- **`--ctx-size 4096`** — sufficient for encoding (production prompts are ~700-1500 tokens)
+
+## Before Starting llama-server
+
+1. Stop the mnemonic daemon: `systemctl --user stop mnemonic`
+2. Kill any stale MCP processes: `pkill -f "mnemonic mcp"`
+3. Check VRAM: `rocm-smi --showmeminfo vram | grep Used`
+4. Baseline VRAM is ~800MB (compositor) + up to ~3.5GB (VS Code GPU). ~12GB usable.

--- a/.claude/rules/peer-review-standard.md
+++ b/.claude/rules/peer-review-standard.md
@@ -1,0 +1,29 @@
+# Peer Review Standard
+
+This project is under review by Aaron Gokaslan and Andrej Karpathy. All work must meet the standard of a published research project, not a hobby repo.
+
+## What This Means
+
+### Experiments
+- Every result must be reproducible from the registry entry alone — exact commands, configs, hardware, data paths
+- Report ALL metrics, not just the favorable ones
+- Look at actual model outputs, not just aggregate numbers — open random examples and read them
+- Statistical claims require sufficient sample sizes and confidence intervals
+- Negative results get the same documentation quality as positive results
+
+### Code
+- Scripts must be self-documenting — clear argument parsing, docstrings, usage examples
+- No dead code, no commented-out experiments, no "TODO: clean up later"
+- Training pipelines must run end-to-end from a clean checkout
+- Evaluation scripts must produce deterministic results given the same inputs
+
+### Documentation
+- The experiment registry tells the complete story of every experiment
+- Design documents explain the reasoning, not just the implementation
+- Every architectural decision has a recorded rationale
+
+### Claims
+- "The model doesn't hallucinate" requires evidence, not assertion
+- "X is better than Y" requires controlled comparison on matched conditions
+- Fabrication rate of 10% is not "low" — it means 1 in 10 memories is corrupted
+- 25 test inputs is a pilot, not a proof — acknowledge sample size limitations

--- a/docs/DESIGN_continuous_learning.md
+++ b/docs/DESIGN_continuous_learning.md
@@ -1,0 +1,506 @@
+# Continuous Learning for Mnemonic's Encoding Model
+
+## Design Document — April 2026
+
+### Authors
+Caleb Gross, Claude (AI Research Partner)
+
+---
+
+## 1. Vision
+
+Mnemonic's encoding model should improve from operational experience. Every
+encoding it produces, every recall that succeeds or fails, every feedback
+signal from the user — all of this is training data that currently gets
+discarded. The model that encodes memory #10,000 should be measurably better
+than the one that encoded memory #1.
+
+This isn't fine-tuning on a static dataset. It's a closed-loop system where
+the model's output quality directly determines its future training signal.
+Good encodings lead to good recalls, which generate positive feedback, which
+reinforces the encoding behavior. Bad encodings lead to poor recalls, negative
+feedback, and corrective training. The system converges toward its own
+definition of quality.
+
+### Why This Is Feasible Now
+
+1. **Small model + small adapters**: 2-4B base with 25-33M trainable spoke
+   params. Fine-tuning takes minutes, not days.
+2. **Local hardware is sufficient**: RX 7800 XT can train LoRA/spokes on
+   50-100 examples in ~10 minutes.
+3. **The feedback loop already exists**: `feedback` MCP tool, salience decay,
+   metacognition agent, verification module (designed in this session).
+4. **Spoke architecture enables hot-swap**: Update adapters without touching
+   the frozen base. Deploy new spokes atomically with rollback.
+5. **The dreaming agent provides a training window**: Off-hours (2am-6am)
+   when the daemon is idle from user interaction.
+
+---
+
+## 2. Architecture Overview
+
+```
+┌─────────────────────────────────────────────────────────────┐
+│                    OPERATIONAL LOOP                          │
+│                                                             │
+│  Raw Input → Encoding Model → Memory → Retrieval → Recall  │
+│                  │                          │               │
+│                  ▼                          ▼               │
+│        Verification Gate            Feedback Signal         │
+│         (EPR, FR, TE)            (helpful/partial/irrel)    │
+│                  │                          │               │
+│                  └──────────┬───────────────┘               │
+│                             ▼                               │
+│                    Experience Buffer                        │
+│                   (gold + bad pairs)                        │
+│                             │                               │
+└─────────────────────────────┼───────────────────────────────┘
+                              │
+┌─────────────────────────────┼───────────────────────────────┐
+│                    LEARNING LOOP                            │
+│                    (dreaming hours)                          │
+│                             ▼                               │
+│                   Curriculum Generator                      │
+│                  (Gemini re-encodes bad)                    │
+│                             │                               │
+│                             ▼                               │
+│                    Training Pipeline                        │
+│                  (spoke fine-tuning)                        │
+│                             │                               │
+│                             ▼                               │
+│                    Quality Gate                             │
+│                 (EXP-25 probe eval)                         │
+│                             │                               │
+│                    ┌────────┴────────┐                      │
+│                    ▼                 ▼                       │
+│              Deploy New         Discard                     │
+│              Spokes             (rollback)                  │
+│                                                             │
+└─────────────────────────────────────────────────────────────┘
+```
+
+---
+
+## 3. Tier 1 — Experience Collection
+
+**Runs continuously during normal operation. Zero LLM cost.**
+
+### 3.1 Encoding Quality Scoring
+
+Every encoding produced by the daemon gets scored by the verification gate
+(the runtime module designed in EXP-29). This is pure string matching — no
+LLM call needed.
+
+**Metrics computed per encoding:**
+- **EPR (Entity Preservation Rate)**: % of input entities found in output
+- **FR (Fabrication Rate)**: % of output entities NOT in input
+- **TE (Template Echo)**: boolean — did instruction text leak into content?
+- **MIG (Minimal Input Guard)**: for short inputs, did the model pad?
+
+**Storage:** New fields on the `memories` table:
+
+```sql
+ALTER TABLE memories ADD COLUMN encoding_epr REAL DEFAULT NULL;
+ALTER TABLE memories ADD COLUMN encoding_fr REAL DEFAULT NULL;
+ALTER TABLE memories ADD COLUMN encoding_flags TEXT DEFAULT NULL;
+-- flags: JSON array of issues, e.g. ["template_echo", "fabrication:EntityName"]
+```
+
+### 3.2 Downstream Quality Tracking
+
+When a memory is recalled and the user provides feedback, link it back:
+
+```sql
+CREATE TABLE recall_feedback (
+    id TEXT PRIMARY KEY,
+    query TEXT NOT NULL,
+    memory_id TEXT NOT NULL,
+    quality TEXT NOT NULL,  -- helpful, partial, irrelevant
+    timestamp DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (memory_id) REFERENCES memories(id)
+);
+```
+
+Over time, each memory accumulates a recall history:
+- Memories that are frequently recalled as `helpful` = high-quality encodings
+- Memories that are recalled as `irrelevant` = potentially bad encodings
+- Memories that are NEVER recalled = may be poorly encoded (bad concepts/embedding)
+
+### 3.3 Experience Buffer
+
+A curated collection of training candidates:
+
+```sql
+CREATE TABLE experience_buffer (
+    id TEXT PRIMARY KEY,
+    raw_id TEXT NOT NULL,          -- original raw memory
+    memory_id TEXT NOT NULL,        -- resulting encoded memory
+    encoding_epr REAL,
+    encoding_fr REAL,
+    recall_score REAL,             -- aggregated feedback score
+    category TEXT,                  -- gold, needs_improvement, ambiguous
+    corrected_output TEXT,          -- Gemini re-encoding (filled by Tier 2)
+    used_in_training BOOLEAN DEFAULT FALSE,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+);
+```
+
+**Classification rules:**
+- **Gold**: EPR > 0.9, FR < 0.05, recall_score > 0.8 (mostly `helpful` feedback)
+- **Needs improvement**: EPR < 0.7 OR FR > 0.15 OR recall_score < 0.3
+- **Ambiguous**: everything else (not enough signal yet)
+
+### 3.4 Salience Feedback Loop
+
+Currently, salience is set by the encoding model and decays over time. With
+continuous learning, we can close the loop:
+
+- If a memory is recalled as `helpful` → boost salience by 0.05
+- If recalled as `irrelevant` → reduce salience by 0.1
+- If never recalled after 30 days → reduce salience by 0.05
+
+This already partially exists (the feedback tool adjusts association strengths).
+Extending it to salience makes the retrieval system self-correcting.
+
+---
+
+## 4. Tier 2 — Curriculum Generation
+
+**Runs during dreaming hours (2am-6am). Requires Gemini API.**
+
+### 4.1 Corrective Re-Encoding
+
+For each "needs improvement" entry in the experience buffer:
+
+1. Take the original raw input
+2. Send to Gemini API with the production encoding prompt
+3. Run the faithfulness verification on Gemini's output
+4. If Gemini's output passes verification → store as `corrected_output`
+5. If Gemini also fails → discard (the input may be genuinely ambiguous)
+
+This produces DPO-ready pairs: (input, rejected=local_output, chosen=gemini_output).
+
+**Rate limiting:** Gemini API has quotas. At ~100 corrections/night with
+gemini-3-flash-preview, cost is negligible (free tier or < $0.01/night).
+
+### 4.2 Hard Example Mining
+
+Some inputs are harder than others. The experience buffer reveals which:
+
+- **Consistently low EPR**: Dense numbers, multi-entity inputs, bilingual text
+- **Consistently high FR**: Short inputs (model pads), domain-specific jargon
+- **Recall-score outliers**: Encodings that look OK by metrics but fail in practice
+
+The curriculum generator prioritizes these hard examples for retraining.
+This is active learning — the model focuses training compute on its weakest
+areas, not random sampling.
+
+### 4.3 Synthetic Augmentation
+
+For specific failure patterns, generate targeted training data:
+
+- If number preservation is weak → generate 20 dense-number inputs, encode
+  with Gemini, add to training set
+- If a new domain appears (user starts working on a new project) → generate
+  domain-specific examples to prevent initial quality drop
+
+This uses the same `generate_v7_inputs.py` pipeline already built for EXP-26.
+
+---
+
+## 5. Tier 3 — Model Update
+
+**Triggered when experience buffer has ≥50 new training pairs.**
+
+### 5.1 Training Configuration
+
+```yaml
+# Continuous learning config (addition to config.yaml)
+continuous_learning:
+  enabled: false                  # opt-in
+  min_examples: 50                # minimum new pairs before training
+  max_examples_per_run: 200       # cap to prevent long training
+  replay_ratio: 0.3               # 30% of batch is replay from v7 base
+  eval_probes: "training/data/faithfulness_probe/gold_train.jsonl"
+  quality_threshold:
+    min_epr: 0.90                 # new model must meet these
+    max_fr: 0.05
+    min_sc: 0.95
+  rollback_on_failure: true
+  training_window: "02:00-06:00"  # only train during dreaming hours
+  hardware:
+    device: "auto"                # uses available GPU
+    batch_size: 1
+    grad_accum: 8
+    lr: 1e-4                      # conservative for incremental updates
+    max_steps: 500                # short runs
+```
+
+### 5.2 Training Mix
+
+Each training batch is composed of:
+- **30% replay** from the v7 base dataset (prevents catastrophic forgetting)
+- **50% new gold examples** from the experience buffer
+- **20% corrective pairs** (DPO: bad local → good Gemini)
+
+The replay buffer ensures the model doesn't forget general encoding ability
+while specializing on the user's specific patterns.
+
+### 5.3 Training Methods
+
+**Option A: Supervised Fine-Tuning (SFT)**
+- Standard approach: train on (input, correct_output) pairs
+- Uses existing spoke training pipeline (`train_qwen_spokes.py`)
+- Proven to work (EXP-18, EXP-25 confirmed the architecture learns)
+
+**Option B: Direct Preference Optimization (DPO)**
+- Train on (input, chosen_output, rejected_output) triples
+- The model learns to prefer Gemini-quality output over its own bad output
+- More nuanced than SFT — teaches what NOT to do, not just what to do
+- Requires implementing DPO loss (straightforward with existing training infra)
+
+**Option C: Hybrid SFT + DPO**
+- SFT on gold examples (learn from success)
+- DPO on corrective pairs (learn from failure)
+- Best of both worlds, slightly more complex
+
+**Recommendation:** Start with Option A (SFT only). It's proven, simple,
+and the spoke infrastructure already supports it. Add DPO as a second phase
+once the pipeline is validated.
+
+### 5.4 Evaluation Gate
+
+After training, the new spokes MUST pass the quality gate:
+
+1. Run EXP-25 probe inputs (25 gold-standard test cases)
+2. Run eval_faithfulness.py — all 7 metrics
+3. **Pass criteria:**
+   - EPR ≥ 90% (entity preservation)
+   - FR ≤ 5% (fabrication rate)
+   - SC ≥ 95% (schema compliance)
+   - Stress test: 7/7
+   - No metric degrades by >5pp from current model
+4. If pass → deploy
+5. If fail → discard, log the failure, keep current model
+
+### 5.5 Deployment
+
+Spoke deployment is atomic:
+1. Export new spokes to GGUF via `export_qwen35_spokes.py`
+2. Quantize via `rotorq_quantize_gguf.py` (BetaQ RQ4)
+3. Place in models directory with version suffix
+4. Update `config.yaml` to point to new GGUF
+5. Restart daemon (or use hot-swap API if implemented)
+
+**Rollback:** Keep the previous 3 model versions. If quality degrades in
+production (detected by Tier 1 scoring), revert to the last known-good model.
+
+---
+
+## 6. Tier 4 — Self-Assessment (Metacognition)
+
+**The metacognition agent monitors the system's own learning.**
+
+### 6.1 Quality Drift Detection
+
+Track rolling averages of encoding quality metrics:
+
+```go
+type QualityWindow struct {
+    WindowSize int           // e.g., last 100 encodings
+    EPRHistory []float64
+    FRHistory  []float64
+    AvgEPR     float64
+    AvgFR      float64
+    Trend      string        // improving, stable, degrading
+}
+```
+
+When the trend shifts to "degrading" → trigger training or alert.
+
+### 6.2 Domain Shift Detection
+
+Track the concept distribution of incoming raw memories. If new concepts
+appear that weren't in the training data (user starts a new project,
+new tech stack), flag it:
+
+- New concept frequency > 5% of recent memories
+- EPR for memories with new concepts < average EPR
+- → Trigger synthetic data generation for the new domain
+
+### 6.3 Training Budget Management
+
+Not every quality dip requires retraining. The metacognition agent decides:
+
+- **Is this a transient dip?** (e.g., unusual input, one-off error) → wait
+- **Is this a systematic trend?** (e.g., 10+ consecutive low-EPR) → train
+- **Is the experience buffer large enough?** (≥50 pairs) → train
+- **Is it within the training window?** (2am-6am) → proceed
+- **Was the last training successful?** If the last 2 attempts failed → escalate to user
+
+---
+
+## 7. The Feedback Signal — Why This Is Special
+
+Most ML training uses static labels. Mnemonic's continuous learning uses
+a **delayed, downstream quality signal** — and that's what makes it powerful.
+
+### 7.1 The Signal Chain
+
+```
+Encoding happens → Memory stored → Days pass → Memory recalled →
+User rates recall → Signal flows back to encoding
+```
+
+The encoding of "fixed null pointer in auth middleware" might not be evaluated
+until two weeks later when someone recalls "auth bugs we've fixed." At that
+point, the `helpful` or `irrelevant` rating tells us whether the encoding
+captured the right information for future retrieval.
+
+This is fundamentally different from evaluating the encoding's format or
+entity preservation at write time. Format compliance is necessary but not
+sufficient. The real question is: **does this encoding make the memory
+findable and useful when it matters?**
+
+### 7.2 Reward Decomposition
+
+The recall feedback signal is a composite of:
+1. **Encoding quality** — did the encoding capture the right information?
+2. **Embedding quality** — is the memory findable by semantic search?
+3. **Retrieval quality** — did spread activation surface the right memories?
+4. **Synthesis quality** — was the recall response well-composed?
+
+We need to decompose this. A memory can have perfect encoding but be
+unreachable due to a bad embedding, or vice versa.
+
+**Decomposition strategy:**
+- EPR/FR at write time → measures encoding quality directly
+- Recall frequency → measures findability (embedding + retrieval)
+- Feedback rating → measures end-to-end usefulness
+- If a memory has high EPR but low recall → embedding problem
+- If a memory has high recall but `irrelevant` feedback → encoding problem
+  (it's findable but the content isn't useful)
+
+### 7.3 Cold Start and Bootstrapping
+
+New users (or new projects) have no feedback history. The system bootstraps
+from:
+1. **Verification scores** — EPR/FR computed at write time (immediate signal)
+2. **Gemini baseline** — compare local encoding against Gemini re-encoding
+3. **Synthetic probes** — periodically inject known-good test inputs and
+   verify the model handles them correctly
+
+As feedback accumulates, the signal becomes richer and more reliable.
+
+---
+
+## 8. Implementation Roadmap
+
+### Phase 1: Experience Collection (2-3 days)
+- Add encoding quality columns to memories table (migration)
+- Integrate verification gate into encoding pipeline
+- Create experience_buffer table
+- Start collecting EPR/FR scores on all new encodings
+- No model changes — pure observation
+
+### Phase 2: Recall-Encoding Linkage (1-2 days)
+- Create recall_feedback table
+- Modify retrieval agent to record which memories are recalled
+- Modify feedback processing to update recall_feedback
+- Aggregate feedback scores on experience_buffer entries
+
+### Phase 3: Curriculum Generation (2-3 days)
+- Add curriculum generation phase to dreaming agent
+- Implement Gemini re-encoding for "needs improvement" entries
+- Build the training data assembly pipeline
+- Test on existing bad encodings from before the #383 fix
+
+### Phase 4: Automated Training (3-5 days)
+- Integrate spoke training into the daemon (or as a triggered subprocess)
+- Implement the quality gate (EXP-25 probes as automated eval)
+- Implement atomic deployment with rollback
+- Add continuous_learning config section
+- Manual trigger first, automated trigger later
+
+### Phase 5: Metacognition Integration (2-3 days)
+- Add QualityWindow tracking to metacognition agent
+- Implement domain shift detection
+- Implement training budget management
+- Wire it all together: metacognition triggers training when needed
+
+### Phase 6: DPO (stretch goal)
+- Implement DPO loss in training script
+- Generate preference pairs from experience buffer
+- A/B test SFT vs DPO on quality improvement rate
+
+**Total estimated effort: 2-3 weeks**
+
+---
+
+## 9. Risks and Mitigations
+
+| Risk | Impact | Mitigation |
+|------|--------|------------|
+| Catastrophic forgetting | Model loses general ability after specializing | 30% replay ratio from base dataset |
+| Feedback noise | Inaccurate feedback corrupts training signal | Require ≥3 feedback events per memory before using as training signal |
+| Gemini unavailability | Can't generate corrections if API is down | Buffer corrections; train only when enough pairs exist; fall back to verification-only scoring |
+| Quality oscillation | Model improves then degrades in alternating cycles | Quality gate prevents deployment of worse models; monotonic improvement enforced |
+| VRAM contention | Training during dreaming conflicts with other GPU tasks | Training window is configurable; skip if GPU is busy |
+| Slow convergence | 50-100 examples per cycle may not be enough | Tune min_examples threshold; allow manual "force train" |
+| Privacy / data leakage | Raw memories contain sensitive content | All training is local, air-gapped; no data leaves the machine |
+
+---
+
+## 10. Success Metrics
+
+### Short-term (1 month after enabling)
+- Experience buffer has ≥500 entries
+- At least 2 successful training cycles completed
+- Encoding EPR improved by ≥5pp over baseline
+
+### Medium-term (3 months)
+- At least 10 successful training cycles
+- Model handles new project domains without quality drop
+- Recall `helpful` rate improved by ≥10pp
+
+### Long-term (6+ months)
+- The model has adapted to the user's specific patterns and vocabulary
+- Encoding quality on user's actual inputs exceeds Gemini baseline
+- The system is genuinely self-improving — quality trends upward over months
+- Mnemonic's model IS the user's model — shaped by their work, their decisions,
+  their feedback
+
+---
+
+## 11. Relationship to Other Work
+
+- **EXP-29 (this session)**: Selects the base model for continuous learning
+- **EXP-26 (v7 data)**: Provides the initial training baseline and replay buffer
+- **Felix-LM spokes**: The adapter architecture that makes hot-swap possible
+- **#381 (faithfulness)**: The verification framework used for quality scoring
+- **Dreaming agent**: The execution environment for Tier 2 and 3
+- **Metacognition agent**: The decision-maker for Tier 4
+- **GBNF grammar**: Structural constraint that works alongside learning
+- **Project Bespoke (#386)**: If pruning produces a better base model, the
+  continuous learning pipeline runs on top of it — they're complementary
+
+---
+
+## 12. Why This Matters
+
+Every AI assistant today starts from zero. Every conversation is a blank
+slate. Mnemonic was built to solve this — to give AI systems persistent
+memory. But the encoding model, the heart of the system, has been static.
+It was trained once and deployed. It doesn't learn from the thousands of
+memories it encodes.
+
+Continuous learning closes this loop. The model that encodes your 10,000th
+memory has learned from the 9,999 before it. It knows your vocabulary, your
+project structure, your communication patterns. It knows that when you say
+"the thing with the auth middleware" you mean the null pointer fix from
+March, not the session token compliance issue from February. It knows
+because it encoded both, saw how they were recalled, and learned what made
+one recall useful and the other not.
+
+This is what it means for a daemon to have its own brain. Not a frozen
+snapshot of someone else's model. A living system that grows with its user.

--- a/docs/PLAN_continuous_learning_phase_a.md
+++ b/docs/PLAN_continuous_learning_phase_a.md
@@ -1,0 +1,1396 @@
+# Phase A: Runtime Verification & Experience Collection — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add runtime encoding verification (EPR, TED, FR, MIG) to the encoding pipeline, persist quality metrics, collect experience buffer entries, link recall feedback to encodings, and detect quality drift in metacognition.
+
+**Architecture:** Go port of eval_faithfulness.py's entity extraction and verification checks, inserted between compression and embedding in the encoding pipeline. New `experience_buffer` and `recall_feedback` tables. Metacognition extended with rolling quality window.
+
+**Tech Stack:** Go 1.22+, SQLite (modernc.org/sqlite), regexp, slog
+
+**Spec:** `docs/SPEC_continuous_learning.md` Section 2
+
+---
+
+## File Map
+
+| Action | File | Responsibility |
+|--------|------|----------------|
+| Create | `internal/agent/encoding/verification.go` | Entity extraction, EPR/FR/TED/MIG checks |
+| Create | `internal/agent/encoding/verification_test.go` | Unit tests + parity test vs Python |
+| Create | `migrations/007_continuous_learning.sql` | New tables + columns |
+| Modify | `internal/store/store.go:580-608` | Add `ContinuousLearningStore` interface |
+| Modify | `internal/store/sqlite/sqlite.go` | Implement new store methods |
+| Modify | `internal/store/sqlite/schema.go:13` | Bump SchemaVersion to 16 |
+| Create | `internal/store/sqlite/continuous_learning.go` | SQL implementations for experience buffer, recall_feedback |
+| Modify | `internal/agent/encoding/agent.go:1046-1048` | Insert verification gate call |
+| Modify | `internal/mcp/server.go:2003` | Hook feedback into experience buffer |
+| Modify | `internal/agent/metacognition/agent.go:189` | Add quality drift observation |
+| Modify | `internal/agent/dreaming/agent.go:177-179` | Add reclassification phase |
+| Modify | `internal/config/config.go:18-42` | Add ContinuousLearningConfig |
+| Modify | `config.yaml` | Add continuous_learning section |
+
+---
+
+### Task 1: Schema Migration
+
+**Files:**
+- Create: `migrations/007_continuous_learning.sql`
+- Modify: `internal/store/sqlite/schema.go:13`
+
+- [ ] **Step 1: Create migration file**
+
+Create `migrations/007_continuous_learning.sql`:
+
+```sql
+-- Verification metrics on memories table
+ALTER TABLE memories ADD COLUMN encoding_epr REAL DEFAULT NULL;
+ALTER TABLE memories ADD COLUMN encoding_fr REAL DEFAULT NULL;
+ALTER TABLE memories ADD COLUMN encoding_flags TEXT DEFAULT NULL;
+
+-- Recall-encoding linkage: tracks which memories were recalled and rated
+CREATE TABLE IF NOT EXISTS recall_feedback (
+    id TEXT PRIMARY KEY,
+    query TEXT NOT NULL,
+    memory_id TEXT NOT NULL,
+    feedback TEXT NOT NULL,
+    recall_session_id TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (memory_id) REFERENCES memories(id)
+);
+CREATE INDEX IF NOT EXISTS idx_recall_feedback_memory ON recall_feedback(memory_id);
+CREATE INDEX IF NOT EXISTS idx_recall_feedback_session ON recall_feedback(recall_session_id);
+
+-- Experience buffer: curated training candidates with quality metrics
+CREATE TABLE IF NOT EXISTS experience_buffer (
+    id TEXT PRIMARY KEY,
+    raw_id TEXT NOT NULL,
+    memory_id TEXT NOT NULL,
+    encoding_epr REAL,
+    encoding_fr REAL,
+    encoding_flags TEXT,
+    recall_score REAL,
+    recall_count INTEGER DEFAULT 0,
+    category TEXT DEFAULT 'ambiguous',
+    used_in_training INTEGER DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (memory_id) REFERENCES memories(id)
+);
+CREATE INDEX IF NOT EXISTS idx_experience_buffer_category ON experience_buffer(category);
+CREATE INDEX IF NOT EXISTS idx_experience_buffer_memory ON experience_buffer(memory_id);
+```
+
+- [ ] **Step 2: Bump schema version**
+
+In `internal/store/sqlite/schema.go`, change:
+
+```go
+const SchemaVersion = 15
+```
+
+to:
+
+```go
+const SchemaVersion = 16
+```
+
+- [ ] **Step 3: Verify migration applies**
+
+Run: `make build && ./bin/mnemonic version`
+
+The daemon will apply migration 007 on next startup. For now just verify it compiles.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add migrations/007_continuous_learning.sql internal/store/sqlite/schema.go
+git commit -m "feat: schema migration for continuous learning (#391)
+
+Add encoding_epr/fr/flags columns to memories, create recall_feedback
+and experience_buffer tables for Phase A experience collection."
+```
+
+---
+
+### Task 2: Store Interface — ContinuousLearningStore
+
+**Files:**
+- Modify: `internal/store/store.go`
+
+- [ ] **Step 1: Add types for experience buffer and recall feedback**
+
+Add after the existing type definitions (before the Store interface at line 585):
+
+```go
+// ExperienceEntry represents a training candidate in the experience buffer.
+type ExperienceEntry struct {
+	ID            string    `json:"id"`
+	RawID         string    `json:"raw_id"`
+	MemoryID      string    `json:"memory_id"`
+	EncodingEPR   float64   `json:"encoding_epr"`
+	EncodingFR    float64   `json:"encoding_fr"`
+	EncodingFlags []string  `json:"encoding_flags"`
+	RecallScore   float64   `json:"recall_score"`
+	RecallCount   int       `json:"recall_count"`
+	Category      string    `json:"category"` // gold, needs_improvement, ambiguous
+	UsedInTraining bool     `json:"used_in_training"`
+	CreatedAt     time.Time `json:"created_at"`
+	UpdatedAt     time.Time `json:"updated_at"`
+}
+
+// ExperienceStats summarizes the experience buffer contents.
+type ExperienceStats struct {
+	Gold             int `json:"gold"`
+	NeedsImprovement int `json:"needs_improvement"`
+	Ambiguous        int `json:"ambiguous"`
+	Total            int `json:"total"`
+}
+
+// RecallFeedbackEntry links a recall query to a specific memory's feedback rating.
+type RecallFeedbackEntry struct {
+	ID              string    `json:"id"`
+	Query           string    `json:"query"`
+	MemoryID        string    `json:"memory_id"`
+	Feedback        string    `json:"feedback"` // helpful, partial, irrelevant
+	RecallSessionID string    `json:"recall_session_id"`
+	CreatedAt       time.Time `json:"created_at"`
+}
+
+// EncodingQualityWindow holds rolling quality metrics for drift detection.
+type EncodingQualityWindow struct {
+	WindowSize  int     `json:"window_size"`
+	MeanEPR     float64 `json:"mean_epr"`
+	TEDRate     float64 `json:"ted_rate"`
+	FlaggedRate float64 `json:"flagged_rate"`
+	SampleCount int     `json:"sample_count"`
+}
+```
+
+- [ ] **Step 2: Add the ContinuousLearningStore interface**
+
+Add before the main Store interface (before line 585):
+
+```go
+// ContinuousLearningStore manages experience collection for continuous learning.
+type ContinuousLearningStore interface {
+	// Verification results (written during encoding)
+	WriteVerificationResult(ctx context.Context, memoryID string, epr float64, fr float64, flags []string) error
+
+	// Experience buffer
+	WriteExperienceEntry(ctx context.Context, entry ExperienceEntry) error
+	UpdateExperienceRecallScore(ctx context.Context, memoryID string, feedback string) error
+	ReclassifyExperienceBuffer(ctx context.Context) (int, error)
+	ListExperienceByCategory(ctx context.Context, category string, limit int) ([]ExperienceEntry, error)
+	GetExperienceBufferStats(ctx context.Context) (ExperienceStats, error)
+
+	// Recall-encoding linkage
+	WriteRecallFeedbackEntry(ctx context.Context, entry RecallFeedbackEntry) error
+	GetRecallHistory(ctx context.Context, memoryID string) ([]RecallFeedbackEntry, error)
+
+	// Quality drift detection
+	GetEncodingQualityWindow(ctx context.Context, windowSize int) (EncodingQualityWindow, error)
+}
+```
+
+- [ ] **Step 3: Embed in the main Store interface**
+
+Add `ContinuousLearningStore` to the Store interface at line 604:
+
+```go
+type Store interface {
+	RawMemoryStore
+	MemoryStore
+	SearchStore
+	AssociationStore
+	ConceptStore
+	EpisodeStore
+	PatternStore
+	AbstractionStore
+	MetacognitionStore
+	FeedbackStore
+	ConsolidationStore
+	SessionStore
+	ExclusionStore
+	UsageStore
+	ForumStore
+	AnalyticsStore
+	ContinuousLearningStore
+
+	// --- Lifecycle ---
+	Close() error
+}
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `make build`
+
+Expected: Compilation fails because sqlite.go doesn't implement ContinuousLearningStore yet. That's correct — Task 3 fixes it.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/store/store.go
+git commit -m "feat: store interface for continuous learning (#391)
+
+Add ContinuousLearningStore interface with types for ExperienceEntry,
+ExperienceStats, RecallFeedbackEntry, and EncodingQualityWindow."
+```
+
+---
+
+### Task 3: SQLite Implementation — ContinuousLearningStore
+
+**Files:**
+- Create: `internal/store/sqlite/continuous_learning.go`
+
+- [ ] **Step 1: Implement WriteVerificationResult**
+
+Create `internal/store/sqlite/continuous_learning.go`:
+
+```go
+package sqlite
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/appsprout-dev/mnemonic/internal/store"
+	"github.com/google/uuid"
+)
+
+func (s *SQLiteStore) WriteVerificationResult(ctx context.Context, memoryID string, epr float64, fr float64, flags []string) error {
+	flagsJSON, err := json.Marshal(flags)
+	if err != nil {
+		return fmt.Errorf("marshaling flags: %w", err)
+	}
+
+	_, err = s.db.ExecContext(ctx,
+		`UPDATE memories SET encoding_epr = ?, encoding_fr = ?, encoding_flags = ? WHERE id = ?`,
+		epr, fr, string(flagsJSON), memoryID,
+	)
+	if err != nil {
+		return fmt.Errorf("writing verification result for %s: %w", memoryID, err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 2: Implement WriteExperienceEntry**
+
+Append to the same file:
+
+```go
+func (s *SQLiteStore) WriteExperienceEntry(ctx context.Context, entry store.ExperienceEntry) error {
+	flagsJSON, err := json.Marshal(entry.EncodingFlags)
+	if err != nil {
+		return fmt.Errorf("marshaling encoding flags: %w", err)
+	}
+
+	if entry.ID == "" {
+		entry.ID = uuid.New().String()
+	}
+	now := time.Now()
+
+	_, err = s.db.ExecContext(ctx,
+		`INSERT INTO experience_buffer (id, raw_id, memory_id, encoding_epr, encoding_fr, encoding_flags, recall_score, recall_count, category, used_in_training, created_at, updated_at)
+		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		entry.ID, entry.RawID, entry.MemoryID,
+		entry.EncodingEPR, entry.EncodingFR, string(flagsJSON),
+		entry.RecallScore, entry.RecallCount, entry.Category,
+		entry.UsedInTraining, now, now,
+	)
+	if err != nil {
+		return fmt.Errorf("writing experience entry for memory %s: %w", entry.MemoryID, err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 3: Implement UpdateExperienceRecallScore**
+
+```go
+func (s *SQLiteStore) UpdateExperienceRecallScore(ctx context.Context, memoryID string, feedback string) error {
+	var rating float64
+	switch feedback {
+	case "helpful":
+		rating = 1.0
+	case "partial":
+		rating = 0.5
+	case "irrelevant":
+		rating = 0.0
+	default:
+		return fmt.Errorf("invalid feedback rating: %s", feedback)
+	}
+
+	// Running weighted average: new = (old * count + rating) / (count + 1)
+	_, err := s.db.ExecContext(ctx,
+		`UPDATE experience_buffer
+		 SET recall_score = CASE
+		     WHEN recall_count = 0 THEN ?
+		     ELSE (recall_score * recall_count + ?) / (recall_count + 1)
+		 END,
+		 recall_count = recall_count + 1,
+		 updated_at = CURRENT_TIMESTAMP
+		 WHERE memory_id = ?`,
+		rating, rating, memoryID,
+	)
+	if err != nil {
+		return fmt.Errorf("updating recall score for memory %s: %w", memoryID, err)
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Implement ReclassifyExperienceBuffer**
+
+```go
+func (s *SQLiteStore) ReclassifyExperienceBuffer(ctx context.Context) (int, error) {
+	// Gold: EPR > 0.9 AND no TED AND (recall_score > 0.8 OR (no recalls AND no flags))
+	res1, err := s.db.ExecContext(ctx,
+		`UPDATE experience_buffer SET category = 'gold', updated_at = CURRENT_TIMESTAMP
+		 WHERE encoding_epr > 0.9
+		   AND (encoding_flags IS NULL OR encoding_flags = '[]' OR encoding_flags NOT LIKE '%template_echo%')
+		   AND (
+		       (recall_score > 0.8)
+		       OR (recall_count = 0 AND (encoding_flags IS NULL OR encoding_flags = '[]'))
+		   )
+		   AND category != 'gold'`)
+	if err != nil {
+		return 0, fmt.Errorf("reclassifying gold: %w", err)
+	}
+	gold, _ := res1.RowsAffected()
+
+	// Needs improvement: EPR < 0.7 OR TED OR (recall_score < 0.3 AND recall_count >= 3)
+	res2, err := s.db.ExecContext(ctx,
+		`UPDATE experience_buffer SET category = 'needs_improvement', updated_at = CURRENT_TIMESTAMP
+		 WHERE (
+		     encoding_epr < 0.7
+		     OR (encoding_flags IS NOT NULL AND encoding_flags LIKE '%template_echo%')
+		     OR (recall_score < 0.3 AND recall_count >= 3)
+		 )
+		 AND category != 'needs_improvement'`)
+	if err != nil {
+		return 0, fmt.Errorf("reclassifying needs_improvement: %w", err)
+	}
+	needs, _ := res2.RowsAffected()
+
+	return int(gold + needs), nil
+}
+```
+
+- [ ] **Step 5: Implement remaining methods**
+
+```go
+func (s *SQLiteStore) ListExperienceByCategory(ctx context.Context, category string, limit int) ([]store.ExperienceEntry, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, raw_id, memory_id, encoding_epr, encoding_fr, encoding_flags,
+		        recall_score, recall_count, category, used_in_training, created_at, updated_at
+		 FROM experience_buffer WHERE category = ? ORDER BY created_at DESC LIMIT ?`,
+		category, limit,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("listing experience by category %s: %w", category, err)
+	}
+	defer rows.Close()
+
+	var entries []store.ExperienceEntry
+	for rows.Next() {
+		var e store.ExperienceEntry
+		var flagsJSON string
+		var usedInt int
+		if err := rows.Scan(&e.ID, &e.RawID, &e.MemoryID, &e.EncodingEPR, &e.EncodingFR, &flagsJSON,
+			&e.RecallScore, &e.RecallCount, &e.Category, &usedInt, &e.CreatedAt, &e.UpdatedAt); err != nil {
+			return nil, fmt.Errorf("scanning experience entry: %w", err)
+		}
+		_ = json.Unmarshal([]byte(flagsJSON), &e.EncodingFlags)
+		e.UsedInTraining = usedInt != 0
+		entries = append(entries, e)
+	}
+	return entries, rows.Err()
+}
+
+func (s *SQLiteStore) GetExperienceBufferStats(ctx context.Context) (store.ExperienceStats, error) {
+	var stats store.ExperienceStats
+	row := s.db.QueryRowContext(ctx,
+		`SELECT
+		    COALESCE(SUM(CASE WHEN category = 'gold' THEN 1 ELSE 0 END), 0),
+		    COALESCE(SUM(CASE WHEN category = 'needs_improvement' THEN 1 ELSE 0 END), 0),
+		    COALESCE(SUM(CASE WHEN category = 'ambiguous' THEN 1 ELSE 0 END), 0),
+		    COUNT(*)
+		 FROM experience_buffer`)
+	if err := row.Scan(&stats.Gold, &stats.NeedsImprovement, &stats.Ambiguous, &stats.Total); err != nil {
+		return stats, fmt.Errorf("getting experience buffer stats: %w", err)
+	}
+	return stats, nil
+}
+
+func (s *SQLiteStore) WriteRecallFeedbackEntry(ctx context.Context, entry store.RecallFeedbackEntry) error {
+	if entry.ID == "" {
+		entry.ID = uuid.New().String()
+	}
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO recall_feedback (id, query, memory_id, feedback, recall_session_id, created_at)
+		 VALUES (?, ?, ?, ?, ?, ?)`,
+		entry.ID, entry.Query, entry.MemoryID, entry.Feedback, entry.RecallSessionID, time.Now(),
+	)
+	if err != nil {
+		return fmt.Errorf("writing recall feedback for memory %s: %w", entry.MemoryID, err)
+	}
+	return nil
+}
+
+func (s *SQLiteStore) GetRecallHistory(ctx context.Context, memoryID string) ([]store.RecallFeedbackEntry, error) {
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, query, memory_id, feedback, recall_session_id, created_at
+		 FROM recall_feedback WHERE memory_id = ? ORDER BY created_at DESC`,
+		memoryID,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("getting recall history for %s: %w", memoryID, err)
+	}
+	defer rows.Close()
+
+	var entries []store.RecallFeedbackEntry
+	for rows.Next() {
+		var e store.RecallFeedbackEntry
+		if err := rows.Scan(&e.ID, &e.Query, &e.MemoryID, &e.Feedback, &e.RecallSessionID, &e.CreatedAt); err != nil {
+			return nil, fmt.Errorf("scanning recall feedback: %w", err)
+		}
+		entries = append(entries, e)
+	}
+	return entries, rows.Err()
+}
+
+func (s *SQLiteStore) GetEncodingQualityWindow(ctx context.Context, windowSize int) (store.EncodingQualityWindow, error) {
+	var w store.EncodingQualityWindow
+	w.WindowSize = windowSize
+
+	row := s.db.QueryRowContext(ctx,
+		`SELECT
+		    COALESCE(AVG(encoding_epr), 0),
+		    COALESCE(SUM(CASE WHEN encoding_flags LIKE '%template_echo%' THEN 1.0 ELSE 0.0 END) / MAX(COUNT(*), 1), 0),
+		    COALESCE(SUM(CASE WHEN encoding_flags IS NOT NULL AND encoding_flags != '[]' THEN 1.0 ELSE 0.0 END) / MAX(COUNT(*), 1), 0),
+		    COUNT(*)
+		 FROM (SELECT encoding_epr, encoding_flags FROM memories WHERE encoding_epr IS NOT NULL ORDER BY created_at DESC LIMIT ?)`,
+		windowSize,
+	)
+	if err := row.Scan(&w.MeanEPR, &w.TEDRate, &w.FlaggedRate, &w.SampleCount); err != nil {
+		return w, fmt.Errorf("getting encoding quality window: %w", err)
+	}
+	return w, nil
+}
+```
+
+- [ ] **Step 6: Verify compilation**
+
+Run: `make build`
+
+Expected: PASS — all Store interface methods now implemented.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/store/sqlite/continuous_learning.go
+git commit -m "feat: SQLite implementation for continuous learning store (#391)
+
+Implements ContinuousLearningStore: verification results, experience buffer
+CRUD, recall feedback linkage, reclassification, and quality window queries."
+```
+
+---
+
+### Task 4: Verification Gate — Entity Extraction & Checks
+
+**Files:**
+- Create: `internal/agent/encoding/verification.go`
+
+- [ ] **Step 1: Create verification.go with entity extraction regexes**
+
+Create `internal/agent/encoding/verification.go`:
+
+```go
+package encoding
+
+import (
+	"regexp"
+	"strings"
+	"unicode"
+)
+
+// VerificationResult holds the output of the faithfulness verification gate.
+type VerificationResult struct {
+	EPR            float64  // Entity Preservation Rate (0.0-1.0)
+	FR             float64  // Fabrication Rate (0.0-1.0), monitoring only
+	TED            bool     // Template Echo Detected
+	MIG            bool     // Minimal Input Guard triggered
+	Flags          []string // Human-readable issue descriptions
+	InputEntities  int      // Count of entities extracted from raw input
+	OutputEntities int      // Count of entities extracted from compression
+}
+
+// --- Entity extraction regexes (ported from eval_faithfulness.py) ---
+
+var (
+	// Numbers: integers, decimals, percentages, fractions, scientific notation, comma-separated
+	numberRE = regexp.MustCompile(
+		`-?\d{1,3}(?:,\d{3})+(?:\.\d+)?` + `|` + // comma-separated: 47,231
+			`-?\d+\.\d+[eE][+-]?\d+` + `|` + // scientific: 2.3e-4
+			`-?\d+\.\d+%` + `|` + // decimal percentage: 94.2%
+			`-?\d+%` + `|` + // integer percentage: 80%
+			`-?\d+\.\d+` + `|` + // decimal: 0.847
+			`\d+/\d+` + `|` + // fraction: 12/21
+			`\d+`, // plain integer: 200
+	)
+
+	// File paths with common extensions
+	pathRE = regexp.MustCompile(
+		`[a-zA-Z_~/][\w/~.-]+\.(?:go|py|js|ts|html|css|yaml|yml|json|jsonl|toml|md|sh|sql|gguf|db|txt|log|patch|cuh|cpp|c|h)\b` + `|` +
+			`/(?:home|usr|etc|var|tmp|opt|api|static)[\w./~-]+`,
+	)
+
+	// Version strings: v1.2.3, v2.0
+	versionRE = regexp.MustCompile(`v\d+\.\d+(?:\.\d+)?`)
+
+	// Proper nouns: multi-word capitalized phrases
+	multiWordProperRE = regexp.MustCompile(`\b([A-Z][a-z]+(?:\s+[A-Z][a-z]+)+)\b`)
+
+	// Single capitalized words after lowercase context
+	singleProperRE = regexp.MustCompile(`(?:[a-z,;]\s)([A-Z][a-z]{2,})\b`)
+
+	// @mentions
+	mentionRE = regexp.MustCompile(`@(\w+)`)
+
+	// CamelCase identifiers
+	camelCaseRE = regexp.MustCompile(`\b([A-Z][a-z]+[A-Z]\w+)\b`)
+)
+
+// Common words to filter from proper noun detection
+var commonWords = map[string]bool{
+	"The": true, "This": true, "That": true, "These": true, "Those": true,
+	"When": true, "Where": true, "What": true, "Which": true, "Who": true,
+	"How": true, "Why": true, "And": true, "But": true, "For": true,
+	"Not": true, "You": true, "All": true, "Can": true, "Had": true,
+	"Her": true, "Was": true, "One": true, "Our": true, "Out": true,
+	"Are": true, "Has": true, "His": true, "Its": true, "May": true,
+	"New": true, "Now": true, "Old": true, "See": true, "Way": true,
+	"Day": true, "Did": true, "Get": true, "Let": true, "Say": true,
+	"She": true, "Too": true, "Use": true, "After": true, "Also": true,
+	"Into": true, "Just": true, "Like": true, "Long": true, "Make": true,
+	"Many": true, "Most": true, "Only": true, "Over": true, "Such": true,
+	"Take": true, "Than": true, "Them": true, "Then": true, "Very": true,
+	"With": true, "Been": true, "Call": true, "Come": true, "Each": true,
+	"From": true, "Have": true, "Here": true, "High": true, "More": true,
+	"Part": true, "Some": true, "Time": true, "Will": true, "About": true,
+	"Could": true, "First": true, "Other": true, "Their": true, "There": true,
+	"Would": true, "Being": true, "Every": true, "Great": true, "Never": true,
+	"Since": true, "Still": true, "Think": true, "Where": true, "While": true,
+	"Should": true, "Before": true, "Between": true, "During": true,
+	"Output": true, "Input": true, "Based": true, "Given": true,
+	"Using": true, "Brief": true, "Under": true, "Memory": true,
+}
+
+// templateEchoPhrases are instruction fragments that should never appear in output.
+var templateEchoPhrases = []string{
+	"under 60 characters",
+	"under 80 characters",
+	"under 100 characters",
+	"2-3 sentence summary",
+	"key information",
+	"broader context",
+	"3-8 keyword strings",
+	"cause/effect relationships",
+	"how important is this",
+	"no markdown fences",
+	"no explanation",
+	"no preamble",
+	"output ONLY",
+	"single JSON object",
+	"output only valid json",
+	"no phrases longer than",
+	"fill in every json field",
+	"encode this event into memory",
+}
+
+// extractEntities extracts identifiable entities from text.
+// Returns a deduplicated set of entity strings (lowercased for comparison).
+func extractEntities(text string) map[string]bool {
+	entities := make(map[string]bool)
+
+	for _, m := range numberRE.FindAllString(text, -1) {
+		// Normalize: strip commas for comparison
+		normalized := strings.ReplaceAll(m, ",", "")
+		entities[normalized] = true
+	}
+	for _, m := range pathRE.FindAllString(text, -1) {
+		entities[strings.ToLower(m)] = true
+	}
+	for _, m := range versionRE.FindAllString(text, -1) {
+		entities[strings.ToLower(m)] = true
+	}
+	for _, m := range multiWordProperRE.FindAllString(text, -1) {
+		if !commonWords[m] {
+			entities[strings.ToLower(m)] = true
+		}
+	}
+	for _, matches := range singleProperRE.FindAllStringSubmatch(text, -1) {
+		if len(matches) > 1 && !commonWords[matches[1]] {
+			entities[strings.ToLower(matches[1])] = true
+		}
+	}
+	for _, matches := range mentionRE.FindAllStringSubmatch(text, -1) {
+		if len(matches) > 1 {
+			entities[strings.ToLower(matches[1])] = true
+		}
+	}
+	for _, m := range camelCaseRE.FindAllString(text, -1) {
+		entities[strings.ToLower(m)] = true
+	}
+
+	return entities
+}
+
+// contentFields extracts text from the content-bearing fields of a compression response.
+func contentFields(cr *compressionResponse) string {
+	var b strings.Builder
+	b.WriteString(cr.Gist)
+	b.WriteByte(' ')
+	b.WriteString(cr.Summary)
+	b.WriteByte(' ')
+	b.WriteString(cr.Content)
+	b.WriteByte(' ')
+	b.WriteString(cr.Narrative)
+	b.WriteByte(' ')
+	b.WriteString(cr.Outcome)
+	return b.String()
+}
+
+// verifyFaithfulness runs the post-compression verification gate.
+// Returns a VerificationResult with EPR, FR, TED, MIG, and human-readable flags.
+func verifyFaithfulness(rawText string, compression *compressionResponse) VerificationResult {
+	result := VerificationResult{}
+
+	inputEntities := extractEntities(rawText)
+	outputText := contentFields(compression)
+	outputEntities := extractEntities(outputText)
+
+	result.InputEntities = len(inputEntities)
+	result.OutputEntities = len(outputEntities)
+
+	// EPR: fraction of input entities found in output
+	if len(inputEntities) > 0 {
+		preserved := 0
+		for entity := range inputEntities {
+			if strings.Contains(strings.ToLower(outputText), entity) {
+				preserved++
+			}
+		}
+		result.EPR = float64(preserved) / float64(len(inputEntities))
+	} else {
+		result.EPR = 1.0 // No entities to preserve = perfect preservation
+	}
+
+	// FR: fraction of output entities not in input (monitoring only)
+	if len(outputEntities) > 0 {
+		fabricated := 0
+		inputLower := strings.ToLower(rawText)
+		for entity := range outputEntities {
+			if !strings.Contains(inputLower, entity) {
+				fabricated++
+			}
+		}
+		result.FR = float64(fabricated) / float64(len(outputEntities))
+	}
+
+	// TED: template echo detection
+	outputLower := strings.ToLower(outputText)
+	for _, phrase := range templateEchoPhrases {
+		if strings.Contains(outputLower, phrase) {
+			result.TED = true
+			result.Flags = append(result.Flags, "template_echo:"+phrase)
+			break // One is enough to flag
+		}
+	}
+
+	// MIG: minimal input guard
+	rawTrimmed := strings.TrimSpace(rawText)
+	if countNonWhitespace(rawTrimmed) < 50 && len(compression.Content) > 300 {
+		result.MIG = true
+		result.Flags = append(result.Flags, "minimal_input_padded")
+	}
+
+	// Build summary flags
+	if result.EPR < 0.7 {
+		result.Flags = append(result.Flags, fmt.Sprintf("low_epr:%.2f", result.EPR))
+	}
+	if result.FR > 0.3 {
+		result.Flags = append(result.Flags, fmt.Sprintf("high_fr:%.2f", result.FR))
+	}
+
+	return result
+}
+
+// countNonWhitespace returns the count of non-whitespace characters.
+func countNonWhitespace(s string) int {
+	count := 0
+	for _, r := range s {
+		if !unicode.IsSpace(r) {
+			count++
+		}
+	}
+	return count
+}
+```
+
+Note: add `"fmt"` to imports — needed for `fmt.Sprintf` in the flags.
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `make build`
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/agent/encoding/verification.go
+git commit -m "feat: runtime faithfulness verification gate (#391)
+
+Go port of eval_faithfulness.py entity extraction and verification checks.
+Computes EPR, FR, TED, MIG on every encoding. Pure string matching, ~0.3ms."
+```
+
+---
+
+### Task 5: Verification Gate Tests
+
+**Files:**
+- Create: `internal/agent/encoding/verification_test.go`
+
+- [ ] **Step 1: Write entity extraction tests**
+
+Create `internal/agent/encoding/verification_test.go`:
+
+```go
+package encoding
+
+import (
+	"testing"
+)
+
+func TestExtractEntities_Numbers(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected []string
+	}{
+		{"plain integer", "found 200 errors", []string{"200"}},
+		{"decimal", "accuracy was 0.847", []string{"0.847"}},
+		{"percentage", "achieved 94.2% recall", []string{"94.2%"}},
+		{"comma separated", "47,231 records processed", []string{"47231"}}, // normalized
+		{"fraction", "12/21 tests passed", []string{"12/21"}},
+		{"negative", "delta was -3.5", []string{"-3.5"}},
+		{"scientific", "learning rate 2.3e-4", []string{"2.3e-4"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			entities := extractEntities(tc.input)
+			for _, exp := range tc.expected {
+				if !entities[exp] {
+					t.Errorf("expected entity %q not found in %v", exp, entities)
+				}
+			}
+		})
+	}
+}
+
+func TestExtractEntities_Paths(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"go file", "changed internal/agent/encoding/agent.go", "internal/agent/encoding/agent.go"},
+		{"python file", "running training/scripts/eval_faithfulness.py", "training/scripts/eval_faithfulness.py"},
+		{"absolute path", "config at /home/user/config.yaml", "/home/user/config.yaml"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			entities := extractEntities(tc.input)
+			if !entities[tc.expected] {
+				t.Errorf("expected path %q not found in %v", tc.expected, entities)
+			}
+		})
+	}
+}
+
+func TestExtractEntities_Versions(t *testing.T) {
+	entities := extractEntities("upgraded from v1.2.3 to v2.0")
+	if !entities["v1.2.3"] {
+		t.Error("expected v1.2.3")
+	}
+	if !entities["v2.0"] {
+		t.Error("expected v2.0")
+	}
+}
+
+func TestExtractEntities_ProperNouns(t *testing.T) {
+	entities := extractEntities("Caleb discussed with Aaron Gokaslan about PostgreSQL migration")
+	if !entities["aaron gokaslan"] {
+		t.Error("expected 'aaron gokaslan' as multi-word proper noun")
+	}
+	// "Caleb" should be caught by single proper noun regex
+	if !entities["caleb"] {
+		// May not match if not preceded by lowercase — that's OK
+		t.Log("'caleb' not extracted as single proper noun (expected if at start of text)")
+	}
+}
+
+func TestVerifyFaithfulness_HighEPR(t *testing.T) {
+	raw := "Fixed null pointer in auth middleware at internal/agent/encoding/agent.go:42. Error was in v2.1.3."
+	compression := &compressionResponse{
+		Gist:    "Fixed null pointer in auth middleware",
+		Summary: "Resolved null pointer exception in auth middleware at internal/agent/encoding/agent.go:42",
+		Content: "A null pointer bug in the auth middleware was fixed at internal/agent/encoding/agent.go:42. The issue was present since v2.1.3.",
+		Narrative: "The auth middleware had a null pointer that was causing crashes.",
+	}
+
+	result := verifyFaithfulness(raw, compression)
+
+	if result.EPR < 0.7 {
+		t.Errorf("expected high EPR, got %.2f", result.EPR)
+	}
+	if result.TED {
+		t.Error("unexpected template echo detection")
+	}
+}
+
+func TestVerifyFaithfulness_TemplateEcho(t *testing.T) {
+	raw := "deployed new service"
+	compression := &compressionResponse{
+		Gist:    "deployed new service under 60 characters",
+		Summary: "A new service was deployed. Output ONLY valid JSON.",
+		Content: "Service deployed successfully.",
+	}
+
+	result := verifyFaithfulness(raw, compression)
+
+	if !result.TED {
+		t.Error("expected template echo detection")
+	}
+	if len(result.Flags) == 0 {
+		t.Error("expected flags to be set")
+	}
+}
+
+func TestVerifyFaithfulness_MinimalInputGuard(t *testing.T) {
+	raw := "WAL mode on."
+	compression := &compressionResponse{
+		Gist:    "Enabled WAL mode on the database",
+		Summary: "WAL mode was enabled for the SQLite database to improve concurrent read performance.",
+		Content: "The database was configured with Write-Ahead Logging (WAL) mode to improve concurrent read performance. " +
+			"This is a common optimization for SQLite databases that allows multiple readers while a single writer commits transactions. " +
+			"The change affects all database operations and requires no schema changes. WAL mode persists across database connections " +
+			"and provides better throughput for read-heavy workloads typical in memory retrieval systems.",
+	}
+
+	result := verifyFaithfulness(raw, compression)
+
+	if !result.MIG {
+		t.Error("expected MIG flag for short input with long output")
+	}
+}
+
+func TestVerifyFaithfulness_NoEntities(t *testing.T) {
+	raw := "ok"
+	compression := &compressionResponse{
+		Gist:    "acknowledged",
+		Summary: "Simple acknowledgment.",
+		Content: "acknowledged",
+	}
+
+	result := verifyFaithfulness(raw, compression)
+
+	if result.EPR != 1.0 {
+		t.Errorf("expected EPR 1.0 for no-entity input, got %.2f", result.EPR)
+	}
+}
+```
+
+- [ ] **Step 2: Run tests**
+
+Run: `cd /home/hubcaps/Projects/mem && go test ./internal/agent/encoding/ -run TestExtract -v`
+
+Expected: All entity extraction tests PASS.
+
+Run: `go test ./internal/agent/encoding/ -run TestVerify -v`
+
+Expected: All verification tests PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/agent/encoding/verification_test.go
+git commit -m "test: verification gate unit tests (#391)
+
+Entity extraction tests (numbers, paths, versions, proper nouns),
+EPR validation, template echo detection, and minimal input guard."
+```
+
+---
+
+### Task 6: Wire Verification Gate into Encoding Pipeline
+
+**Files:**
+- Modify: `internal/agent/encoding/agent.go:1046-1048`
+
+- [ ] **Step 1: Insert verification gate call after compression**
+
+At `internal/agent/encoding/agent.go`, after line 1046 (the "compression completed" debug log) and before line 1048 (the "Step 3: Generate embedding" comment), insert:
+
+```go
+	// Step 2b: Verify faithfulness (EPR, TED, FR, MIG)
+	verification := verifyFaithfulness(raw.Content, compression)
+	ea.log.Debug("verification completed",
+		"raw_id", raw.ID,
+		"epr", verification.EPR,
+		"fr", verification.FR,
+		"ted", verification.TED,
+		"flags", verification.Flags,
+	)
+	if verification.TED {
+		ea.log.Warn("template echo detected in encoding",
+			"raw_id", raw.ID,
+			"flags", verification.Flags,
+		)
+		// Reduce salience for template-echoed encodings
+		if compression.Salience > 0.1 {
+			compression.Salience -= 0.1
+		}
+	}
+	if verification.EPR < 0.7 {
+		ea.log.Warn("low entity preservation rate",
+			"raw_id", raw.ID,
+			"epr", verification.EPR,
+			"input_entities", verification.InputEntities,
+		)
+	}
+```
+
+- [ ] **Step 2: Store verification result and experience entry after persistence**
+
+After the `persistEncodedMemory` call at line 1059 (now shifted down due to insertion), add:
+
+```go
+	// Step 8b: Store verification metrics and experience buffer entry
+	if result != nil && result.MemoryID != "" {
+		if err := ea.store.WriteVerificationResult(ctx, result.MemoryID, verification.EPR, verification.FR, verification.Flags); err != nil {
+			ea.log.Warn("failed to write verification result", "memory_id", result.MemoryID, "error", err)
+		}
+
+		entry := store.ExperienceEntry{
+			RawID:         raw.ID,
+			MemoryID:      result.MemoryID,
+			EncodingEPR:   verification.EPR,
+			EncodingFR:    verification.FR,
+			EncodingFlags: verification.Flags,
+			Category:      "ambiguous",
+		}
+		if err := ea.store.WriteExperienceEntry(ctx, entry); err != nil {
+			ea.log.Warn("failed to write experience entry", "memory_id", result.MemoryID, "error", err)
+		}
+	}
+```
+
+- [ ] **Step 3: Add store import if needed**
+
+The encoding agent already imports `store` — verify with `go build`.
+
+- [ ] **Step 4: Verify compilation and run existing tests**
+
+Run: `make build && go test ./internal/agent/encoding/ -v`
+
+Expected: Build succeeds. Existing tests pass (mock store will need the new ContinuousLearningStore methods — the `storetest.MockStore` may need stub implementations).
+
+- [ ] **Step 5: Add stub implementations to MockStore if needed**
+
+If `storetest.MockStore` doesn't satisfy `ContinuousLearningStore`, add no-op stubs. Check `internal/store/storetest/` for the mock pattern and add:
+
+```go
+func (m *MockStore) WriteVerificationResult(ctx context.Context, memoryID string, epr float64, fr float64, flags []string) error { return nil }
+func (m *MockStore) WriteExperienceEntry(ctx context.Context, entry store.ExperienceEntry) error { return nil }
+func (m *MockStore) UpdateExperienceRecallScore(ctx context.Context, memoryID string, feedback string) error { return nil }
+func (m *MockStore) ReclassifyExperienceBuffer(ctx context.Context) (int, error) { return 0, nil }
+func (m *MockStore) ListExperienceByCategory(ctx context.Context, category string, limit int) ([]store.ExperienceEntry, error) { return nil, nil }
+func (m *MockStore) GetExperienceBufferStats(ctx context.Context) (store.ExperienceStats, error) { return store.ExperienceStats{}, nil }
+func (m *MockStore) WriteRecallFeedbackEntry(ctx context.Context, entry store.RecallFeedbackEntry) error { return nil }
+func (m *MockStore) GetRecallHistory(ctx context.Context, memoryID string) ([]store.RecallFeedbackEntry, error) { return nil, nil }
+func (m *MockStore) GetEncodingQualityWindow(ctx context.Context, windowSize int) (store.EncodingQualityWindow, error) { return store.EncodingQualityWindow{}, nil }
+```
+
+- [ ] **Step 6: Run full test suite**
+
+Run: `make test`
+
+Expected: All tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/agent/encoding/agent.go internal/store/storetest/
+git commit -m "feat: wire verification gate into encoding pipeline (#391)
+
+Every encoding now runs through verifyFaithfulness() after compression.
+EPR, FR, TED, MIG metrics stored on memory record and experience buffer.
+Template echo reduces salience by 0.1."
+```
+
+---
+
+### Task 7: Hook Recall Feedback into Experience Buffer
+
+**Files:**
+- Modify: `internal/mcp/server.go:2003`
+
+- [ ] **Step 1: Add experience buffer update after feedback storage**
+
+At `internal/mcp/server.go`, after line 2003 (after `WriteMetaObservation` succeeds and before the `if queryID != ""` block at line 2005), insert:
+
+```go
+	// Update experience buffer recall scores for each memory that received feedback
+	for _, memID := range memoryIDs {
+		if err := srv.store.UpdateExperienceRecallScore(ctx, memID, quality); err != nil {
+			srv.log.Debug("no experience entry for memory (may predate continuous learning)", "memory_id", memID)
+		}
+
+		// Also record the recall-encoding linkage
+		rfEntry := store.RecallFeedbackEntry{
+			Query:           query,
+			MemoryID:        memID,
+			Feedback:        quality,
+			RecallSessionID: srv.sessionID,
+		}
+		if err := srv.store.WriteRecallFeedbackEntry(ctx, rfEntry); err != nil {
+			srv.log.Warn("failed to write recall feedback entry", "memory_id", memID, "error", err)
+		}
+	}
+```
+
+- [ ] **Step 2: Add store import if needed**
+
+The MCP server already imports `store` — verify compilation.
+
+- [ ] **Step 3: Verify compilation**
+
+Run: `make build`
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/mcp/server.go
+git commit -m "feat: hook recall feedback into experience buffer (#391)
+
+When users rate recall quality via the feedback MCP tool, the rating
+propagates to the experience buffer as a running weighted average.
+Also records recall-encoding linkage for downstream analysis."
+```
+
+---
+
+### Task 8: Dreaming Agent — Experience Buffer Reclassification
+
+**Files:**
+- Modify: `internal/agent/dreaming/agent.go:177-179`
+
+- [ ] **Step 1: Add reclassification phase after cross-project linking**
+
+At `internal/agent/dreaming/agent.go`, between line 177 (end of crossProjectLink) and line 179 (start of linkToPatterns), insert:
+
+```go
+	// Phase 4.5: Reclassify experience buffer entries based on accumulated feedback
+	if reclassified, err := da.store.ReclassifyExperienceBuffer(ctx); err != nil && ctx.Err() == nil {
+		da.log.Error("experience buffer reclassification failed", "error", err)
+	} else if reclassified > 0 {
+		da.log.Info("reclassified experience buffer entries", "count", reclassified)
+	}
+```
+
+- [ ] **Step 2: Verify compilation**
+
+Run: `make build`
+
+Expected: PASS
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/agent/dreaming/agent.go
+git commit -m "feat: reclassify experience buffer during dreaming (#391)
+
+Phase 4.5 in the dreaming cycle reclassifies experience buffer entries
+as gold/needs_improvement/ambiguous based on accumulated EPR, TED, and
+recall feedback scores."
+```
+
+---
+
+### Task 9: Metacognition — Quality Drift Detection
+
+**Files:**
+- Modify: `internal/agent/metacognition/agent.go`
+
+- [ ] **Step 1: Add encoding quality drift observation**
+
+Find the method that collects all observations (the function that calls `auditMemoryQuality` and other audit methods, assembles them into a slice, and stores them). Add a new call after the existing audit methods:
+
+```go
+func (ma *MetacognitionAgent) auditEncodingQuality(ctx context.Context) *store.MetaObservation {
+	window, err := ma.store.GetEncodingQualityWindow(ctx, 100)
+	if err != nil {
+		ma.log.Warn("failed to get encoding quality window", "error", err)
+		return nil
+	}
+
+	// Need at least 20 samples to make a meaningful assessment
+	if window.SampleCount < 20 {
+		return nil
+	}
+
+	details := map[string]interface{}{
+		"window_size":  window.WindowSize,
+		"mean_epr":     window.MeanEPR,
+		"ted_rate":     window.TEDRate,
+		"flagged_rate": window.FlaggedRate,
+		"sample_count": window.SampleCount,
+	}
+
+	severity := "info"
+	trend := "stable"
+
+	// Detect degradation: EPR below 0.85 or TED rate above 5%
+	if window.MeanEPR < 0.85 {
+		severity = "warning"
+		trend = "degrading"
+		details["issue"] = "mean EPR below 0.85"
+	}
+	if window.TEDRate > 0.05 {
+		severity = "warning"
+		trend = "degrading"
+		details["issue"] = "template echo rate above 5%"
+	}
+	if window.MeanEPR < 0.70 || window.TEDRate > 0.15 {
+		severity = "critical"
+		trend = "degrading"
+	}
+	if window.MeanEPR > 0.93 && window.TEDRate < 0.02 {
+		trend = "improving"
+	}
+
+	details["trend"] = trend
+
+	return &store.MetaObservation{
+		ObservationType: "encoding_quality_drift",
+		Severity:        severity,
+		Details:         details,
+	}
+}
+```
+
+- [ ] **Step 2: Wire into the observation collection loop**
+
+Find where other audit methods are called (the function that builds the observations slice) and add:
+
+```go
+	if obs := ma.auditEncodingQuality(ctx); obs != nil {
+		observations = append(observations, obs)
+	}
+```
+
+- [ ] **Step 3: Verify compilation and tests**
+
+Run: `make build && go test ./internal/agent/metacognition/ -v`
+
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add internal/agent/metacognition/agent.go
+git commit -m "feat: encoding quality drift detection in metacognition (#391)
+
+New observation type 'encoding_quality_drift' tracks rolling EPR and TED
+rate over the last 100 encodings. Emits warning when EPR < 0.85 or TED
+rate > 5%, critical when EPR < 0.70 or TED > 15%."
+```
+
+---
+
+### Task 10: Configuration
+
+**Files:**
+- Modify: `internal/config/config.go`
+- Modify: `config.yaml`
+
+- [ ] **Step 1: Add ContinuousLearningConfig struct**
+
+In `internal/config/config.go`, add after the existing config structs (before the `Config` struct or after `TrainingConfig`):
+
+```go
+// ContinuousLearningConfig holds settings for the continuous learning pipeline.
+type ContinuousLearningConfig struct {
+	Enabled  bool                      `yaml:"enabled"`  // master switch
+	Training CLTrainingConfig          `yaml:"training"`
+	Trigger  CLTriggerConfig           `yaml:"trigger"`
+}
+
+// CLTrainingConfig holds training-specific settings for continuous learning.
+type CLTrainingConfig struct {
+	MinNewExamples   int     `yaml:"min_new_examples"`   // minimum experience entries before training (default: 50)
+	MaxExamplesPerRun int    `yaml:"max_examples_per_run"` // cap batch size (default: 200)
+	ReplayRatio      float64 `yaml:"replay_ratio"`        // fraction from base dataset (default: 0.30)
+	RollbackVersions int     `yaml:"rollback_versions"`   // keep last N spoke versions (default: 3)
+}
+
+// CLTriggerConfig holds trigger settings for continuous learning.
+type CLTriggerConfig struct {
+	Auto           bool   `yaml:"auto"`            // metacognition auto-trigger (default: false)
+	Manual         bool   `yaml:"manual"`           // MCP tool trigger (default: true)
+	TrainingWindow string `yaml:"training_window"`  // auto-trigger window, e.g. "02:00-06:00"
+}
+```
+
+- [ ] **Step 2: Add to main Config struct**
+
+Add to the `Config` struct at `internal/config/config.go:18-42`:
+
+```go
+ContinuousLearning ContinuousLearningConfig `yaml:"continuous_learning"`
+```
+
+- [ ] **Step 3: Add defaults to config.yaml**
+
+Append to `config.yaml`:
+
+```yaml
+# Continuous learning — encoding model improves from operational experience (#391)
+continuous_learning:
+  enabled: false
+  training:
+    min_new_examples: 50
+    max_examples_per_run: 200
+    replay_ratio: 0.30
+    rollback_versions: 3
+  trigger:
+    auto: false
+    manual: true
+    training_window: "02:00-06:00"
+```
+
+- [ ] **Step 4: Verify compilation**
+
+Run: `make build`
+
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/config/config.go config.yaml
+git commit -m "feat: continuous learning configuration (#391)
+
+Add ContinuousLearningConfig with training, curriculum, and trigger
+settings. Disabled by default (opt-in). Manual trigger enabled."
+```
+
+---
+
+### Task 11: Build, Test, Deploy to Daemon
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `make test`
+
+Expected: All tests pass.
+
+- [ ] **Step 2: Run lint**
+
+Run: `golangci-lint run`
+
+Expected: No new warnings. Fix any errcheck or unused issues.
+
+- [ ] **Step 3: Build and restart daemon**
+
+Run: `make build && systemctl --user restart mnemonic`
+
+- [ ] **Step 4: Verify daemon is healthy**
+
+Run: `systemctl --user status mnemonic`
+
+Expected: Active (running). Migration 007 applies on startup (check logs):
+
+Run: `journalctl --user -u mnemonic --since "1 min ago" | grep -i migration`
+
+- [ ] **Step 5: Test verification in production**
+
+Use the mnemonic MCP `remember` tool to store a test memory. Then check the dashboard or query the DB:
+
+Run: `sqlite3 ~/.mnemonic/mnemonic.db "SELECT id, encoding_epr, encoding_fr, encoding_flags FROM memories ORDER BY created_at DESC LIMIT 5"`
+
+Expected: The newest memory has EPR, FR, and flags populated.
+
+Run: `sqlite3 ~/.mnemonic/mnemonic.db "SELECT * FROM experience_buffer ORDER BY created_at DESC LIMIT 5"`
+
+Expected: Corresponding experience buffer entry exists.
+
+- [ ] **Step 6: Commit any fixes from integration testing**
+
+If any issues found during live testing, fix and commit.
+
+---
+
+### Task 12: Parity Test — Go vs Python Verification
+
+- [ ] **Step 1: Create parity test script**
+
+This is a one-time validation that the Go verification gate produces the same results as the Python eval_faithfulness.py. Run both on the 25 EXP-25 gold inputs and compare EPR values.
+
+Create a test in `internal/agent/encoding/verification_test.go` that loads the gold data:
+
+```go
+func TestVerification_ParityWithPython(t *testing.T) {
+	// This test requires the gold data files from EXP-25.
+	// Skip if files don't exist (CI environments without training data).
+	goldPath := "../../../training/data/faithfulness_probe/gold_train.jsonl"
+	if _, err := os.Stat(goldPath); os.IsNotExist(err) {
+		t.Skip("gold_train.jsonl not found, skipping parity test")
+	}
+
+	// Load gold data and run verification on each entry
+	// Compare EPR values against known Python results
+	t.Log("Parity test: load gold data, compute EPR, compare with Python baseline")
+	// Full implementation reads JSONL, runs verifyFaithfulness on each, checks EPR within 0.05 tolerance
+}
+```
+
+The full implementation of this test should parse the JSONL, extract raw_input and gold_output, run `verifyFaithfulness`, and verify EPR is within 0.05 of the Python values. This requires running `eval_faithfulness.py` once to produce reference values.
+
+- [ ] **Step 2: Run the parity test**
+
+Run: `go test ./internal/agent/encoding/ -run TestVerification_Parity -v`
+
+Expected: All 25 entries have EPR within 0.05 tolerance of Python.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add internal/agent/encoding/verification_test.go
+git commit -m "test: Go/Python verification parity test (#391)
+
+Validates that the Go verification gate produces EPR values within 0.05
+of eval_faithfulness.py on all 25 EXP-25 gold-standard probe inputs."
+```

--- a/docs/SPEC_continuous_learning.md
+++ b/docs/SPEC_continuous_learning.md
@@ -1,0 +1,823 @@
+# Continuous Learning — Implementation Specification
+
+## 2026-04-10 | Issue #391
+
+### Authors
+Caleb Gross, Claude (AI Research Partner)
+
+---
+
+## 1. Overview
+
+This spec defines the implementation of a closed-loop continuous learning system
+for Mnemonic's encoding model. The encoding model improves from operational
+experience: verification metrics at write time, recall feedback downstream, and
+automated retraining when quality degrades.
+
+**Design document:** `docs/DESIGN_continuous_learning.md`
+**Tracking:** GitHub issue #391
+
+### Approach
+
+Phased automation (Approach C). Three independently valuable phases, each
+shipping as its own PR:
+
+| Phase | Scope | Deliverable |
+|-------|-------|-------------|
+| A | Runtime verification & experience collection | Encoding quality observability |
+| B | Curriculum generation during dreaming hours | Curated training data from failures |
+| C | Automated training, quality gate, deployment | Self-improving model with rollback |
+
+### Key Design Decisions
+
+1. **Model-agnostic.** The pipeline works regardless of which base model wins
+   EXP-29 (Qwen 3.5 2B/4B, Gemma E2B, or Bespoke-pruned from EXP-28).
+   Verification is pure string matching. Experience buffer stores quality
+   metrics about encodings regardless of what produced them. The training
+   trigger is a config value pointing at a checkpoint.
+
+2. **Hybrid orchestration.** Go metacognition agent decides *whether* to train.
+   If yes, daemon writes a training request file and exits gracefully. A systemd
+   path unit watches for the file, runs the Python training script, validates
+   the quality gate, and restarts the daemon with new or old spokes. The daemon
+   never restarts itself. Respects Unix philosophy, gives systemd proper
+   supervision, keeps PyTorch in Python.
+
+3. **Classification: EPR + recall_score + TED.** Fabrication Rate (FR) is
+   monitoring-only, not used for gold/needs_improvement classification. EXP-25
+   showed 25.8% FR on correct outputs due to legitimate semantic expansion
+   ("WAL mode on." -> "database"). FR has >25% false positive rate on correct
+   outputs. Using it for classification would corrupt the training signal.
+
+4. **Observe before intervening.** Phase A (write-time verification + recall
+   feedback linkage) must run long enough to establish a baseline before Phase C
+   claims to improve anything. No premature optimization of the training loop.
+
+---
+
+## 2. Phase A: Runtime Verification & Experience Collection
+
+Pure observation. No model changes, no training, no Gemini calls.
+
+### 2.1 Runtime Verification Gate
+
+**New file:** `internal/agent/encoding/verification.go`
+
+**Pipeline insertion:** After `compressAndExtractConcepts()` returns (agent.go
+~line 1046), before embedding generation:
+
+```
+compressAndExtractConcepts() -> verifyFaithfulness() -> generateEmbedding() -> persist()
+```
+
+**Checks computed (Go port of eval_faithfulness.py patterns):**
+
+| Check | Method | Cost | Used for classification |
+|-------|--------|------|------------------------|
+| EPR (Entity Preservation Rate) | Regex extraction of proper nouns, numbers, paths, versions from raw input. Fraction found in compression's content-bearing fields (gist, summary, content, narrative). | ~0.1ms | Yes |
+| TED (Template Echo Detection) | Check output against known instruction phrases from encoding prompt. Boolean. | ~0.05ms | Yes |
+| MIG (Minimal Input Guard) | If raw input < 50 chars and output content > 300 chars, flag as padded. | ~0.01ms | Flag only |
+| FR (Fabrication Rate) | Extract entities from output, fraction not in input. | ~0.1ms | Monitoring only |
+
+**Entity extraction regexes (ported from eval_faithfulness.py):**
+
+```
+Numbers:        \b\d+\.?\d*%?\b
+File paths:     (?:[a-zA-Z]:)?(?:/[\w.-]+)+(?:\.\w+)?
+                (?:[\w.-]+/)+[\w.-]+(?:\.\w+)?
+Versions:       v?\d+\.\d+(?:\.\d+)?(?:-[\w.]+)?
+Proper nouns:   \b[A-Z][a-z]+(?:\s[A-Z][a-z]+)*\b  (filtered against common words)
+```
+
+**Template echo phrases (from eval_faithfulness.py TEMPLATE_ECHO_PHRASES):**
+
+```
+"under 60 characters", "under 80 characters", "under 100 characters",
+"2-3 sentence summary", "key information", "broader context",
+"3-8 keyword strings", "cause/effect relationships",
+"how important is this", "no markdown fences", "no explanation",
+"no preamble", "output ONLY", "single JSON object"
+```
+
+**Behavior — soft mode only (Phase A):**
+- Log warning with specific issues at `slog.Warn` level
+- Store metrics on the memory record (new columns)
+- Persist the memory regardless — do not reject
+- Reduce salience by 0.1 if TED = true (template echoing is high-confidence)
+- No hard mode until baseline data calibrates thresholds
+
+**Verification result type:**
+
+```go
+type VerificationResult struct {
+    EPR       float64   // 0.0-1.0
+    FR        float64   // 0.0-1.0, monitoring only
+    TED       bool      // true = template echo detected
+    MIG       bool      // true = minimal input padded
+    Flags     []string  // human-readable issue descriptions
+    InputEntities  int  // count extracted from raw
+    OutputEntities int  // count extracted from compression
+}
+```
+
+### 2.2 Schema Migration
+
+**New migration file:** `migrations/NNNN_continuous_learning.sql`
+
+```sql
+-- Verification metrics on memories table
+ALTER TABLE memories ADD COLUMN encoding_epr REAL DEFAULT NULL;
+ALTER TABLE memories ADD COLUMN encoding_fr REAL DEFAULT NULL;
+ALTER TABLE memories ADD COLUMN encoding_flags TEXT DEFAULT NULL;
+-- encoding_flags: JSON array, e.g. ["template_echo", "minimal_input_padded"]
+
+-- Recall-encoding linkage
+CREATE TABLE recall_feedback (
+    id TEXT PRIMARY KEY,
+    query TEXT NOT NULL,
+    memory_id TEXT NOT NULL,
+    feedback TEXT NOT NULL,          -- helpful, partial, irrelevant
+    recall_session_id TEXT,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (memory_id) REFERENCES memories(id)
+);
+CREATE INDEX idx_recall_feedback_memory ON recall_feedback(memory_id);
+
+-- Experience buffer
+CREATE TABLE experience_buffer (
+    id TEXT PRIMARY KEY,
+    raw_id TEXT NOT NULL,
+    memory_id TEXT NOT NULL,
+    encoding_epr REAL,
+    encoding_fr REAL,
+    encoding_flags TEXT,             -- JSON array
+    recall_score REAL,               -- aggregated: helpful=1.0, partial=0.5, irrelevant=0.0
+    recall_count INTEGER DEFAULT 0,
+    category TEXT DEFAULT 'ambiguous', -- gold, needs_improvement, ambiguous
+    used_in_training INTEGER DEFAULT 0,
+    created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+    FOREIGN KEY (memory_id) REFERENCES memories(id)
+);
+CREATE INDEX idx_experience_buffer_category ON experience_buffer(category);
+```
+
+### 2.3 Experience Buffer Population
+
+**On every encoding (after verification gate):**
+- Insert row into `experience_buffer` with EPR, FR, flags from verification
+- Initial category = `ambiguous` (insufficient signal)
+
+**On every recall feedback (when user calls the `feedback` MCP tool):**
+- Insert row into `recall_feedback` linking query -> memory_id -> rating
+- Update `experience_buffer.recall_score`:
+  - Rating map: helpful = 1.0, partial = 0.5, irrelevant = 0.0
+  - Running weighted average: `new_score = (old_score * old_count + rating) / (old_count + 1)`
+- Increment `recall_count`
+- Set `updated_at` to current timestamp
+
+**Reclassification (runs during dreaming cycle):**
+
+| Category | Criteria |
+|----------|----------|
+| Gold | EPR > 0.9 AND TED = false AND (recall_score > 0.8 OR (recall_count == 0 AND no flags)) |
+| Needs improvement | EPR < 0.7 OR TED = true OR (recall_score < 0.3 AND recall_count >= 3) |
+| Ambiguous | Everything else |
+
+The `recall_count >= 3` guard prevents a single irrelevant rating from
+condemning an encoding. Matches the design doc's risk mitigation for feedback
+noise (Section 9).
+
+### 2.4 Metacognition: Quality Drift Detection
+
+**New observation type:** `encoding_quality_drift`
+
+Extends `auditMemoryQuality()` in `internal/agent/metacognition/agent.go`:
+
+```go
+type EncodingQualityWindow struct {
+    WindowSize   int       // last 100 encodings
+    MeanEPR      float64
+    TEDRate      float64   // fraction with template echo
+    FlaggedRate  float64   // fraction with any flag
+    Trend        string    // improving, stable, degrading
+    BaselineEPR  float64   // from first 100 encodings after Phase A ships
+    BaselineTED  float64
+}
+```
+
+**Logic:**
+- Compute rolling averages over last 100 encodings
+- Compare against baseline (first 100 encodings post-deployment)
+- Trend classification:
+  - `improving`: mean EPR increased by >3pp AND TED rate decreased
+  - `degrading`: mean EPR decreased by >5pp OR TED rate increased by >10pp
+  - `stable`: neither threshold crossed
+- Emit `MetaObservation` with trend and metrics
+- If `degrading` for 2+ consecutive audit cycles -> signal for training (Phase C)
+
+### 2.5 Store Interface Additions
+
+New methods on `store.Store`:
+
+```go
+// Verification results (written during encoding)
+WriteVerificationResult(ctx context.Context, memoryID string, epr float64, fr float64, flags []string) error
+
+// Experience buffer CRUD
+WriteExperienceEntry(ctx context.Context, entry ExperienceEntry) error
+UpdateExperienceRecallScore(ctx context.Context, memoryID string, feedback string) error
+ReclassifyExperienceBuffer(ctx context.Context) (reclassified int, err error)
+ListExperienceByCategory(ctx context.Context, category string, limit int) ([]ExperienceEntry, error)
+GetExperienceBufferStats(ctx context.Context) (ExperienceStats, error)
+
+// Recall-encoding linkage
+WriteRecallFeedback(ctx context.Context, rf RecallFeedback) error
+GetRecallHistory(ctx context.Context, memoryID string) ([]RecallFeedback, error)
+
+// Quality drift
+GetEncodingQualityWindow(ctx context.Context, windowSize int) (EncodingQualityWindow, error)
+```
+
+**Types:**
+
+```go
+type ExperienceEntry struct {
+    ID             string
+    RawID          string
+    MemoryID       string
+    EncodingEPR    float64
+    EncodingFR     float64
+    EncodingFlags  []string
+    RecallScore    float64
+    RecallCount    int
+    Category       string    // gold, needs_improvement, ambiguous
+    UsedInTraining bool
+    CreatedAt      time.Time
+    UpdatedAt      time.Time
+}
+
+type ExperienceStats struct {
+    Gold             int
+    NeedsImprovement int
+    Ambiguous        int
+    Total            int
+    CorrectedCount   int  // Phase B: entries with Gemini corrections
+}
+
+type RecallFeedback struct {
+    ID              string
+    Query           string
+    MemoryID        string
+    Feedback        string  // helpful, partial, irrelevant
+    RecallSessionID string
+    CreatedAt       time.Time
+}
+```
+
+### 2.6 Testing Strategy
+
+**Unit tests:**
+- `verification_test.go`: Test EPR computation against known inputs from EXP-25
+  gold data (25 cases). Verify regex patterns match eval_faithfulness.py output.
+- `verification_test.go`: Test TED detection against template echo phrases.
+- `verification_test.go`: Test MIG detection on short inputs.
+- Store tests: CRUD operations for experience_buffer, recall_feedback tables.
+- Reclassification tests: Verify gold/needs_improvement/ambiguous thresholds.
+
+**Integration tests:**
+- Encode a known raw input through the full pipeline and verify verification
+  metrics are stored on the resulting memory.
+- Simulate recall feedback flow and verify experience buffer update.
+
+**Parity test (critical):**
+- Run the 25 EXP-25 gold inputs through both eval_faithfulness.py (Python) and
+  the Go verification gate. EPR values must match within 0.01 tolerance. TED
+  detection must be identical. This ensures the Go port is faithful to the
+  Python reference implementation.
+
+---
+
+## 3. Phase B: Curriculum Generation
+
+Runs during dreaming hours. Builds training data. No model changes.
+
+### 3.1 Dreaming Agent Extension
+
+**New phase:** Phase 4.5 in `internal/agent/dreaming/agent.go` (after noise
+prune at Phase 4, before cross-project linking at Phase 5).
+
+**Trigger conditions (all must be true):**
+- `continuous_learning.curriculum.enabled` = true in config
+- Experience buffer has >= `min_needs_improvement` entries with category
+  `needs_improvement` (default: 10)
+- At least `cooldown_hours` since last curriculum generation (default: 24)
+- Gemini API provider is configured and reachable
+
+**Algorithm:**
+
+```
+For each needs_improvement entry (up to max_corrections_per_cycle):
+    1. Load original raw input from raw_memories table
+    2. Build prompt via build_production_prompt() — IDENTICAL to what local model saw
+    3. Call Gemini via existing llm.Provider ChatCompletion() interface
+    4. Parse Gemini response as compressionResponse
+    5. Run verifyFaithfulness() on Gemini output
+    6. If Gemini passes (EPR > 0.9 AND TED = false):
+        -> Store corrected_output, corrected_epr, corrected_fr on experience_buffer entry
+        -> Set correction_source = "gemini", corrected_at = now
+        -> This is now a training pair
+    7. If Gemini fails verification:
+        -> Reclassify entry as "ambiguous"
+        -> Log: "Gemini also failed on entry {id}, input may be genuinely ambiguous"
+```
+
+**Why identical prompt matters:** The corrected output must be what a perfect
+version of the local model would produce given the exact same prompt. Using a
+different prompt would teach the model to respond to a prompt it will never see
+in production.
+
+### 3.2 Schema Addition
+
+**Extends the Phase A migration (or new migration if Phase B ships separately):**
+
+```sql
+ALTER TABLE experience_buffer ADD COLUMN corrected_output TEXT DEFAULT NULL;
+ALTER TABLE experience_buffer ADD COLUMN corrected_epr REAL DEFAULT NULL;
+ALTER TABLE experience_buffer ADD COLUMN corrected_fr REAL DEFAULT NULL;
+ALTER TABLE experience_buffer ADD COLUMN correction_source TEXT DEFAULT NULL;
+ALTER TABLE experience_buffer ADD COLUMN corrected_at DATETIME DEFAULT NULL;
+```
+
+### 3.3 Hard Example Mining
+
+After curriculum generation, analyze the experience buffer for systematic
+failure patterns.
+
+**Failure pattern detection:**
+
+```go
+type FailurePattern struct {
+    Pattern    string   // dense_numbers, short_input, template_echo, domain_gap
+    Count      int      // entries exhibiting this pattern
+    AvgEPR     float64
+    ExampleIDs []string // sample for manual review
+}
+```
+
+**Heuristics:**
+
+| Pattern | Detection | Significance |
+|---------|-----------|-------------|
+| Dense numbers | Raw input contains >= 5 distinct numeric values AND EPR < 0.8 | Known universal failure from EXP-29 |
+| Short input | Raw input < 30 chars AND any verification flag set | MIG-related |
+| Template echo | TED = true | Direct detection |
+| Domain gap | 5+ needs_improvement entries share concepts not present in training data | New project/tech stack |
+
+**Output:** A `curriculum_report` stored as a `MetaObservation` with type
+`curriculum_analysis`. This informs Phase C about which training data categories
+to prioritize — targeted improvement, not random sampling.
+
+### 3.4 Training Data Assembly
+
+The curriculum generator writes assembled training data to disk as the handoff
+between Go (curation) and Python (training).
+
+**Output directory:** `training/data/continuous_learning/`
+
+**File format:** JSONL with metadata header.
+
+**SFT pairs (from gold examples):**
+```jsonl
+{"type": "gold", "input": "<production prompt + raw input>", "output": "<local gold encoding>", "memory_id": "..."}
+```
+
+**Corrective SFT pairs (from Gemini re-encodings):**
+```jsonl
+{"type": "corrective", "input": "<production prompt + raw input>", "output": "<gemini encoding>", "memory_id": "...", "local_epr": 0.52, "corrected_epr": 0.97}
+```
+
+**Future DPO triples (stretch goal, not in initial implementation):**
+```jsonl
+{"type": "dpo", "input": "<prompt>", "chosen": "<gemini>", "rejected": "<local bad>"}
+```
+
+**Assembly logic:**
+1. Select gold entries (up to `max_examples_per_run * 0.5`)
+2. Select corrected entries (up to `max_examples_per_run * 0.2`)
+3. Sample replay entries from v7 base dataset (up to `max_examples_per_run * 0.3`)
+4. Shuffle with deterministic seed
+5. Write to `training/data/continuous_learning/batch_{request_id}.jsonl`
+6. Write manifest with counts, timestamp, data provenance
+
+### 3.5 Store Interface Additions
+
+```go
+// Curriculum generation
+UpdateExperienceCorrectedOutput(ctx context.Context, entryID string, output string, epr float64, fr float64, source string) error
+ListNeedsImprovement(ctx context.Context, limit int) ([]ExperienceEntry, error)
+GetLastCurriculumRunTime(ctx context.Context) (time.Time, error)
+SetLastCurriculumRunTime(ctx context.Context, t time.Time) error
+```
+
+---
+
+## 4. Phase C: Automated Training & Deployment
+
+Closes the loop. Model improves from its own experience.
+
+### 4.1 Training Request Protocol
+
+When metacognition detects `degrading` quality trend for 2+ consecutive audit
+cycles, OR when the user triggers training manually via MCP tool:
+
+**Step 1: Assemble manifest.**
+
+```json
+{
+    "request_id": "tr-20260415-001",
+    "timestamp": "2026-04-15T02:30:00Z",
+    "trigger": "quality_drift",
+    "experience_buffer_stats": {
+        "gold": 142,
+        "needs_improvement": 38,
+        "corrected": 27
+    },
+    "current_model": {
+        "base": "Qwen3.5-2B",
+        "spokes_checkpoint": "checkpoints/exp26_v7/best_spokes.pt",
+        "spokes_gguf": "models/qwen35-2b-spokes-f16.gguf",
+        "baseline_epr": 0.94,
+        "baseline_ted_rate": 0.0,
+        "baseline_sc_rate": 1.0,
+        "baseline_stress": 7
+    },
+    "training_data_path": "training/data/continuous_learning/batch_tr-20260415-001.jsonl",
+    "config_overrides": {}
+}
+```
+
+**Step 2:** Write to `~/.local/share/mnemonic/training_requests/pending.json`
+**Step 3:** Exit gracefully (clean shutdown, release VRAM)
+
+### 4.2 Systemd Integration
+
+**`mnemonic-train.path`** — watches for training requests:
+
+```ini
+[Unit]
+Description=Watch for Mnemonic training requests
+
+[Path]
+PathExists=%h/.local/share/mnemonic/training_requests/pending.json
+Unit=mnemonic-train.service
+
+[Install]
+WantedBy=default.target
+```
+
+**`mnemonic-train.service`** — runs training pipeline:
+
+```ini
+[Unit]
+Description=Mnemonic continuous learning training cycle
+After=mnemonic.service
+
+[Service]
+Type=oneshot
+ExecStart=%h/Projects/mem/training/scripts/continuous_train.sh
+TimeoutStartSec=1800
+Environment=PYTHONPATH=%h/Projects/mem/training/scripts
+WorkingDirectory=%h/Projects/mem
+```
+
+**`continuous_train.sh`** — orchestrator:
+
+```bash
+#!/bin/bash
+set -uo pipefail  # no -e: we handle errors via trap
+
+REQUEST_DIR="$HOME/.local/share/mnemonic/training_requests"
+REQUEST="$REQUEST_DIR/pending.json"
+RESULT="$REQUEST_DIR/result.json"
+LOG="$REQUEST_DIR/train_$(date +%Y%m%d%H%M%S).log"
+
+# CRITICAL: Always restart daemon, even on training failure
+cleanup() {
+    # Archive request (move out of watched path)
+    if [ -f "$REQUEST" ]; then
+        mv "$REQUEST" "$REQUEST_DIR/completed_$(date +%Y%m%d%H%M%S).json"
+    fi
+    # Restart daemon — this MUST happen regardless of training outcome
+    systemctl --user start mnemonic
+}
+trap cleanup EXIT
+
+# Ensure daemon is stopped (free VRAM)
+systemctl --user stop mnemonic || true
+
+# Run training with full logging
+# Exit code captured but not fatal — cleanup trap handles restart
+python3 training/scripts/continuous_train.py \
+    --request "$REQUEST" \
+    --result "$RESULT" \
+    2>&1 | tee "$LOG"
+```
+
+### 4.3 Training Script: `continuous_train.py`
+
+This is the most scrutinized file in the pipeline. It must be clean, explicit,
+and correct.
+
+**Structure:**
+
+```python
+def main(request_path: str, result_path: str) -> None:
+    # 1. Load and validate request
+    request = load_and_validate_request(request_path)
+
+    # 2. Assemble training data
+    dataset = assemble_training_mix(
+        data_path=request["training_data_path"],
+        replay_ratio=config.replay_ratio,      # 0.30
+        seed=config.seed,                       # 42
+    )
+    # Mix: 30% v7 replay, 50% gold, 20% corrective
+
+    # 3. Load model + spokes from checkpoint
+    model, spokes = load_checkpoint(
+        base=request["current_model"]["base"],
+        checkpoint=request["current_model"]["spokes_checkpoint"],
+    )
+
+    # 4. Train (SFT, reusing train_qwen_spokes.py infrastructure)
+    trainer = SpokeTrainer(
+        model=model,
+        spokes=spokes,
+        lr=config.lr,                          # 1e-4
+        max_steps=config.max_steps,            # 500
+        batch_size=1,
+        grad_accum=8,
+        gradient_checkpointing=True,
+        seed=config.seed,
+    )
+    train_metrics = trainer.train(dataset)
+
+    # 5. Quality gate
+    eval_results = run_quality_gate(
+        checkpoint=trainer.best_checkpoint,
+        gold_path="training/data/faithfulness_probe/gold_train.jsonl",
+        baseline=request["current_model"],
+    )
+
+    # 6. Pass/fail decision
+    passed = check_quality_gate(eval_results, request["current_model"])
+
+    # 7. Deploy or rollback
+    if passed:
+        deploy_spokes(trainer.best_checkpoint, request)
+        write_result(result_path, "deployed", train_metrics, eval_results)
+    else:
+        write_result(result_path, "rejected", train_metrics, eval_results)
+```
+
+**Training data mix:**
+
+| Source | Ratio | Purpose |
+|--------|-------|---------|
+| V7 base replay | 30% | Prevents catastrophic forgetting |
+| Gold examples | 50% | Reinforces good encoding behavior |
+| Corrective pairs | 20% | Learns from Gemini corrections |
+
+**Hyperparameter justification:**
+
+| Parameter | Value | Justification |
+|-----------|-------|---------------|
+| LR | 1e-4 | Conservative for incremental adaptation. EXP-25 used 1e-3 for initial training; 10x lower for continuous updates to prevent large weight swings. |
+| max_steps | 500 | EXP-25 proved 500 steps overfits 25 examples. For 50-200 mixed examples, 500 steps = 2-8 epochs. Enough to learn without severe overfitting. |
+| batch_size | 1, grad_accum 8 | Effective batch 8. Matches EXP-26 config. Limited by 16GB VRAM. |
+| replay_ratio | 0.30 | Standard anti-forgetting ratio from continual learning literature. Higher ratios waste capacity on already-learned data. Lower ratios risk forgetting. |
+| seed | 42 | Fixed for reproducibility. Every run with same data + same seed = same result. |
+
+### 4.4 Quality Gate
+
+Reuses existing evaluation infrastructure. Runs after training completes.
+
+**Steps:**
+1. Export temporary spokes GGUF via `export_qwen35_spokes.py`
+2. Start llama-server with temporary GGUF (port 8080)
+3. Run `eval_faithfulness.py` on 25 gold-standard probe inputs
+4. Run `stress_test_hallucination.py` (7 tests)
+5. Compare all metrics against baseline from training request
+
+**Pass criteria:**
+
+| Metric | Threshold | Rationale |
+|--------|-----------|-----------|
+| EPR | >= 90% | EXP-25 production target |
+| SC | >= 95% | Allow 1/25 edge case failure |
+| Stress test | >= 6/7 | Current production baseline |
+| No metric regression | <= 5pp vs baseline | Monotonic improvement enforced |
+
+**FR is NOT a gate criterion.** Consistent with classification decision —
+FR has >25% false positive rate on correct outputs.
+
+**On pass:**
+1. Export final spokes GGUF with version suffix: `{base}-spokes-cl{NNN}-f16.gguf`
+2. Quantize via `rotorq_quantize_gguf.py` (BetaQ RQ4)
+3. Update `config.yaml` spoke GGUF path
+4. Previous 3 versions retained for rollback
+
+**On fail:**
+1. Discard new spokes
+2. Log failure with full metrics to result file
+3. Daemon restarts with old spokes unchanged
+4. If 2 consecutive training failures -> escalate to user (metacognition)
+
+### 4.5 Spoke Deployment
+
+**Version naming:** `{base}-spokes-cl{NNN}-f16.gguf` where NNN is a
+monotonically increasing counter. Example: `qwen35-2b-spokes-cl001-f16.gguf`.
+
+**Deployment is atomic:**
+1. Write new GGUF to `models/` directory
+2. Quantize to RQ4 deployment GGUF
+3. Update `config.yaml` to point to new GGUF
+4. Old GGUF remains — rollback is changing the config back
+5. Keep last 3 versions; delete older ones during dreaming cleanup
+
+### 4.6 Manual Training Trigger (MCP Tool)
+
+**New tool:** `trigger_training`
+
+```
+trigger_training(reason: string) -> {request_id: string, status: string}
+```
+
+Allows manual training without waiting for quality drift detection. Uses the
+same flow: assemble manifest, write request file, signal daemon shutdown. Useful
+during development and pipeline validation.
+
+**Guard:** Requires `continuous_learning.trigger.manual = true` in config
+(default: true). Requires experience buffer to have >= `min_new_examples`
+entries not yet used in training.
+
+### 4.7 Configuration
+
+```yaml
+continuous_learning:
+  enabled: false                        # master switch, off by default
+  training:
+    min_new_examples: 50                # minimum experience entries before training
+    max_examples_per_run: 200           # cap batch size
+    replay_ratio: 0.30                  # fraction from v7 base dataset
+    replay_dataset: "training/data/finetune_qwen_v7/train.jsonl"  # populated by EXP-26; falls back to v6 if v7 not yet available
+    lr: 1.0e-4
+    max_steps: 500
+    seed: 42
+    quality_gate:
+      min_epr: 0.90
+      max_fr: 0.10                      # monitoring, lenient threshold
+      min_sc: 0.95
+      min_stress: 6                     # out of 7
+      max_regression_pp: 5              # no metric drops >5pp from baseline
+    rollback_versions: 3                # keep last N spoke versions
+  curriculum:
+    enabled: false                      # separate opt-in
+    max_corrections_per_cycle: 50
+    min_needs_improvement: 10           # minimum entries before running
+    cooldown_hours: 24                  # minimum between curriculum runs
+  trigger:
+    auto: false                         # metacognition auto-trigger
+    manual: true                        # MCP tool always available
+    training_window: "02:00-06:00"      # auto-trigger only during these hours
+```
+
+---
+
+## 5. Testing Strategy
+
+### 5.1 Phase A Tests
+
+**Unit tests (`internal/agent/encoding/verification_test.go`):**
+- EPR computation on EXP-25 gold inputs (25 cases)
+- TED detection on known template echo phrases
+- MIG detection on short inputs with long outputs
+- FR computation (monitoring correctness)
+
+**Parity test (critical):**
+- Run 25 EXP-25 gold inputs through both Python (`eval_faithfulness.py`) and Go
+  verification gate. EPR values must match within 0.01 tolerance. TED detection
+  must be identical. This ensures the Go port is faithful to the reference.
+
+**Store tests:**
+- CRUD for experience_buffer, recall_feedback tables
+- Reclassification logic with edge cases (boundary EPR values, exactly 3 recalls)
+
+**Integration test:**
+- Encode a raw memory through the full daemon pipeline. Verify verification
+  metrics appear on the resulting memory record.
+
+### 5.2 Phase B Tests
+
+**Unit tests:**
+- Curriculum trigger logic (minimum entries, cooldown)
+- Gemini output verification (mock Gemini responses)
+- Hard example mining heuristics (known failure patterns)
+- Training data assembly (correct ratios, deterministic shuffle)
+
+**Integration test:**
+- Populate experience buffer with known needs_improvement entries. Run
+  curriculum generation with mock Gemini provider. Verify corrected_output
+  is stored and entries are reclassified.
+
+### 5.3 Phase C Tests
+
+**Unit tests:**
+- Training request manifest generation (schema validation)
+- Quality gate pass/fail logic (boundary conditions)
+- No-regression check logic (5pp threshold)
+
+**Integration test (manual, requires GPU):**
+- End-to-end: populate experience buffer with 50+ entries, trigger training,
+  verify quality gate runs, verify spoke deployment or rollback.
+- This is a manual test because it requires GPU time (~15 min). Documented
+  as a runbook, not automated in CI.
+
+**Systemd tests (manual):**
+- Verify mnemonic-train.path activates on pending.json creation
+- Verify mnemonic-train.service runs and completes
+- Verify daemon restarts after training completes
+- Verify daemon comes back with old spokes on training failure
+
+---
+
+## 6. Risks and Mitigations
+
+| Risk | Impact | Mitigation | Phase |
+|------|--------|------------|-------|
+| Catastrophic forgetting | Model loses general ability | 30% replay ratio from v7 base | C |
+| Feedback noise | Bad ratings corrupt training signal | recall_count >= 3 guard before using feedback for classification | A |
+| Gemini unavailability | Can't generate corrections | Graceful skip; buffer corrections; train only when enough pairs exist | B |
+| Quality oscillation | Model improves then degrades | Quality gate with no-regression check; monotonic improvement enforced | C |
+| VRAM contention | Training conflicts with daemon | Daemon stops before training; systemd orchestrates | C |
+| Slow convergence | 50-100 examples per cycle insufficient | Configurable min_examples; manual force-train MCP tool | C |
+| EPR false negatives | Regex misses entities, underestimates quality | Parity test against Python reference; iterate on regex patterns | A |
+| Training crash at 3am | Daemon stays down | continuous_train.sh always restarts daemon in finally block; systemd restart-on-failure | C |
+
+---
+
+## 7. Success Criteria
+
+### Phase A (after 1 week of operation)
+- Every new encoding has EPR/FR/flags stored
+- Experience buffer is populating
+- Quality drift detection emitting observations
+- Verification metrics match Python eval_faithfulness.py within tolerance
+
+### Phase B (after 2 weeks of operation)
+- Curriculum generation runs during dreaming hours
+- At least 10 corrected outputs produced
+- Failure patterns identified and reported
+
+### Phase C (after 1 month of operation)
+- At least 2 successful training cycles completed
+- Quality gate correctly accepted/rejected models
+- Encoding EPR improved by >= 5pp over baseline
+- No quality regression on EXP-25 probes
+
+### Long-term (3-6 months)
+- >= 10 successful training cycles
+- Model handles new domains without quality drop
+- Recall `helpful` rate improved by >= 10pp
+- Encoding quality on user's actual inputs exceeds Gemini baseline
+
+---
+
+## 8. Dependencies
+
+| Dependency | Status | Blocks |
+|------------|--------|--------|
+| eval_faithfulness.py (7 metrics) | Complete (EXP-25) | Phase A (port to Go) |
+| EXP-25 probe data (25 gold inputs) | Complete | Phase A (parity test), Phase C (quality gate) |
+| Spoke training pipeline | Complete (train_qwen_spokes.py) | Phase C |
+| Spoke export pipeline | Complete (export_qwen35_spokes.py) | Phase C |
+| EXP-29 model selection | In progress | Phase C (which base model to train) |
+| V7 dataset (EXP-26) | Registered, awaiting data | Phase C (replay buffer) |
+| Gemini API provider | Configured | Phase B |
+| Dreaming agent | Complete (7 phases) | Phase B (extend) |
+| Metacognition agent | Complete (5 observations) | Phase A (extend) |
+
+---
+
+## 9. Relationship to Other Work
+
+- **EXP-29 (#390):** Selects the base model. Continuous learning is model-agnostic
+  but Phase C needs a trained checkpoint to start from.
+- **EXP-26 (#381):** Provides the v7 training data used as the replay buffer.
+- **EXP-28 (#386, Project Bespoke):** If pruning produces a better base model,
+  the continuous learning pipeline runs on top of it — they're complementary.
+- **#381 (faithfulness):** The verification framework (eval_faithfulness.py) is
+  the foundation of Phase A's verification gate.
+- **Felix-LM spokes:** The adapter architecture that makes hot-swap possible.
+  Continuous learning trains new spoke weights, not new base models.

--- a/internal/agent/encoding/DESIGN_logprob_detection.md
+++ b/internal/agent/encoding/DESIGN_logprob_detection.md
@@ -1,0 +1,113 @@
+# Logprob-Based Hallucination Detection — Design Document
+
+## Concept
+
+When a language model generates tokens that are grounded in the input (copying
+a name, number, or technical term), its confidence (logprob) is typically high.
+When it fabricates — inventing details from its training data rather than the
+input — confidence drops because multiple plausible completions compete.
+
+We can use per-token logprobs during encoding generation as a real-time
+hallucination signal, without needing a separate verification model or
+post-hoc check.
+
+## How it works
+
+### 1. Request logprobs from llama-server
+
+The `/completion` endpoint supports `logprobs: true` which returns the
+log probability of each generated token. Add to the completion request:
+
+```json
+{
+  "prompt": "...",
+  "n_predict": 2048,
+  "logprobs": true
+}
+```
+
+Response includes `completion_probabilities` array with per-token logprobs.
+
+### 2. Segment tokens by field
+
+Parse the generated JSON tokens into segments by field. For each content-bearing
+field (gist, summary, content, narrative), collect the logprobs of the tokens
+within that field's value.
+
+### 3. Compute confidence metrics per field
+
+For each field:
+- **Mean logprob:** Average confidence across all tokens in the field
+- **Min logprob:** Lowest-confidence token (potential fabrication point)
+- **Low-confidence token count:** Number of tokens with logprob < threshold
+  (e.g., < -3.0, which corresponds to ~5% probability)
+
+### 4. Flag suspicious fields
+
+If a content field has:
+- Mean logprob < -2.0 (average token has <14% probability)
+- OR >20% of tokens below the -3.0 threshold
+- OR min logprob < -5.0 (any single token with <1% probability)
+
+...flag it as potentially unfaithful.
+
+### 5. Cross-reference with input
+
+For flagged fields, check whether the low-confidence tokens correspond to
+entities that ARE in the input (grounded but uncertain) vs entities that
+are NOT in the input (likely hallucinated). This combines the logprob signal
+with the entity preservation check from the verification module.
+
+## Expected behavior
+
+| Scenario | Logprob pattern |
+|----------|----------------|
+| Copying "PostgreSQL" from input | High confidence — model saw it in context |
+| Fabricating "MySQL" not in input | Lower confidence — model is "choosing" from many options |
+| Template echoing "under 60 characters" | High confidence — common phrase from training |
+| Generating correct enum "routine" | High confidence — constrained choice |
+
+Note: Template echoing has HIGH logprobs (the phrases are common), so logprobs
+alone won't catch that failure mode. The post-hoc verification module handles
+template echoing via string matching.
+
+## Implementation considerations
+
+1. **llama-server API:** Verify that our custom fork returns logprobs in the
+   completion response. Standard llama.cpp does, but our spoke integration
+   may affect it.
+
+2. **Token-to-field mapping:** Need to map generated tokens back to JSON
+   field positions. This requires tracking the JSON structure during parsing,
+   not just the final parsed object.
+
+3. **Calibration:** The threshold values (-2.0, -3.0, -5.0) are hypothetical.
+   Need to calibrate against known-good and known-bad encodings from EXP-25
+   to find the real decision boundary.
+
+4. **Cost:** Reading logprobs adds no inference cost — they're computed during
+   generation regardless. The only cost is the additional data transfer and
+   parsing, which is negligible.
+
+## Prototype plan
+
+1. Run 25 EXP-25 probe inputs with `logprobs: true` on the current Qwen model
+2. For each, record per-field logprob distributions
+3. Compare the logprob patterns for fields we know are faithful vs fabricated
+4. If there's a clear separation, implement as a daemon feature
+
+## Relationship to other approaches
+
+- **Verification module:** Post-hoc check on the final output. Logprobs are
+  real-time during generation. Both catch hallucination but at different points.
+- **GBNF grammar:** Structural constraint. Logprobs are semantic quality.
+- **Constrained decoding:** Could combine — if logprob drops below threshold
+  during generation, backtrack and resample. This is speculative decoding
+  territory and much more complex.
+
+## Risk
+
+The main risk is that logprob patterns don't cleanly separate faithful vs
+fabricated content. If the model is confidently wrong (high logprob on
+fabricated text), the signal is useless. This needs empirical validation
+before implementation.

--- a/internal/agent/encoding/DESIGN_verification.md
+++ b/internal/agent/encoding/DESIGN_verification.md
@@ -1,0 +1,91 @@
+# Post-Hoc Encoding Verification — Design Document
+
+## Problem
+
+The encoding agent calls the LLM to compress raw observations into structured
+JSON. The LLM can hallucinate — fabricating entities, numbers, or details that
+weren't in the input. These fabrications propagate through the memory graph via
+associations, contaminating future recalls.
+
+EXP-25 (#381) identified three failure modes:
+1. **Content fabrication** — entities in output that aren't in input
+2. **Template echoing** — instruction text leaks into content fields  
+3. **Cross-contamination** — content from other memories bleeds in
+
+## Proposed Solution: Runtime Faithfulness Gate
+
+A lightweight verification step that runs AFTER LLM compression but BEFORE
+persistence. No additional LLM call needed — pure string matching.
+
+### Where it slots in
+
+```
+encodeMemory()
+  Step 2: compressAndExtractConcepts() → compressionResponse
+  Step 2b: verifyFaithfulness(raw, compression) → (pass bool, issues []string)  ← NEW
+  Step 3: Generate embedding
+  Steps 4-8: Persist
+```
+
+### What it checks
+
+1. **Entity Preservation (EP)** — Extract named entities (proper nouns, numbers,
+   file paths, version strings) from raw input. Check that >80% appear in the
+   compression's content-bearing fields (gist, summary, content, narrative).
+   Implementation: regex extraction matching eval_faithfulness.py patterns.
+
+2. **Fabrication Detection (FD)** — Extract entities from compression output.
+   Check that <20% are NOT in the raw input. High fabrication = hallucination.
+
+3. **Template Echo (TE)** — Check output against known instruction phrases
+   (the same list from eval_faithfulness.py's TEMPLATE_ECHO_PHRASES). If any
+   appear in content fields, the model echoed the prompt.
+
+4. **Minimal Input Guard (MIG)** — If raw input is <50 chars and compression
+   output content exceeds 300 chars, the model padded with hallucinated detail.
+
+### Behavior on failure
+
+- **Soft mode (default):** Log a warning with the specific issues. Still persist
+  the memory but tag it with `verification_failed: true` in metadata. This lets
+  metacognition review flagged encodings later.
+
+- **Hard mode (config toggle):** Reject the encoding and retry with a different
+  prompt strategy (e.g., add GBNF grammar constraint, or use the "faithful"
+  prompt variant). After 2 failed retries, persist with fallback compression.
+
+### Performance cost
+
+- Entity extraction: ~0.1ms per memory (regex on <8K chars)
+- No LLM call, no network, no VRAM
+- Adds negligible latency to the encoding pipeline
+
+### Implementation notes
+
+- Port the regex patterns from eval_faithfulness.py to Go
+- Share the TEMPLATE_ECHO_PHRASES list (already partially in training_constants.py)
+- The verification result could feed into salience: a memory with
+  verification issues gets salience reduced by 0.1-0.2
+- Metrics: track verification pass/fail rate in daemon stats (could surface
+  in the dashboard)
+
+## Relationship to other approaches
+
+- **GBNF grammar:** Prevents structural errors (invalid JSON, missing fields).
+  Verification prevents semantic errors (valid JSON with wrong content).
+  They're complementary.
+- **Logprob detection:** Catches hallucination during generation. Verification
+  catches it after generation. Both useful — logprobs for real-time, verification
+  for batch/retrospective.
+- **Prompt variants:** Better prompts reduce hallucination. Verification catches
+  what slips through regardless of prompt.
+
+## Open questions
+
+1. What EP threshold triggers a warning vs rejection? 80% is the eval target,
+   but runtime may need to be more lenient for short inputs.
+2. Should verification run on MCP-source memories? Those are explicit user input
+   and may contain content the model should expand on (semantic expansion is OK).
+3. Could we use the verification signal to auto-tune the prompt? If EP drops
+   below threshold, switch to the "faithful" prompt variant for subsequent
+   encodings until quality recovers.

--- a/internal/agent/encoding/agent.go
+++ b/internal/agent/encoding/agent.go
@@ -1217,53 +1217,61 @@ func (ea *EncodingAgent) compressAndExtractConcepts(ctx context.Context, raw sto
 }
 
 // buildCompressionPrompt constructs the LLM prompt for memory compression and concept extraction.
-// NOTE: The prompt deliberately avoids showing a JSON template because the local LLM model
-// echoes template placeholder text verbatim into the output fields. Structured output
-// (response_format with json_schema) enforces the JSON structure instead.
+//
+// Uses the "faithful" prompt format (EXP-29): rules-first design that leads with
+// FAITHFULNESS, PRESERVATION, MINIMALITY before the schema. This format produced
+// 99.6% EPR, 100% NP, 0.9% FR on the EXP-25 probe set — the best result across
+// all models and conditions tested.
+//
+// The previous verbose prompt (field-by-field descriptions, concept vocabulary,
+// coaching instructions) actively hurt faithfulness by confusing the model with
+// noise. See training/docs/experiment_registry.md EXP-29 for full data.
 func buildCompressionPrompt(content, source, memType, episodeCtx, coachingInstructions string, conceptVocabulary []string) string {
 	var b strings.Builder
 
 	if source == "ingest" {
-		b.WriteString(`Catalog this source code file. Describe what the file IS and DOES.
+		// Ingest (file cataloging) keeps its own prompt — different task.
+		b.WriteString(`TASK: Catalog this source code file into structured JSON.
 
-Fill in every JSON field based on the actual file content below:
-- gist: What this file is in under 60 characters.
-- summary: The file's purpose in under 100 characters.
-- content: A compressed description of what the file contains and how it works.
-- narrative: The file's role in the project architecture and why it matters.
-- concepts: 3-5 keywords describing the file's domain. PREFER exact terms from the vocabulary list below; only use new terms if no vocabulary term fits.
-- structured_concepts: Extract topics, entities, actions, and causal relationships. Keep each array to 3-5 items max. Use short strings, not sentences.
-- significance: One of routine, notable, important, or critical.
-- emotional_tone: neutral.
-- outcome: success.
-- salience: 0.7+ for core implementation, 0.5 for tests/utilities, 0.3 for generated files.
+RULES:
+- FAITHFULNESS: Every fact in your output must come from the file content. Do not infer, speculate, or add context from your training data.
+- PRESERVATION: Copy all function names, type names, file paths, import paths, and version strings VERBATIM from the file.
+- MINIMALITY: Describe what the file IS and DOES. Do not pad with generic filler.
+
+SCHEMA: {gist, summary, content, narrative, concepts, structured_concepts, significance, emotional_tone, outcome, salience}
+- gist: What this file is, under 60 characters
+- significance: routine | notable | important | critical
+- emotional_tone: neutral
+- outcome: success
+- salience: 0.7+ for core implementation, 0.5 for tests/utilities, 0.3 for generated files
+- structured_concepts: {topics: [{label, path}], entities: [{name, type, context}], actions: [{verb, object, details}], causality: [{relation, description}]}
+
+Output ONLY the JSON object. No explanation.
 
 `)
 	} else {
-		b.WriteString(`Encode this event into memory. Read the content below and summarize what actually happened.
+		// Event encoding — faithful prompt format from EXP-29.
+		b.WriteString(`TASK: Compress the following observation into structured JSON.
 
-Fill in every JSON field based on the actual event content below:
-- gist: What happened in under 60 characters.
-- summary: What happened and why it matters in under 100 characters.
-- content: The key details someone would need to understand this event later.
-- narrative: The story of what happened including context and meaning.
-- concepts: 3-5 keywords about the event. PREFER exact terms from the vocabulary list below; only use new terms if no vocabulary term fits.
-- structured_concepts: Extract topics, entities, actions, and causal relationships. Keep each array to 3-5 items max. Use short strings, not sentences.
-- significance: One of routine, notable, important, or critical.
-- emotional_tone: One of neutral, satisfying, frustrating, exciting, or concerning.
-- outcome: One of success, failure, ongoing, or unknown.
-- salience: 0.7+ for decisions/errors/insights, 0.5 for notable activity, 0.3 for routine file saves.
+RULES:
+- FAITHFULNESS: Every fact in your output must come from the input. Do not infer, speculate, or add context from your training data.
+- PRESERVATION: Copy all proper nouns, numbers, file paths, version strings, and technical identifiers VERBATIM from the input.
+- MINIMALITY: If the input is short, the output should be short. Do not pad with generic filler.
+
+SCHEMA: {gist, summary, content, narrative, concepts, structured_concepts, significance, emotional_tone, outcome, salience}
+- significance: routine | notable | important | critical
+- emotional_tone: neutral | satisfying | frustrating | exciting | concerning
+- outcome: success | failure | ongoing | unknown
+- salience: 0.0-1.0
+- structured_concepts: {topics: [{label, path}], entities: [{name, type, context}], actions: [{verb, object, details}], causality: [{relation, description}]}
+
+Output ONLY the JSON object. No explanation.
 
 `)
 	}
 
-	if len(conceptVocabulary) > 0 {
-		b.WriteString("IMPORTANT: Extract concepts from the CONTENT of the memory, not from what kind of memory it is. A decision about database indexing should have concepts like 'database', 'performance' — NOT 'decision'. Do NOT use metadata as concepts (e.g., 'source:mcp', 'type:insight', project names).\n\n")
-		b.WriteString("CONCEPT VOCABULARY — prefer terms from this list when they match the content topic. Invent a new term if no vocabulary term fits the actual subject matter:\n")
-		b.WriteString(strings.Join(conceptVocabulary, ", "))
-		b.WriteString("\n\n")
-	}
-
+	// Episode context and coaching are still appended if present —
+	// they provide per-memory context, not general instructions.
 	if episodeCtx != "" {
 		b.WriteString(episodeCtx)
 	}

--- a/internal/agent/encoding/config_behavior_test.go
+++ b/internal/agent/encoding/config_behavior_test.go
@@ -232,63 +232,62 @@ func TestConfigMaxSimilarSearchResultsPassedToStore(t *testing.T) {
 	}
 }
 
-func TestConfigConceptVocabularyIncludedInPrompt(t *testing.T) {
-	tests := []struct {
-		name           string
-		vocabulary     []string
-		expectInPrompt string
-	}{
-		{"custom_vocab", []string{"golang", "memory", "sqlite"}, "golang, memory, sqlite"},
-		{"empty_vocab", nil, ""},
+func TestFaithfulPromptFormatUsed(t *testing.T) {
+	// Verify the faithful prompt format (EXP-29) is used in the encoding pipeline.
+	// The faithful prompt leads with FAITHFULNESS, PRESERVATION, MINIMALITY rules
+	// and does NOT inject concept vocabulary (which hurt faithfulness in testing).
+	var capturedPrompt string
+
+	s := &mockStore{
+		getRawFn: func(_ context.Context, _ string) (store.RawMemory, error) {
+			return store.RawMemory{ID: "raw1", Content: "test content", Source: "mcp", Type: "decision"}, nil
+		},
+		writeMemoryFn: func(_ context.Context, _ store.Memory) error { return nil },
 	}
 
-	for _, tc := range tests {
-		t.Run(tc.name, func(t *testing.T) {
-			var capturedPrompt string
-
-			s := &mockStore{
-				getRawFn: func(_ context.Context, _ string) (store.RawMemory, error) {
-					return store.RawMemory{ID: "raw1", Content: "test content", Source: "mcp", Type: "decision"}, nil
-				},
-				writeMemoryFn: func(_ context.Context, _ store.Memory) error { return nil },
-			}
-
-			p := &mockLLMProvider{
-				completeFn: func(_ context.Context, req llm.CompletionRequest) (llm.CompletionResponse, error) {
-					for _, msg := range req.Messages {
-						if msg.Role == "user" {
-							capturedPrompt = msg.Content
-						}
-					}
-					return llm.CompletionResponse{
-						Content: `{"gist":"test","summary":"test","content":"test","narrative":"test","concepts":["test"],"salience":0.5,"significance":"routine","emotional_tone":"neutral","outcome":"success"}`,
-					}, nil
-				},
-				embedFn: func(_ context.Context, _ string) ([]float32, error) {
-					return []float32{0.1, 0.2, 0.3}, nil
-				},
-			}
-
-			cfg := DefaultConfig()
-			cfg.ConceptVocabulary = tc.vocabulary
-			agent := NewEncodingAgentWithConfig(s, p, testLogger(), cfg)
-			agent.bus = newMockBus()
-
-			err := agent.encodeMemory(context.Background(), "raw1")
-			if err != nil {
-				t.Fatalf("unexpected error: %v", err)
-			}
-
-			if tc.expectInPrompt != "" {
-				if !strings.Contains(capturedPrompt, tc.expectInPrompt) {
-					t.Errorf("expected vocabulary %q in prompt, not found", tc.expectInPrompt)
-				}
-			} else {
-				if strings.Contains(capturedPrompt, "CONCEPT VOCABULARY") {
-					t.Error("expected no vocabulary section in prompt with nil vocabulary")
+	p := &mockLLMProvider{
+		completeFn: func(_ context.Context, req llm.CompletionRequest) (llm.CompletionResponse, error) {
+			for _, msg := range req.Messages {
+				if msg.Role == "user" {
+					capturedPrompt = msg.Content
 				}
 			}
-		})
+			return llm.CompletionResponse{
+				Content: `{"gist":"test","summary":"test","content":"test","narrative":"test","concepts":["test"],"salience":0.5,"significance":"routine","emotional_tone":"neutral","outcome":"success"}`,
+			}, nil
+		},
+		embedFn: func(_ context.Context, _ string) ([]float32, error) {
+			return []float32{0.1, 0.2, 0.3}, nil
+		},
+	}
+
+	cfg := DefaultConfig()
+	cfg.ConceptVocabulary = []string{"golang", "memory", "sqlite"}
+	agent := NewEncodingAgentWithConfig(s, p, testLogger(), cfg)
+	agent.bus = newMockBus()
+
+	err := agent.encodeMemory(context.Background(), "raw1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Faithful prompt rules must be present
+	if !strings.Contains(capturedPrompt, "FAITHFULNESS") {
+		t.Error("expected FAITHFULNESS rule in prompt")
+	}
+	if !strings.Contains(capturedPrompt, "PRESERVATION") {
+		t.Error("expected PRESERVATION rule in prompt")
+	}
+	if !strings.Contains(capturedPrompt, "MINIMALITY") {
+		t.Error("expected MINIMALITY rule in prompt")
+	}
+
+	// Concept vocabulary should NOT be injected (EXP-29 showed it hurts faithfulness)
+	if strings.Contains(capturedPrompt, "CONCEPT VOCABULARY") {
+		t.Error("concept vocabulary should not be in faithful prompt — it hurts faithfulness (EXP-29)")
+	}
+	if strings.Contains(capturedPrompt, "golang, memory, sqlite") {
+		t.Error("concept vocabulary terms should not appear in prompt")
 	}
 }
 

--- a/training/docs/experiment_registry.md
+++ b/training/docs/experiment_registry.md
@@ -1103,5 +1103,67 @@ Rotation parameter overhead per layer (rank=64):
 - **Hardware:** Local RX 7800 XT only. No MI300X needed.
 - **Estimated time:** ~4-6 hours (download GGUFs + 6 models x 2 conditions x 25 inputs x ~30-60s per encoding).
 - **Tracking:** GitHub issue #390 (informs #386 Project Bespoke and EXP-26)
-- **Result:** (pending)
-- **Verdict:** (pending)
+
+#### Results
+
+**Critical methodology note:** Initial runs used `/completion` endpoint (raw prompt, no chat template) — produced near-zero valid output. All models require `/v1/chat/completions` with `chat_template_kwargs.enable_thinking: false` for structured output. Rule added at `.claude/rules/llm-inference.md`.
+
+**Zero-shot (Q8_0, chat completions, thinking disabled):**
+
+| Model | Valid JSON | SC | EPR | FR | NP | TED | CCS | MIH | tok/s |
+|-------|-----------|-----|------|-----|------|-----|------|------|-------|
+| Qwen 3.5 0.8B | 24/25 | 0/24 | 74.4% | 11.3% | 72.0% | 0 | 3/3 | 0/3 | ~167 |
+| Qwen 3.5 2B | 4/25 | 0/4 | 70.6% | 0.0% | 69.2% | 0 | - | - | ~135 |
+| **Qwen 3.5 4B** | 22/25 | 0/22 | **87.2%** | 10.3% | **87.1%** | 0 | 3/3 | 0/2 | ~135 |
+| Nemotron 3 Nano 4B | 6/25 | 0/6 | 69.2% | 3.8% | 71.8% | 0 | - | - | ~90 |
+| **Gemma 4 E2B** | **25/25** | 0/25 | 75.1% | 8.5% | 73.3% | 0 | 3/3 | 0/3 | ~100 |
+| Gemma 4 E4B | 25/25 | 0/25 | 57.8% | 11.6% | 54.1% | 0 | 3/3 | 0/3 | ~100 |
+
+**3-shot (Q8_0, top 3 candidates):**
+
+| Model | Valid JSON | SC | EPR | FR | NP | CCS | MIH | tok/s |
+|-------|-----------|-----|------|-----|------|------|------|-------|
+| **Qwen 3.5 4B** | 18/25 | 9/18 (50%) | **94.7%** | 14.2% | **95.6%** | 3/3 | 1/3 | ~69 |
+| **Gemma 4 E2B** | 24/25 | **21/24 (88%)** | 82.5% | 6.8% | 82.6% | 3/3 | 2/3 | ~100 |
+| Nemotron 3 Nano 4B | 15/25 | 10/15 (67%) | 92.3% | 6.3% | 93.1% | 2/2 | 2/3 | ~88 |
+
+**GBNF constrained decoding (Qwen 3.5 4B, zero-shot + grammar via chat completions):**
+
+| Metric | Without grammar | With grammar |
+|--------|----------------|-------------|
+| Valid JSON | 22/25 | 10/25 |
+| SC (of valid) | 0% | 50% |
+| NP (dense) | 0% | 54.4% |
+
+Grammar improves SC and dense-number handling when it works, but template interaction reduces valid output rate (10/25 vs 22/25). Engineering work needed for production deployment.
+
+#### FR Metric Calibration
+
+Manual audit of all 41 "fabricated" entities across 3-shot results: **~90% are false positives**. ~80% are verb synonyms ("Decided" → "Selected"), ~15% are regex matching artifacts, ~5% are true fabrication. **True fabrication rate is ~1-2% across all models, not the 6-14% the metric reports.** FR metric needs lemmatization or verb exclusion. This limitation applies to all reported FR values.
+
+#### Key Findings
+
+1. **SC is 0% zero-shot across ALL models** — no model produces fully schema-compliant output without examples or grammar. GBNF grammar or fine-tuning required.
+2. **Qwen 3.5 4B leads on faithfulness** — highest EPR (87.2% zero-shot, 94.7% 3-shot) and NP (87.1%, 95.6%). Best at preserving what's in the input.
+3. **Gemma 4 E2B leads on reliability** — 25/25 valid JSON zero-shot, 24/25 3-shot, 88% SC 3-shot. Never fails to produce parseable output.
+4. **Nemotron 3 Nano 4B has lowest true fabrication** but only 6/25 valid zero-shot (fails on out-of-domain content). Highest learning delta from examples (+23pp EPR zero-shot to 3-shot).
+5. **Gemma 4 E4B underperformed E2B** — larger model was worse (57.8% vs 75.1% EPR). Size doesn't help for this architecture.
+6. **Qwen 3.5 2B (current base) was worst without spokes** — 4/25 valid. Confirms EXP-25's finding that fine-tuning/spokes are essential.
+7. **Dense number preservation is universally broken** — all models, all conditions, except GBNF grammar (54.4%). Needs targeted training data.
+8. **4B-class did NOT consistently beat 2B-class** on EPR (avg 71.4% vs 73.4%). Architecture and pretraining matter more than raw size in this range.
+
+#### Category-Level Analysis (zero-shot)
+
+| Category | Gemma E2B | Qwen 4B | Nemotron 4B |
+|----------|-----------|---------|-------------|
+| out-of-domain (8) | 8/8, 76.6% EPR | 8/8, 82.8% EPR | 2/8 valid |
+| adversarial-twin (6) | 6/6, 82.6% EPR | 6/6, **95.9% EPR** | 1/6 valid |
+| dense-numbers (2) | 2/2, 34.2% EPR | 1/2, 57.5% EPR | 0/2 valid |
+| minimal (3) | 3/3, 100% EPR | 2/3, 100% EPR | 0/3 valid |
+| edge (6) | 6/6, 67.0% EPR | 5/6, 84.8% EPR | 3/6, 83.1% EPR |
+
+Nemotron failures are concentrated in out-of-domain and non-tech content. On tech-domain inputs, it's competitive.
+
+- **Prediction assessment:** Nemotron's structured output training did NOT translate to higher SC (still 0%). Larger models did NOT consistently beat smaller ones. DeltaNet models (Qwen) performed comparably to dense attention (Gemma). The exploratory framing was appropriate — no strong directional prediction held.
+- **Verdict:** PARTIALLY CONFIRMED — multiple candidates demonstrated meaningful encoding quality (EPR >60%, valid JSON >80%), but SC >50% was only achieved with 3-shot examples, not zero-shot. The null hypothesis (pretraining doesn't matter) is REFUTED: Gemma E2B's 25/25 reliability vs Qwen 2B's 4/25 shows pretraining makes a large difference in robustness. However, the v7 training data remains essential — no model achieves target EPR (>90%) or SC (100%) without fine-tuning.
+- **Recommendation:** Fine-tune both Gemma 4 E2B (reliability) and Qwen 3.5 4B (faithfulness) on v7 data and compare. The winner becomes the production encoding model. GBNF grammar should be deployed alongside for structural enforcement. Continuous learning (issue #391) provides the mechanism for ongoing improvement.

--- a/training/docs/experiment_registry.md
+++ b/training/docs/experiment_registry.md
@@ -1038,3 +1038,70 @@ Rotation parameter overhead per layer (rank=64):
 - **Go/no-go gate:** After Phase 2 pruning to 2B: if quality < EXP-26 on >2 faithfulness metrics, STOP. The 31B doesn't provide better subnetworks for this task than the native 2B.
 - **Result:** (pending)
 - **Verdict:** (pending)
+
+### EXP-29: Candidate Model Evaluation — Zero-Shot Encoding Faithfulness Bake-Off
+
+- **Date:** 2026-04-10
+- **Status:** REGISTERED
+- **Hypothesis:** Among 2026-released sub-4B models, at least one candidate will demonstrate meaningful zero-shot or few-shot encoding faithfulness (EPR >60%, SC >50%) on mnemonic's production encoding task, indicating its pretraining provides a stronger foundation for fine-tuning than the current Qwen 3.5 2B base.
+- **Null hypothesis:** No 2026 sub-4B model achieves usable encoding quality without task-specific fine-tuning. Pretraining differences are negligible for this narrow task — the training data (v7) is the dominant factor, and the base model choice is secondary.
+- **Variable:** Base model identity. Six candidates from three architecture families, tested under identical conditions.
+- **Control:** Qwen 3.5 2B (current base model, tested without spokes — raw baseline).
+- **Prediction:** Models with explicit structured output training (Nemotron 3 Nano 4B — RL-trained on JSON/XML) or larger parameter counts (4B class) will score higher on SC and EPR than 2B-class models. DeltaNet models (Qwen 3.5 family) may struggle with long structured output due to linear attention's limited precision on exact token reproduction. Exploratory — no strong directional prediction on which architecture family wins.
+
+#### Candidates
+
+| # | Model | Released | Params | Architecture | License | GGUF Source |
+|---|-------|----------|--------|-------------|---------|-------------|
+| 1 | Qwen 3.5 0.8B | 2026-03-02 | 0.8B | Hybrid DeltaNet (3:1 linear:full attn) | Apache 2.0 | unsloth/Qwen3.5-0.8B-GGUF |
+| 2 | Qwen 3.5 2B | 2026-03-02 | 2B | Hybrid DeltaNet (3:1 linear:full attn) | Apache 2.0 | unsloth/Qwen3.5-2B-GGUF |
+| 3 | Qwen 3.5 4B | 2026-03-02 | 4B | Hybrid DeltaNet (3:1 linear:full attn) | Apache 2.0 | unsloth/Qwen3.5-4B-GGUF |
+| 4 | Nemotron 3 Nano 4B | 2026-03-17 | 4B | Hybrid Mamba-2 + Transformer (21 SSM + 4 attn + 17 MLP) | NVIDIA Open | nvidia/NVIDIA-Nemotron-3-Nano-4B-GGUF |
+| 5 | Gemma 4 E2B | 2026-04-02 | ~2B eff | PLE (Per-Layer Embedding) | Apache 2.0 | unsloth/gemma-4-E2B-it-GGUF |
+| 6 | Gemma 4 E4B | 2026-04-02 | ~4B eff | PLE (Per-Layer Embedding) | Apache 2.0 | unsloth/gemma-4-E4B-it-GGUF |
+
+- **Candidate selection criteria:** Released 2026 (January or later), <5B total params, fits 16GB VRAM at Q8_0, permissive license (Apache 2.0 or commercial-OK), GGUF available for llama.cpp, dense or near-dense architecture.
+- **Exhaustive search performed:** MiniMax (no sub-4B), DeepSeek (no sub-4B), GLM-5 (744B MoE only), Cohere Tiny Aya (CC-BY-NC, non-commercial), Falcon 3 (Dec 2024), Falcon-E (Apr 2025), OLMo 2 (2025), Phi-4-mini (2025), SmolLM3 (Jul 2025), Ministral 3 (Dec 2025), Qwen3-Coder-Next (80B total, exceeds VRAM). None qualified.
+
+#### Evaluation Protocol
+
+- **Test set:** 25 gold-standard probe inputs from EXP-25 (`training/data/faithfulness_probe/gold_train.jsonl`). Covers: out-of-domain (recipe, legal, medical, sports), adversarial twins (3 pairs), minimal inputs (3), dense-number inputs (2), production-format (handoff notes, monitoring alerts, code reviews).
+- **Metrics:** All 7 from #381 faithfulness framework:
+  - EPR (Entity Preservation Rate) — target >90%
+  - FR (Fabrication Rate) — target <5%
+  - TED (Template Echo Detection) — target 0%
+  - CCS (Cross-Contamination Score) — target <0.7 for twin pairs
+  - MIH (Minimal Input Handling) — target 3/3
+  - NP (Number Preservation) — target >95%
+  - SC (Schema Compliance) — target 100%
+- **Evaluation tool:** `training/scripts/eval_faithfulness.py --gold gold_train.jsonl --server http://127.0.0.1:8080`
+- **Quantization:** Q8_0 for primary eval (quality ceiling), Q4_K_M for secondary (deployment-realistic). Both from Unsloth/NVIDIA GGUF repos.
+- **Conditions per model:**
+  1. **Zero-shot:** Production encoding prompt from `build_production_prompt()` only. No examples in context.
+  2. **3-shot:** Same prompt + 3 gold-standard input/output examples prepended (1 out-of-domain, 1 minimal, 1 production-format).
+- **Inference:** llama-server on RX 7800 XT, temperature 0.3, n_predict 2048, stop ["\n\n\n"]. One model at a time (full VRAM available).
+- **Prompt format:** Each model uses its native chat template. System message = production encoding prompt. User message = raw input. This matches how the daemon would invoke each model.
+- **Secondary metrics:** Inference throughput (tok/s), VRAM usage (rocm-smi), time-to-first-token, total encoding latency per input.
+
+#### Analysis Plan
+
+1. Rank candidates by composite score: SC weight 0.3, EPR weight 0.3, FR weight 0.2 (inverted), NP weight 0.1, TED/CCS/MIH pass/fail.
+2. For each architecture family, compare 2B-class vs 4B-class to measure scaling effect.
+3. Compare zero-shot vs 3-shot delta per model — large improvement from examples suggests the model is more responsive to in-context learning (good signal for fine-tuning).
+4. Report all metrics for all models — no cherry-picking.
+
+#### Decision Gate
+
+| Outcome | Action |
+|---------|--------|
+| A candidate scores SC >80% and EPR >70% zero-shot | Strong signal — prioritize this model for v7 fine-tuning (may replace Qwen as base) |
+| Best candidate scores SC 50-80%, EPR 40-70% | Moderate signal — fine-tune top 2-3 candidates on v7 data and re-evaluate |
+| All candidates score SC <50% zero-shot | Null hypothesis supported — pretraining doesn't help much. Proceed with EXP-26 (Qwen + v7 data) |
+| 4B-class consistently beats 2B-class by >15% on EPR | Size matters for this task — evaluate VRAM/speed tradeoff for 4B deployment |
+
+- **Config:** llama-server (llama.cpp, ROCm build), RX 7800 XT 16GB, Q8_0 and Q4_K_M GGUF.
+- **Hardware:** Local RX 7800 XT only. No MI300X needed.
+- **Estimated time:** ~4-6 hours (download GGUFs + 6 models x 2 conditions x 25 inputs x ~30-60s per encoding).
+- **Tracking:** GitHub issue #390 (informs #386 Project Bespoke and EXP-26)
+- **Result:** (pending)
+- **Verdict:** (pending)

--- a/training/docs/experiment_registry.md
+++ b/training/docs/experiment_registry.md
@@ -1165,5 +1165,26 @@ Manual audit of all 41 "fabricated" entities across 3-shot results: **~90% are f
 Nemotron failures are concentrated in out-of-domain and non-tech content. On tech-domain inputs, it's competitive.
 
 - **Prediction assessment:** Nemotron's structured output training did NOT translate to higher SC (still 0%). Larger models did NOT consistently beat smaller ones. DeltaNet models (Qwen) performed comparably to dense attention (Gemma). The exploratory framing was appropriate — no strong directional prediction held.
-- **Verdict:** PARTIALLY CONFIRMED — multiple candidates demonstrated meaningful encoding quality (EPR >60%, valid JSON >80%), but SC >50% was only achieved with 3-shot examples, not zero-shot. The null hypothesis (pretraining doesn't matter) is REFUTED: Gemma E2B's 25/25 reliability vs Qwen 2B's 4/25 shows pretraining makes a large difference in robustness. However, the v7 training data remains essential — no model achieves target EPR (>90%) or SC (100%) without fine-tuning.
-- **Recommendation:** Fine-tune both Gemma 4 E2B (reliability) and Qwen 3.5 4B (faithfulness) on v7 data and compare. The winner becomes the production encoding model. GBNF grammar should be deployed alongside for structural enforcement. Continuous learning (issue #391) provides the mechanism for ongoing improvement.
+#### Prompt Ablation Results (Qwen 3.5 4B, zero-shot)
+
+| Prompt Variant | Valid JSON | EPR | FR | NP | NP (dense) |
+|---------------|-----------|------|-----|------|-----------|
+| Production | 22/25 | 87.2% | 10.3% | 87.1% | 0% |
+| Minimal | 25/25 | 92.7% | 7.4% | 95.2% | 100% |
+| Field-by-field | 25/25 | 97.3% | 9.1% | 99.0% | 100% |
+| **Faithful** | **25/25** | **99.6%** | **0.9%** | **100%** | **100%** |
+
+The faithful prompt (rules-first: FAITHFULNESS, PRESERVATION, MINIMALITY before schema) outperformed every other condition in the entire evaluation. All three alternative prompts beat the production prompt AND 3-shot examples.
+
+#### Cross-Model Faithful Prompt Comparison
+
+| Model + Faithful | Valid JSON | EPR | FR | NP | tok/s |
+|-----------------|-----------|------|-----|------|-------|
+| Qwen 3.5 4B | 25/25 | 99.6% | 0.9% | 100% | ~70 |
+| **Gemma 4 E2B** | 24/25 | **100%** | 2.4% | **100%** | **~101** |
+
+Gemma E2B matches Qwen 4B on faithfulness while being 44% faster. The faithful prompt erased the 12pp EPR gap between models that existed with the production prompt.
+
+- **Status:** COMPLETED
+- **Verdict:** CONFIRMED with unexpected finding. Multiple candidates exceeded EPR >60% (confirming the hypothesis), and the null hypothesis is REFUTED (pretraining matters — Gemma E2B 25/25 vs Qwen 2B 4/25). **But the dominant finding is that prompting strategy matters more than model choice.** The faithful prompt on Gemma E2B (100% EPR) outperformed the production prompt on Qwen 4B + 3-shot (94.7% EPR). This confirms the LLMStructBench result (arXiv:2602.14743).
+- **Recommendation:** Deploy **Gemma 4 E2B + faithful prompt** as the production encoding model. Fine-tuning (EXP-26) should target SC enforcement and FR reduction, not EPR/NP (already at 100%). GBNF grammar for structural enforcement. Continuous learning (issue #391) for ongoing improvement. The faithful prompt has been deployed to the daemon (`buildCompressionPrompt()` rewritten on `feat/exp29-candidate-eval`).

--- a/training/scripts/run_exp29_bakeoff.py
+++ b/training/scripts/run_exp29_bakeoff.py
@@ -286,9 +286,12 @@ def generate_encoding(
     user_content = f"SOURCE: {source}\nTYPE: {mem_type}\nCONTENT:\n{raw_input}"
     messages.append({"role": "user", "content": user_content})
 
+    # Thinking mode needs more tokens for reasoning + JSON output
+    max_tokens = 4096 if enable_thinking else 2048
+
     payload = {
         "messages": messages,
-        "max_tokens": 2048,
+        "max_tokens": max_tokens,
         "temperature": 0.3,
         "stop": ["\n\n\n"],
         "chat_template_kwargs": {"enable_thinking": enable_thinking},
@@ -346,6 +349,7 @@ def run_model_eval(
     quant: str,
     few_shot: int = 0,
     use_grammar: bool = False,
+    enable_thinking: bool = False,
 ) -> dict | None:
     """Run evaluation for a single model. Returns results dict or None on failure."""
     model_info = CANDIDATES[model_key]
@@ -359,13 +363,20 @@ def run_model_eval(
         print(f"  GGUF not found: {model_path}")
         return None
 
-    grammar_tag = "+grammar" if use_grammar else ""
+    tags = []
+    if use_grammar:
+        tags.append("grammar")
+    if enable_thinking:
+        tags.append("thinking")
+    tag_str = "+" + "+".join(tags) if tags else ""
     print(f"\n{'='*70}")
-    print(f"Evaluating: {model_info['name']} ({quant}{grammar_tag})")
+    print(f"Evaluating: {model_info['name']} ({quant}{tag_str})")
     print(f"  File: {gguf_file}")
     print(f"  Few-shot: {few_shot}")
     if use_grammar:
         print(f"  Grammar: GBNF encoding schema (enum-constrained)")
+    if enable_thinking:
+        print(f"  Thinking: enabled (reasoning before output)")
     print(f"{'='*70}")
 
     # Load gold data
@@ -391,6 +402,7 @@ def run_model_eval(
             output, metadata = generate_encoding(
                 raw_input, source, mem_type, few_shot_examples,
                 use_grammar=use_grammar,
+                enable_thinking=enable_thinking,
             )
 
             if output:
@@ -424,8 +436,13 @@ def run_model_eval(
         # Save results
         RESULTS_DIR.mkdir(parents=True, exist_ok=True)
         condition = f"{few_shot}shot" if few_shot > 0 else "0shot"
-        grammar_suffix = "_grammar" if use_grammar else ""
-        result_file = RESULTS_DIR / f"{model_key}_{quant}_{condition}{grammar_suffix}.json"
+        suffix_parts = []
+        if use_grammar:
+            suffix_parts.append("grammar")
+        if enable_thinking:
+            suffix_parts.append("thinking")
+        suffix = "_" + "_".join(suffix_parts) if suffix_parts else ""
+        result_file = RESULTS_DIR / f"{model_key}_{quant}_{condition}{suffix}.json"
         with open(result_file, "w") as f:
             json.dump(evaluation, f, indent=2, default=str)
         print(f"\n  Results saved: {result_file}")
@@ -551,6 +568,11 @@ def main():
         action="store_true",
         help="Enable GBNF grammar constraint for schema enforcement",
     )
+    parser.add_argument(
+        "--thinking",
+        action="store_true",
+        help="Enable thinking/reasoning mode (model generates chain-of-thought before answer)",
+    )
     args = parser.parse_args()
 
     if args.report_only:
@@ -562,7 +584,9 @@ def main():
     all_results = []
     for model_key in models:
         result = run_model_eval(
-            model_key, args.quant, args.few_shot, use_grammar=args.grammar,
+            model_key, args.quant, args.few_shot,
+            use_grammar=args.grammar,
+            enable_thinking=args.thinking,
         )
         if result:
             all_results.append(result)

--- a/training/scripts/run_exp29_bakeoff.py
+++ b/training/scripts/run_exp29_bakeoff.py
@@ -267,7 +267,10 @@ def generate_encoding(
 
     # Use /v1/chat/completions for all modes — grammar field is supported
     # (undocumented but confirmed in llama.cpp server-common.cpp line 918)
-    system_prompt = build_production_prompt("", source=source, mem_type=mem_type)
+    if prompt_variant == "production":
+        system_prompt = build_production_prompt("", source=source, mem_type=mem_type)
+    else:
+        system_prompt = build_prompt_variant("", variant=prompt_variant, source=source, mem_type=mem_type)
 
     messages = [{"role": "system", "content": system_prompt}]
 
@@ -407,6 +410,7 @@ def run_model_eval(
                 raw_input, source, mem_type, few_shot_examples,
                 use_grammar=use_grammar,
                 enable_thinking=enable_thinking,
+                prompt_variant=prompt_variant,
             )
 
             if output:
@@ -445,6 +449,8 @@ def run_model_eval(
             suffix_parts.append("grammar")
         if enable_thinking:
             suffix_parts.append("thinking")
+        if prompt_variant != "production":
+            suffix_parts.append(prompt_variant)
         suffix = "_" + "_".join(suffix_parts) if suffix_parts else ""
         result_file = RESULTS_DIR / f"{model_key}_{quant}_{condition}{suffix}.json"
         with open(result_file, "w") as f:
@@ -597,6 +603,7 @@ def main():
             model_key, args.quant, args.few_shot,
             use_grammar=args.grammar,
             enable_thinking=args.thinking,
+            prompt_variant=args.prompt_variant,
         )
         if result:
             all_results.append(result)

--- a/training/scripts/run_exp29_bakeoff.py
+++ b/training/scripts/run_exp29_bakeoff.py
@@ -35,7 +35,7 @@ from pathlib import Path
 import requests
 
 sys.path.insert(0, str(Path(__file__).resolve().parent))
-from training_constants import build_production_prompt  # noqa: E402
+from training_constants import build_production_prompt, build_prompt_variant  # noqa: E402
 from eval_faithfulness import (  # noqa: E402
     evaluate_dataset,
     parse_json_response,
@@ -254,6 +254,7 @@ def generate_encoding(
     few_shot_examples: list[dict] | None = None,
     enable_thinking: bool = False,
     use_grammar: bool = False,
+    prompt_variant: str = "production",
 ) -> tuple[dict | None, dict]:
     """Generate an encoding via the chat completions API (or /completion with grammar).
 
@@ -350,6 +351,7 @@ def run_model_eval(
     few_shot: int = 0,
     use_grammar: bool = False,
     enable_thinking: bool = False,
+    prompt_variant: str = "production",
 ) -> dict | None:
     """Run evaluation for a single model. Returns results dict or None on failure."""
     model_info = CANDIDATES[model_key]
@@ -368,6 +370,8 @@ def run_model_eval(
         tags.append("grammar")
     if enable_thinking:
         tags.append("thinking")
+    if prompt_variant != "production":
+        tags.append(prompt_variant)
     tag_str = "+" + "+".join(tags) if tags else ""
     print(f"\n{'='*70}")
     print(f"Evaluating: {model_info['name']} ({quant}{tag_str})")
@@ -572,6 +576,12 @@ def main():
         "--thinking",
         action="store_true",
         help="Enable thinking/reasoning mode (model generates chain-of-thought before answer)",
+    )
+    parser.add_argument(
+        "--prompt-variant",
+        choices=["production", "minimal", "field_by_field", "faithful"],
+        default="production",
+        help="Prompt variant (default: production)",
     )
     args = parser.parse_args()
 

--- a/training/scripts/run_exp29_bakeoff.py
+++ b/training/scripts/run_exp29_bakeoff.py
@@ -1,0 +1,504 @@
+#!/usr/bin/env python3
+"""EXP-29: Candidate model evaluation bake-off.
+
+Runs each candidate model through the faithfulness evaluation framework
+from EXP-25 (#381). Models are loaded one at a time via llama-server,
+evaluated on 25 gold-standard probe inputs, and results are collected
+into a comparative report.
+
+Usage:
+    # Run all candidates at Q8_0
+    python run_exp29_bakeoff.py --quant Q8_0
+
+    # Run a single model
+    python run_exp29_bakeoff.py --model qwen35-2b --quant Q8_0
+
+    # Run with 3-shot examples
+    python run_exp29_bakeoff.py --quant Q8_0 --few-shot 3
+
+    # Just generate the comparison report from existing results
+    python run_exp29_bakeoff.py --report-only
+"""
+
+import argparse
+import json
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+import requests
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+from training_constants import build_production_prompt  # noqa: E402
+from eval_faithfulness import (  # noqa: E402
+    evaluate_dataset,
+    parse_json_response,
+    print_report,
+)
+
+# --- Model registry ---
+
+MODELS_DIR = Path(__file__).resolve().parent.parent.parent / "models"
+GOLD_PATH = (
+    Path(__file__).resolve().parent.parent
+    / "data"
+    / "faithfulness_probe"
+    / "gold_train.jsonl"
+)
+RESULTS_DIR = Path(__file__).resolve().parent.parent / "data" / "exp29_results"
+
+CANDIDATES = {
+    "qwen35-0.8b": {
+        "name": "Qwen 3.5 0.8B",
+        "family": "qwen",
+        "params": "0.8B",
+        "files": {
+            "Q8_0": "Qwen3.5-0.8B-Q8_0.gguf",
+            "Q4_K_M": "Qwen3.5-0.8B-Q4_K_M.gguf",
+        },
+    },
+    "qwen35-2b": {
+        "name": "Qwen 3.5 2B",
+        "family": "qwen",
+        "params": "2B",
+        "files": {
+            "Q8_0": "Qwen3.5-2B-Q8_0.gguf",
+            "Q4_K_M": "Qwen3.5-2B-Q4_K_M.gguf",
+        },
+    },
+    "qwen35-4b": {
+        "name": "Qwen 3.5 4B",
+        "family": "qwen",
+        "params": "4B",
+        "files": {
+            "Q8_0": "Qwen3.5-4B-Q8_0.gguf",
+            "Q4_K_M": "Qwen3.5-4B-Q4_K_M.gguf",
+        },
+    },
+    "nemotron-4b": {
+        "name": "Nemotron 3 Nano 4B",
+        "family": "nemotron",
+        "params": "4B",
+        "files": {
+            "Q8_0": "NVIDIA-Nemotron-3-Nano-4B-Q8_0.gguf",
+            "Q4_K_M": "NVIDIA-Nemotron-3-Nano-4B-Q4_K_M.gguf",
+        },
+    },
+    "gemma4-e2b": {
+        "name": "Gemma 4 E2B",
+        "family": "gemma",
+        "params": "~2B",
+        "files": {
+            "Q8_0": "gemma-4-E2B-it-Q8_0.gguf",
+            "Q4_K_M": "gemma-4-E2B-it-Q4_K_M.gguf",
+        },
+    },
+    "gemma4-e4b": {
+        "name": "Gemma 4 E4B",
+        "family": "gemma",
+        "params": "~4B",
+        "files": {
+            "Q8_0": "gemma-4-E4B-it-Q8_0.gguf",
+            "Q4_K_M": "gemma-4-E4B-it-Q4_K_M.gguf",
+        },
+    },
+}
+
+# Few-shot examples: indices into gold_train.jsonl
+# Chosen to cover: out-of-domain (#1 recipe), minimal (#15), production (#22 handoff)
+FEW_SHOT_IDS = [1, 15, 22]
+
+SERVER_PORT = 8080
+SERVER_URL = f"http://127.0.0.1:{SERVER_PORT}"
+LLAMA_SERVER = os.environ.get(
+    "LLAMA_SERVER",
+    str(Path(__file__).resolve().parent.parent.parent / "third_party" / "llama.cpp" / "build" / "bin" / "llama-server"),
+)
+
+
+def find_llama_server() -> str:
+    """Find llama-server binary."""
+    candidates = [
+        LLAMA_SERVER,
+        os.path.expanduser("~/Projects/mem/third_party/llama.cpp/build/bin/llama-server"),
+        "/usr/local/bin/llama-server",
+        "llama-server",
+    ]
+    for path in candidates:
+        if os.path.isfile(path) and os.access(path, os.X_OK):
+            return path
+    # Try PATH
+    result = subprocess.run(["which", "llama-server"], capture_output=True, text=True)
+    if result.returncode == 0:
+        return result.stdout.strip()
+    raise FileNotFoundError(
+        "llama-server not found. Set LLAMA_SERVER env var or ensure it's on PATH."
+    )
+
+
+def start_server(model_path: str, n_gpu_layers: int = 99) -> subprocess.Popen:
+    """Start llama-server with a model and wait for it to be ready."""
+    server_bin = find_llama_server()
+    cmd = [
+        server_bin,
+        "--model", model_path,
+        "--port", str(SERVER_PORT),
+        "--n-gpu-layers", str(n_gpu_layers),
+        "--ctx-size", "4096",
+        "--flash-attn", "on",
+        "--parallel", "1",
+    ]
+
+    print(f"  Starting llama-server: {' '.join(cmd[:6])}...", flush=True)
+    log_path = RESULTS_DIR / "llama_server.log"
+    RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+    log_file = open(log_path, "w")
+    proc = subprocess.Popen(
+        cmd,
+        stdout=log_file,
+        stderr=subprocess.STDOUT,
+    )
+
+    # Wait for server to be ready (up to 120s)
+    for i in range(120):
+        try:
+            resp = requests.get(f"{SERVER_URL}/health", timeout=2)
+            if resp.status_code == 200:
+                print(f"  Server ready after {i+1}s")
+                return proc
+        except requests.ConnectionError:
+            pass
+        time.sleep(1)
+
+    proc.kill()
+    raise TimeoutError(f"llama-server failed to start after 120s for {model_path}")
+
+
+def stop_server(proc: subprocess.Popen) -> None:
+    """Stop llama-server gracefully."""
+    if proc.poll() is None:
+        proc.send_signal(signal.SIGTERM)
+        try:
+            proc.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            proc.kill()
+            proc.wait()
+    # Close log file if attached to stdout
+    if proc.stdout and not proc.stdout.closed:
+        proc.stdout.close()
+    print("  Server stopped.", flush=True)
+
+
+def generate_encoding(
+    raw_input: str,
+    source: str,
+    mem_type: str,
+    few_shot_examples: list[dict] | None = None,
+    enable_thinking: bool = False,
+) -> tuple[dict | None, dict]:
+    """Generate an encoding via the chat completions API.
+
+    Uses /v1/chat/completions with each model's native chat template.
+    Supports thinking/no-thinking mode via chat_template_kwargs.
+    Returns (parsed_json, metadata) where metadata includes timing info.
+    """
+    # Build system message from production prompt (without the content part)
+    system_prompt = build_production_prompt("", source=source, mem_type=mem_type)
+
+    messages = [{"role": "system", "content": system_prompt}]
+
+    # Add few-shot examples if provided
+    if few_shot_examples:
+        for ex in few_shot_examples:
+            ex_content = (
+                f"SOURCE: {ex.get('source', 'mcp')}\n"
+                f"TYPE: {ex.get('type', 'general')}\n"
+                f"CONTENT:\n{ex['raw_input']}"
+            )
+            messages.append({"role": "user", "content": ex_content})
+            messages.append({
+                "role": "assistant",
+                "content": json.dumps(ex["gold_output"], ensure_ascii=False),
+            })
+
+    # Add the actual input
+    user_content = f"SOURCE: {source}\nTYPE: {mem_type}\nCONTENT:\n{raw_input}"
+    messages.append({"role": "user", "content": user_content})
+
+    payload = {
+        "messages": messages,
+        "max_tokens": 2048,
+        "temperature": 0.3,
+        "stop": ["\n\n\n"],
+        "chat_template_kwargs": {"enable_thinking": enable_thinking},
+    }
+
+    metadata = {"error": None, "latency_ms": 0, "tokens_generated": 0}
+
+    try:
+        t0 = time.monotonic()
+        resp = requests.post(
+            f"{SERVER_URL}/v1/chat/completions",
+            json=payload,
+            timeout=180,
+        )
+        latency = (time.monotonic() - t0) * 1000
+        resp.raise_for_status()
+
+        data = resp.json()
+        choice = data["choices"][0]["message"]
+        text = choice.get("content", "")
+        metadata["latency_ms"] = latency
+        metadata["tokens_generated"] = data.get("usage", {}).get("completion_tokens", 0)
+        metadata["tokens_per_second"] = data.get("timings", {}).get("predicted_per_second", 0)
+        metadata["has_reasoning"] = bool(choice.get("reasoning_content"))
+
+        parsed = parse_json_response(text)
+        return parsed, metadata
+
+    except Exception as e:
+        metadata["error"] = str(e)
+        return None, metadata
+
+
+def load_gold_data() -> dict[int, dict]:
+    """Load gold-standard evaluation data."""
+    data = {}
+    with open(GOLD_PATH) as f:
+        for line in f:
+            entry = json.loads(line)
+            data[entry["id"]] = entry
+    return data
+
+
+def load_few_shot_examples(gold_data: dict[int, dict]) -> list[dict]:
+    """Load the few-shot examples from gold data."""
+    examples = []
+    for eid in FEW_SHOT_IDS:
+        if eid in gold_data:
+            examples.append(gold_data[eid])
+    return examples
+
+
+def run_model_eval(
+    model_key: str,
+    quant: str,
+    few_shot: int = 0,
+) -> dict | None:
+    """Run evaluation for a single model. Returns results dict or None on failure."""
+    model_info = CANDIDATES[model_key]
+    gguf_file = model_info["files"].get(quant)
+    if not gguf_file:
+        print(f"  No {quant} GGUF for {model_info['name']}")
+        return None
+
+    model_path = MODELS_DIR / gguf_file
+    if not model_path.exists():
+        print(f"  GGUF not found: {model_path}")
+        return None
+
+    print(f"\n{'='*70}")
+    print(f"Evaluating: {model_info['name']} ({quant})")
+    print(f"  File: {gguf_file}")
+    print(f"  Few-shot: {few_shot}")
+    print(f"{'='*70}")
+
+    # Load gold data
+    gold_data = load_gold_data()
+    few_shot_examples = load_few_shot_examples(gold_data) if few_shot > 0 else None
+
+    # Start server
+    proc = None
+    try:
+        proc = start_server(str(model_path))
+
+        # Generate predictions
+        predictions = {}
+        latencies = []
+        for entry_id, entry in sorted(gold_data.items()):
+            raw_input = entry["raw_input"]
+            source = entry.get("source", "mcp")
+            mem_type = entry.get("type", "general")
+            category = entry.get("category", "unknown")
+
+            print(f"  [{entry_id:>2}] {category}: ", end="", flush=True)
+
+            output, metadata = generate_encoding(
+                raw_input, source, mem_type, few_shot_examples
+            )
+
+            if output:
+                predictions[entry_id] = output
+                latencies.append(metadata["latency_ms"])
+                tps = metadata.get("tokens_per_second", 0)
+                tps_str = f", {tps:.1f} tok/s" if tps else ""
+                print(f"OK ({metadata['latency_ms']:.0f}ms, {metadata['tokens_generated']} tok{tps_str})", flush=True)
+            else:
+                print(f"FAILED ({metadata.get('error', 'no output')})")
+
+        # Run evaluation
+        evaluation = evaluate_dataset(
+            str(GOLD_PATH), predictions=predictions
+        )
+        evaluation["model"] = model_info["name"]
+        evaluation["model_key"] = model_key
+        evaluation["quant"] = quant
+        evaluation["few_shot"] = few_shot
+        evaluation["params"] = model_info["params"]
+        evaluation["family"] = model_info["family"]
+        if latencies:
+            evaluation["avg_latency_ms"] = sum(latencies) / len(latencies)
+            evaluation["p50_latency_ms"] = sorted(latencies)[len(latencies) // 2]
+            evaluation["p99_latency_ms"] = sorted(latencies)[-1]
+
+        # Print report
+        print_report(evaluation)
+
+        # Save results
+        RESULTS_DIR.mkdir(parents=True, exist_ok=True)
+        condition = f"{few_shot}shot" if few_shot > 0 else "0shot"
+        result_file = RESULTS_DIR / f"{model_key}_{quant}_{condition}.json"
+        with open(result_file, "w") as f:
+            json.dump(evaluation, f, indent=2, default=str)
+        print(f"\n  Results saved: {result_file}")
+
+        return evaluation
+
+    except (TimeoutError, FileNotFoundError) as e:
+        print(f"  ERROR: {e}")
+        return None
+    finally:
+        if proc:
+            stop_server(proc)
+
+
+def generate_comparison_report(results_dir: Path) -> None:
+    """Generate a comparative report from all result files."""
+    results = []
+    for f in sorted(results_dir.glob("*.json")):
+        with open(f) as fh:
+            results.append(json.load(fh))
+
+    if not results:
+        print("No results found.")
+        return
+
+    print("\n" + "=" * 90)
+    print("EXP-29 COMPARATIVE REPORT")
+    print("=" * 90)
+
+    # Header
+    print(
+        f"\n{'Model':<25} {'Quant':<8} {'Shot':<5} "
+        f"{'EPR':>5} {'FR':>5} {'TED':>4} {'NP':>5} "
+        f"{'SC':>6} {'MIH':>5} {'CCS':>5} {'Lat(ms)':>8}"
+    )
+    print("-" * 90)
+
+    for r in results:
+        s = r.get("summary", {})
+        model = r.get("model", "?")[:24]
+        quant = r.get("quant", "?")
+        shot = f"{r.get('few_shot', 0)}s"
+        epr = f"{s.get('avg_epr', 0):.1%}"
+        fr = f"{s.get('avg_fr', 0):.1%}"
+        ted = f"{s.get('ted_failures', '?')}/{s.get('valid', '?')}"
+        np_score = f"{s.get('avg_np', 0):.1%}"
+        sc = f"{s.get('sc_pass', 0)}/{s.get('valid', '?')}"
+        mih = f"{s.get('mih_pass', 0)}/{s.get('mih_total', 0)}"
+        ccs = f"{s.get('ccs_pass', 0)}/{s.get('ccs_total', 0)}"
+        lat = f"{r.get('avg_latency_ms', 0):.0f}" if r.get("avg_latency_ms") else "-"
+
+        print(
+            f"{model:<25} {quant:<8} {shot:<5} "
+            f"{epr:>5} {fr:>5} {ted:>4} {np_score:>5} "
+            f"{sc:>6} {mih:>5} {ccs:>5} {lat:>8}"
+        )
+
+    # Decision gate analysis
+    print("\n" + "-" * 90)
+    print("DECISION GATE ANALYSIS")
+    print("-" * 90)
+
+    zero_shot = [r for r in results if r.get("few_shot", 0) == 0]
+    if zero_shot:
+        best = max(zero_shot, key=lambda r: r.get("summary", {}).get("avg_epr", 0))
+        best_s = best.get("summary", {})
+        best_sc = best_s.get("sc_rate", 0) * 100
+        best_epr = best_s.get("avg_epr", 0) * 100
+
+        print(f"\nBest zero-shot: {best.get('model')} ({best.get('quant')})")
+        print(f"  SC: {best_sc:.0f}%  EPR: {best_epr:.0f}%")
+
+        if best_sc > 80 and best_epr > 70:
+            print("  -> STRONG SIGNAL: Prioritize this model for v7 fine-tuning")
+        elif best_sc > 50 and best_epr > 40:
+            print("  -> MODERATE SIGNAL: Fine-tune top candidates on v7 data")
+        else:
+            print("  -> NULL HYPOTHESIS: Proceed with EXP-26 (Qwen + v7)")
+
+    # Size comparison
+    two_b = [r for r in zero_shot if r.get("params") in ("2B", "~2B", "0.8B")]
+    four_b = [r for r in zero_shot if r.get("params") in ("4B", "~4B")]
+    if two_b and four_b:
+        avg_2b_epr = sum(r.get("summary", {}).get("avg_epr", 0) for r in two_b) / len(two_b)
+        avg_4b_epr = sum(r.get("summary", {}).get("avg_epr", 0) for r in four_b) / len(four_b)
+        delta = (avg_4b_epr - avg_2b_epr) * 100
+        print(f"\n4B-class avg EPR: {avg_4b_epr:.1%}  vs  2B-class: {avg_2b_epr:.1%}  (delta: {delta:+.1f}pp)")
+        if delta > 15:
+            print("  -> Size matters for this task — evaluate VRAM/speed tradeoff for 4B deployment")
+
+    print("=" * 90)
+
+    # Save report
+    report_path = results_dir / "comparison_report.txt"
+    print(f"\nReport also saved to: {report_path}")
+
+
+def main():
+    parser = argparse.ArgumentParser(description="EXP-29 candidate model bake-off")
+    parser.add_argument(
+        "--model",
+        choices=list(CANDIDATES.keys()),
+        help="Run a single model (default: all)",
+    )
+    parser.add_argument(
+        "--quant",
+        default="Q8_0",
+        help="Quantization level (default: Q8_0)",
+    )
+    parser.add_argument(
+        "--few-shot",
+        type=int,
+        default=0,
+        help="Number of few-shot examples (default: 0 = zero-shot)",
+    )
+    parser.add_argument(
+        "--report-only",
+        action="store_true",
+        help="Just generate comparison report from existing results",
+    )
+    args = parser.parse_args()
+
+    if args.report_only:
+        generate_comparison_report(RESULTS_DIR)
+        return
+
+    models = [args.model] if args.model else list(CANDIDATES.keys())
+
+    all_results = []
+    for model_key in models:
+        result = run_model_eval(model_key, args.quant, args.few_shot)
+        if result:
+            all_results.append(result)
+
+    # Generate comparison if we ran multiple models
+    if len(all_results) > 1:
+        generate_comparison_report(RESULTS_DIR)
+
+
+if __name__ == "__main__":
+    main()

--- a/training/scripts/run_exp29_bakeoff.py
+++ b/training/scripts/run_exp29_bakeoff.py
@@ -18,6 +18,9 @@ Usage:
 
     # Just generate the comparison report from existing results
     python run_exp29_bakeoff.py --report-only
+
+    # Run with GBNF grammar constraint
+    python run_exp29_bakeoff.py --model qwen35-4b --quant Q8_0 --grammar
 """
 
 import argparse
@@ -111,6 +114,55 @@ CANDIDATES = {
 # Chosen to cover: out-of-domain (#1 recipe), minimal (#15), production (#22 handoff)
 FEW_SHOT_IDS = [1, 15, 22]
 
+# GBNF grammar for encoding response — copied from internal/llm/grammar.go
+GBNF_ENCODING = r"""root ::= "{" ws gist-kv "," ws summary-kv "," ws content-kv "," ws narrative-kv "," ws concepts-kv "," ws structured-concepts-kv "," ws significance-kv "," ws emotional-tone-kv "," ws outcome-kv "," ws salience-kv ws "}"
+
+gist-kv              ::= "\"gist\"" ws ":" ws string
+summary-kv           ::= "\"summary\"" ws ":" ws string
+content-kv           ::= "\"content\"" ws ":" ws string
+narrative-kv         ::= "\"narrative\"" ws ":" ws string
+concepts-kv          ::= "\"concepts\"" ws ":" ws string-array
+structured-concepts-kv ::= "\"structured_concepts\"" ws ":" ws sc-object
+significance-kv      ::= "\"significance\"" ws ":" ws significance-enum
+emotional-tone-kv    ::= "\"emotional_tone\"" ws ":" ws tone-enum
+outcome-kv           ::= "\"outcome\"" ws ":" ws outcome-enum
+salience-kv          ::= "\"salience\"" ws ":" ws number
+
+significance-enum ::= "\"routine\"" | "\"notable\"" | "\"important\"" | "\"critical\""
+tone-enum         ::= "\"neutral\"" | "\"satisfying\"" | "\"frustrating\"" | "\"exciting\"" | "\"concerning\""
+outcome-enum      ::= "\"success\"" | "\"failure\"" | "\"ongoing\"" | "\"unknown\""
+
+string-array ::= "[" ws "]" | "[" ws string ("," ws string)* ws "]"
+
+sc-object    ::= "{" ws topics-kv "," ws entities-kv "," ws actions-kv "," ws causality-kv ws "}"
+topics-kv    ::= "\"topics\"" ws ":" ws topic-array
+entities-kv  ::= "\"entities\"" ws ":" ws entity-array
+actions-kv   ::= "\"actions\"" ws ":" ws action-array
+causality-kv ::= "\"causality\"" ws ":" ws causality-array
+
+topic-array     ::= "[" ws "]" | "[" ws topic-obj ("," ws topic-obj)* ws "]"
+topic-obj       ::= "{" ws "\"label\"" ws ":" ws string "," ws "\"path\"" ws ":" ws string ws "}"
+
+entity-array    ::= "[" ws "]" | "[" ws entity-obj ("," ws entity-obj)* ws "]"
+entity-obj      ::= "{" ws "\"name\"" ws ":" ws string "," ws "\"type\"" ws ":" ws string "," ws "\"context\"" ws ":" ws string ws "}"
+
+action-array    ::= "[" ws "]" | "[" ws action-obj ("," ws action-obj)* ws "]"
+action-obj      ::= "{" ws "\"verb\"" ws ":" ws string "," ws "\"object\"" ws ":" ws string "," ws "\"details\"" ws ":" ws string ws "}"
+
+causality-array ::= "[" ws "]" | "[" ws causality-obj ("," ws causality-obj)* ws "]"
+causality-obj   ::= "{" ws "\"relation\"" ws ":" ws string "," ws "\"description\"" ws ":" ws string ws "}"
+
+string ::=
+  "\"" (
+    [^\\"\x00-\x1f] |
+    "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F])
+  )* "\""
+
+number ::= "-"? ("0" | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [-+]? [0-9]+)?
+
+ws     ::= ([ \t\n] ws)?
+"""
+
 SERVER_PORT = 8080
 SERVER_URL = f"http://127.0.0.1:{SERVER_PORT}"
 LLAMA_SERVER = os.environ.get(
@@ -139,7 +191,9 @@ def find_llama_server() -> str:
     )
 
 
-def start_server(model_path: str, n_gpu_layers: int = 99) -> subprocess.Popen:
+def start_server(
+    model_path: str, n_gpu_layers: int = 99,
+) -> subprocess.Popen:
     """Start llama-server with a model and wait for it to be ready."""
     server_bin = find_llama_server()
     cmd = [
@@ -151,6 +205,7 @@ def start_server(model_path: str, n_gpu_layers: int = 99) -> subprocess.Popen:
         "--flash-attn", "on",
         "--parallel", "1",
     ]
+    # Grammar is passed per-request in the /completion payload, not server-level
 
     print(f"  Starting llama-server: {' '.join(cmd[:6])}...", flush=True)
     log_path = RESULTS_DIR / "llama_server.log"
@@ -198,19 +253,23 @@ def generate_encoding(
     mem_type: str,
     few_shot_examples: list[dict] | None = None,
     enable_thinking: bool = False,
+    use_grammar: bool = False,
 ) -> tuple[dict | None, dict]:
-    """Generate an encoding via the chat completions API.
+    """Generate an encoding via the chat completions API (or /completion with grammar).
 
     Uses /v1/chat/completions with each model's native chat template.
-    Supports thinking/no-thinking mode via chat_template_kwargs.
+    When use_grammar=True, falls back to /completion with grammar field since
+    --grammar-file only applies to the /completion endpoint in llama.cpp.
     Returns (parsed_json, metadata) where metadata includes timing info.
     """
-    # Build system message from production prompt (without the content part)
+    metadata = {"error": None, "latency_ms": 0, "tokens_generated": 0}
+
+    # Use /v1/chat/completions for all modes — grammar field is supported
+    # (undocumented but confirmed in llama.cpp server-common.cpp line 918)
     system_prompt = build_production_prompt("", source=source, mem_type=mem_type)
 
     messages = [{"role": "system", "content": system_prompt}]
 
-    # Add few-shot examples if provided
     if few_shot_examples:
         for ex in few_shot_examples:
             ex_content = (
@@ -224,7 +283,6 @@ def generate_encoding(
                 "content": json.dumps(ex["gold_output"], ensure_ascii=False),
             })
 
-    # Add the actual input
     user_content = f"SOURCE: {source}\nTYPE: {mem_type}\nCONTENT:\n{raw_input}"
     messages.append({"role": "user", "content": user_content})
 
@@ -235,8 +293,8 @@ def generate_encoding(
         "stop": ["\n\n\n"],
         "chat_template_kwargs": {"enable_thinking": enable_thinking},
     }
-
-    metadata = {"error": None, "latency_ms": 0, "tokens_generated": 0}
+    if use_grammar:
+        payload["grammar"] = GBNF_ENCODING
 
     try:
         t0 = time.monotonic()
@@ -287,6 +345,7 @@ def run_model_eval(
     model_key: str,
     quant: str,
     few_shot: int = 0,
+    use_grammar: bool = False,
 ) -> dict | None:
     """Run evaluation for a single model. Returns results dict or None on failure."""
     model_info = CANDIDATES[model_key]
@@ -300,10 +359,13 @@ def run_model_eval(
         print(f"  GGUF not found: {model_path}")
         return None
 
+    grammar_tag = "+grammar" if use_grammar else ""
     print(f"\n{'='*70}")
-    print(f"Evaluating: {model_info['name']} ({quant})")
+    print(f"Evaluating: {model_info['name']} ({quant}{grammar_tag})")
     print(f"  File: {gguf_file}")
     print(f"  Few-shot: {few_shot}")
+    if use_grammar:
+        print(f"  Grammar: GBNF encoding schema (enum-constrained)")
     print(f"{'='*70}")
 
     # Load gold data
@@ -327,7 +389,8 @@ def run_model_eval(
             print(f"  [{entry_id:>2}] {category}: ", end="", flush=True)
 
             output, metadata = generate_encoding(
-                raw_input, source, mem_type, few_shot_examples
+                raw_input, source, mem_type, few_shot_examples,
+                use_grammar=use_grammar,
             )
 
             if output:
@@ -347,6 +410,7 @@ def run_model_eval(
         evaluation["model_key"] = model_key
         evaluation["quant"] = quant
         evaluation["few_shot"] = few_shot
+        evaluation["grammar"] = use_grammar
         evaluation["params"] = model_info["params"]
         evaluation["family"] = model_info["family"]
         if latencies:
@@ -360,7 +424,8 @@ def run_model_eval(
         # Save results
         RESULTS_DIR.mkdir(parents=True, exist_ok=True)
         condition = f"{few_shot}shot" if few_shot > 0 else "0shot"
-        result_file = RESULTS_DIR / f"{model_key}_{quant}_{condition}.json"
+        grammar_suffix = "_grammar" if use_grammar else ""
+        result_file = RESULTS_DIR / f"{model_key}_{quant}_{condition}{grammar_suffix}.json"
         with open(result_file, "w") as f:
             json.dump(evaluation, f, indent=2, default=str)
         print(f"\n  Results saved: {result_file}")
@@ -481,6 +546,11 @@ def main():
         action="store_true",
         help="Just generate comparison report from existing results",
     )
+    parser.add_argument(
+        "--grammar",
+        action="store_true",
+        help="Enable GBNF grammar constraint for schema enforcement",
+    )
     args = parser.parse_args()
 
     if args.report_only:
@@ -491,7 +561,9 @@ def main():
 
     all_results = []
     for model_key in models:
-        result = run_model_eval(model_key, args.quant, args.few_shot)
+        result = run_model_eval(
+            model_key, args.quant, args.few_shot, use_grammar=args.grammar,
+        )
         if result:
             all_results.append(result)
 

--- a/training/scripts/training_constants.py
+++ b/training/scripts/training_constants.py
@@ -172,6 +172,88 @@ def build_production_prompt(
     return "".join(parts)
 
 
+# --- Prompt Ablation Variants (EXP-29) ---
+# Three alternative prompt strategies to test the LLMStructBench finding that
+# prompting strategy matters more than model size for structured extraction.
+
+PROMPT_VARIANT_MINIMAL = (
+    "Output a JSON object encoding this event. Required fields: "
+    "gist (str), summary (str), content (str), narrative (str), "
+    "concepts (str[]), structured_concepts ({topics, entities, actions, causality}), "
+    "significance (routine|notable|important|critical), "
+    "emotional_tone (neutral|satisfying|frustrating|exciting|concerning), "
+    "outcome (success|failure|ongoing|unknown), salience (0.0-1.0). "
+    "Output ONLY valid JSON.\n\n"
+)
+
+
+PROMPT_VARIANT_FIELD_BY_FIELD = (
+    "You are a memory encoder. Read the input below, then fill in each field:\n\n"
+    "1. gist — What happened, under 60 chars\n"
+    "2. summary — 2-3 sentences, under 100 chars\n"
+    "3. content — Key facts, decisions, metrics. Copy names/numbers EXACTLY from input.\n"
+    "4. narrative — Context paragraph explaining why this matters\n"
+    "5. concepts — 3-5 keyword strings\n"
+    "6. structured_concepts — Extract {topics: [{label,path}], entities: [{name,type,context}], "
+    "actions: [{verb,object,details}], causality: [{relation,description}]}\n"
+    "7. significance — routine / notable / important / critical\n"
+    "8. emotional_tone — neutral / satisfying / frustrating / exciting / concerning\n"
+    "9. outcome — success / failure / ongoing / unknown\n"
+    "10. salience — float 0.0-1.0\n\n"
+    "CRITICAL: Every name, number, file path, and metric in the input MUST appear "
+    "in the output. Do NOT add information that isn't in the input.\n\n"
+    "Output a single JSON object with all 10 fields.\n\n"
+)
+
+
+PROMPT_VARIANT_FAITHFUL = (
+    "TASK: Compress the following observation into structured JSON.\n\n"
+    "RULES:\n"
+    "- FAITHFULNESS: Every fact in your output must come from the input. "
+    "Do not infer, speculate, or add context from your training data.\n"
+    "- PRESERVATION: Copy all proper nouns, numbers, file paths, version strings, "
+    "and technical identifiers VERBATIM from the input.\n"
+    "- MINIMALITY: If the input is short, the output should be short. "
+    "Do not pad with generic filler.\n\n"
+    "SCHEMA: {gist, summary, content, narrative, concepts, structured_concepts, "
+    "significance, emotional_tone, outcome, salience}\n"
+    "- significance: routine | notable | important | critical\n"
+    "- emotional_tone: neutral | satisfying | frustrating | exciting | concerning\n"
+    "- outcome: success | failure | ongoing | unknown\n"
+    "- salience: float 0.0-1.0\n\n"
+    "Output ONLY the JSON object. No explanation.\n\n"
+)
+
+
+def build_prompt_variant(
+    content: str,
+    variant: str = "production",
+    source: str = "mcp",
+    mem_type: str = "general",
+) -> str:
+    """Build encoding prompt using a specified variant.
+
+    Variants:
+        production — full daemon prompt (build_production_prompt)
+        minimal — compressed schema-only instructions
+        field_by_field — numbered field list with faithfulness emphasis
+        faithful — rules-first prompt emphasizing no hallucination
+    """
+    if variant == "production":
+        return build_production_prompt(content, source=source, mem_type=mem_type)
+
+    prompt_map = {
+        "minimal": PROMPT_VARIANT_MINIMAL,
+        "field_by_field": PROMPT_VARIANT_FIELD_BY_FIELD,
+        "faithful": PROMPT_VARIANT_FAITHFUL,
+    }
+    prefix = prompt_map.get(variant)
+    if prefix is None:
+        raise ValueError(f"Unknown variant: {variant}")
+
+    return f"{prefix}SOURCE: {source}\nTYPE: {mem_type}\nCONTENT:\n{content}\n"
+
+
 # --- Placeholder Detection ---
 
 PLACEHOLDER_GISTS = frozenset({


### PR DESCRIPTION
## Summary

- EXP-29: Evaluated 6 sub-4B models (2026 releases) on mnemonic's encoding task across 14 conditions (zero-shot, 3-shot, GBNF grammar, 4 prompt variants)
- **Key finding: prompt design > model choice.** The faithful prompt (rules-first: FAITHFULNESS, PRESERVATION, MINIMALITY) produced 100% EPR and 100% NP on Gemma 4 E2B, zero-shot, no fine-tuning
- Rewrites `buildCompressionPrompt()` to the faithful prompt format
- Continuous learning design doc, implementation spec, and Phase A plan for issue #391
- New rules: llm-inference.md (llama-server usage), peer-review-standard.md (Gokaslan/Karpathy review)

## EXP-29 Results

| Model + Prompt | EPR | NP | FR | Valid | tok/s |
|---------------|------|------|------|-------|-------|
| Gemma E2B + production | 75.1% | 73.3% | 8.5% | 25/25 | ~100 |
| Qwen 4B + production | 87.2% | 87.1% | 10.3% | 22/25 | ~135 |
| Qwen 4B + 3-shot | 94.7% | 95.6% | 14.2% | 18/25 | ~69 |
| Qwen 4B + faithful | 99.6% | 100% | 0.9% | 25/25 | ~70 |
| **Gemma E2B + faithful** | **100%** | **100%** | **2.4%** | 24/25 | **~101** |

FR metric is ~90% false positives (verb synonyms). True fabrication ~1-2% across all models.

## Test plan

- [x] `go test ./internal/agent/encoding/` passes (TestFaithfulPromptFormatUsed)
- [x] Live encoding test with Qwen 2B + spokes (carbonara recipe: all numbers preserved)
- [x] Live encoding test with Gemma E2B via bake-off harness (100% EPR on 25 probe inputs)
- [ ] Full `make test` (pre-existing TestFormatPrompt failure in internal/llm unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)