### PR TITLE
fix: add GBNF grammar for episode synthesis

### DIFF
--- a/internal/agent/episoding/agent.go
+++ b/internal/agent/episoding/agent.go
@@ -528,6 +528,12 @@ func parseEpisodeSynthesis(response string) episodeSynthesis {
 	var result episodeSynthesis
 	jsonStr := agentutil.ExtractJSON(response)
 	if err := json.Unmarshal([]byte(jsonStr), &result); err != nil {
+		slog.Warn("episode synthesis parse failed",
+			"error", err,
+			"response_len", len(response),
+			"extracted_json_len", len(jsonStr),
+			"response_preview", agentutil.Truncate(response, 200),
+		)
 		return episodeSynthesis{
 			Title:         "Untitled session",
 			Summary:       "Episode synthesis failed — LLM returned unparseable response.",

--- a/internal/agent/episoding/agent_test.go
+++ b/internal/agent/episoding/agent_test.go
@@ -1,0 +1,72 @@
+package episoding
+
+import (
+	"testing"
+)
+
+func TestParseEpisodeSynthesis_ValidJSON(t *testing.T) {
+	input := `{"title":"Debugging session","summary":"Fixed episode parsing","narrative":"Investigated and resolved JSON parse failures","emotional_tone":"satisfying","outcome":"success","concepts":["debugging","json","parsing"],"salience":0.8}`
+
+	result := parseEpisodeSynthesis(input)
+
+	if result.Title != "Debugging session" {
+		t.Errorf("title = %q, want %q", result.Title, "Debugging session")
+	}
+	if result.Summary != "Fixed episode parsing" {
+		t.Errorf("summary = %q, want %q", result.Summary, "Fixed episode parsing")
+	}
+	if result.Salience != 0.8 {
+		t.Errorf("salience = %f, want %f", result.Salience, 0.8)
+	}
+	if len(result.Concepts) != 3 {
+		t.Errorf("concepts count = %d, want 3", len(result.Concepts))
+	}
+}
+
+func TestParseEpisodeSynthesis_EmptyResponse(t *testing.T) {
+	result := parseEpisodeSynthesis("")
+
+	if result.Title != "Untitled session" {
+		t.Errorf("title = %q, want %q", result.Title, "Untitled session")
+	}
+	if result.Salience != 0.5 {
+		t.Errorf("salience = %f, want %f", result.Salience, 0.5)
+	}
+}
+
+func TestParseEpisodeSynthesis_TypeMismatch(t *testing.T) {
+	// This is what the embedded model produces without a dedicated grammar:
+	// salience as string instead of number
+	input := `{"title":"Test","summary":"Test","narrative":"Test","emotional_tone":"neutral","outcome":"ongoing","concepts":"keyword","salience":"high"}`
+
+	result := parseEpisodeSynthesis(input)
+
+	// Should fall back to defaults since unmarshal fails on type mismatch
+	if result.Title != "Untitled session" {
+		t.Errorf("expected fallback title, got %q", result.Title)
+	}
+}
+
+func TestParseEpisodeSynthesis_MarkdownFenced(t *testing.T) {
+	input := "```json\n{\"title\":\"Test\",\"summary\":\"s\",\"narrative\":\"n\",\"emotional_tone\":\"neutral\",\"outcome\":\"success\",\"concepts\":[],\"salience\":0.5}\n```"
+
+	result := parseEpisodeSynthesis(input)
+
+	if result.Title != "Test" {
+		t.Errorf("title = %q, want %q", result.Title, "Test")
+	}
+}
+
+func TestParseEpisodeSynthesis_MissingFields(t *testing.T) {
+	// Valid JSON but missing fields — unmarshal succeeds, validation fills defaults
+	input := `{"title":"","summary":"test"}`
+
+	result := parseEpisodeSynthesis(input)
+
+	if result.Title != "Untitled session" {
+		t.Errorf("title = %q, want %q", result.Title, "Untitled session")
+	}
+	if result.Salience != 0.5 {
+		t.Errorf("salience = %f, want %f", result.Salience, 0.5)
+	}
+}

--- a/internal/llm/embedded.go
+++ b/internal/llm/embedded.go
@@ -292,9 +292,12 @@ func (p *EmbeddedProvider) Complete(ctx context.Context, req CompletionRequest) 
 		grammar = GBNFJSONObject
 	}
 	if req.ResponseFormat != nil && req.ResponseFormat.Type == "json_schema" && req.ResponseFormat.JSONSchema != nil {
-		if req.ResponseFormat.JSONSchema.Name == "encoding_response" {
+		switch req.ResponseFormat.JSONSchema.Name {
+		case "encoding_response":
 			grammar = GBNFEncodingResponse
-		} else {
+		case "episode_synthesis":
+			grammar = GBNFEpisodeSynthesis
+		default:
 			grammar = GBNFJSONObject
 		}
 	}

--- a/internal/llm/embedded_test.go
+++ b/internal/llm/embedded_test.go
@@ -259,6 +259,24 @@ func TestEmbeddedProviderGrammarRouting(t *testing.T) {
 		t.Errorf("expected encoding-specific GBNF grammar for encoding_response schema, got generic")
 	}
 
+	// json_schema with episode_synthesis name — should use episode-specific grammar
+	_, err = p.Complete(ctx, CompletionRequest{
+		Messages: []Message{{Role: "user", Content: "hello"}},
+		ResponseFormat: &ResponseFormat{
+			Type: "json_schema",
+			JSONSchema: &JSONSchema{
+				Name:   "episode_synthesis",
+				Strict: true,
+			},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Complete failed: %v", err)
+	}
+	if capturedGrammar != GBNFEpisodeSynthesis {
+		t.Errorf("expected episode-specific GBNF grammar for episode_synthesis schema, got generic")
+	}
+
 	// json_schema with other name — should fall back to generic JSON grammar
 	_, err = p.Complete(ctx, CompletionRequest{
 		Messages: []Message{{Role: "user", Content: "hello"}},

--- a/internal/llm/grammar.go
+++ b/internal/llm/grammar.go
@@ -57,6 +57,32 @@ number ::= "-"? ("0" | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [-+]? [0-9]+)?
 ws     ::= ([ \t\n] ws)?
 `
 
+// GBNFEpisodeSynthesis constrains output to the episode synthesis schema.
+// Fixed key order and typed values prevent the embedded model from producing
+// type mismatches (e.g. salience as string) that break json.Unmarshal.
+const GBNFEpisodeSynthesis = `root ::= "{" ws title-kv "," ws summary-kv "," ws narrative-kv "," ws emotional-tone-kv "," ws outcome-kv "," ws concepts-kv "," ws salience-kv ws "}"
+
+title-kv          ::= "\"title\"" ws ":" ws string
+summary-kv        ::= "\"summary\"" ws ":" ws string
+narrative-kv      ::= "\"narrative\"" ws ":" ws string
+emotional-tone-kv ::= "\"emotional_tone\"" ws ":" ws string
+outcome-kv        ::= "\"outcome\"" ws ":" ws string
+concepts-kv       ::= "\"concepts\"" ws ":" ws string-array
+salience-kv       ::= "\"salience\"" ws ":" ws number
+
+string-array ::= "[" ws "]" | "[" ws string ("," ws string)* ws "]"
+
+string ::=
+  "\"" (
+    [^\\"\x00-\x1f] |
+    "\\" (["\\/bfnrt] | "u" [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F])
+  )* "\""
+
+number ::= "-"? ("0" | [1-9] [0-9]*) ("." [0-9]+)? ([eE] [-+]? [0-9]+)?
+
+ws     ::= ([ \t\n] ws)?
+`
+
 // GBNFEncodingResponse constrains output to the mnemonic encoding response schema.
 // Fixed key order eliminates ambiguity for small models and enforces all required fields.
 const GBNFEncodingResponse = `root ::= "{" ws gist-kv "," ws summary-kv "," ws content-kv "," ws narrative-kv "," ws concepts-kv "," ws structured-concepts-kv "," ws significance-kv "," ws emotional-tone-kv "," ws outcome-kv "," ws salience-kv ws "}"


### PR DESCRIPTION
## Summary

- Episoding agent was producing "Untitled session" at 0% for every episode because `json.Unmarshal` failed on the embedded model's output
- Root cause: no dedicated GBNF grammar for `episode_synthesis` — fell through to generic `GBNFJSONObject` which allows type mismatches (salience as string, concepts as string instead of array)
- Added `GBNFEpisodeSynthesis` grammar with fixed key order and typed values, matching the approach that makes encoding work at 98%
- Added debug logging to `parseEpisodeSynthesis` so future failures show actual model output

## Changes

- `internal/llm/grammar.go` — new `GBNFEpisodeSynthesis` constant
- `internal/llm/embedded.go` — register `episode_synthesis` in grammar routing switch
- `internal/agent/episoding/agent.go` — debug log on parse failure
- `internal/agent/episoding/agent_test.go` — new test file for parse function
- `internal/llm/embedded_test.go` — extended grammar routing test

## Test plan

- [x] Grammar routing test verifies `episode_synthesis` maps to `GBNFEpisodeSynthesis`
- [x] Parse tests cover: valid JSON, empty response, type mismatch fallback, markdown fences, missing fields
- [x] Binary rebuilt, daemon restarted — encoding continues working at 98%
- [ ] Observe next episode closure in dashboard for correct title/summary

🤖 Generated with [Claude Code](https://claude.com/claude-code)