### PR TITLE
fix: prevent MCP processes from loading GPU models into VRAM

### DIFF
--- a/cmd/mnemonic/cycle.go
+++ b/cmd/mnemonic/cycle.go
@@ -17,6 +17,7 @@ import (
 	"github.com/appsprout-dev/mnemonic/internal/agent/retrieval"
 	"github.com/appsprout-dev/mnemonic/internal/config"
 	"github.com/appsprout-dev/mnemonic/internal/events"
+	"github.com/appsprout-dev/mnemonic/internal/llm"
 	"github.com/appsprout-dev/mnemonic/internal/mcp"
 )
 
@@ -110,9 +111,17 @@ func dreamCycleCommand(configPath string) {
 }
 
 // mcpCommand runs the MCP server on stdin/stdout for AI agent integration.
+// Uses a lightweight provider (API or deferred embedded) to avoid loading
+// GPU models that the daemon already owns.
 func mcpCommand(configPath string) {
-	cfg, db, llmProvider, log := initRuntime(configPath)
+	cfg, db, log := initBase(configPath)
 	defer func() { _ = db.Close() }()
+
+	llmProvider := newMCPProvider(cfg)
+	// Wrap with training data capture if enabled (MCP encoding produces useful training data)
+	if cfg.Training.CaptureEnabled && cfg.Training.CaptureDir != "" {
+		llmProvider = llm.NewTrainingCaptureProvider(llmProvider, "mcp", cfg.Training.CaptureDir)
+	}
 
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
@@ -165,7 +174,7 @@ func mcpCommand(configPath string) {
 
 // autopilotCommand shows what the system has been doing autonomously.
 func autopilotCommand(configPath string) {
-	_, db, _, _ := initRuntime(configPath)
+	_, db, _ := initBase(configPath)
 	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()

--- a/cmd/mnemonic/dedup_cli.go
+++ b/cmd/mnemonic/dedup_cli.go
@@ -14,7 +14,7 @@ import (
 // dedupCommand scans active memories for near-duplicate clusters and archives duplicates.
 // With --apply it modifies the DB; without it, it's a dry-run that reports what would change.
 func dedupCommand(configPath string, dryRun bool) {
-	cfg, db, _, log := initRuntime(configPath)
+	cfg, db, log := initBase(configPath)
 	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()
@@ -197,7 +197,7 @@ func dedupCommand(configPath string, dryRun bool) {
 // resetPatternsCommand recalculates pattern strengths using logarithmic scaling
 // and merges near-duplicate patterns. Dry-run by default; use --apply to execute.
 func resetPatternsCommand(configPath string, dryRun bool) {
-	_, db, _, log := initRuntime(configPath)
+	_, db, log := initBase(configPath)
 	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()

--- a/cmd/mnemonic/export.go
+++ b/cmd/mnemonic/export.go
@@ -12,7 +12,7 @@ import (
 
 // exportCommand exports the memory store to a file.
 func exportCommand(configPath string, args []string) {
-	cfg, db, _, _ := initRuntime(configPath)
+	cfg, db, _ := initBase(configPath)
 	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()
@@ -74,7 +74,7 @@ func exportCommand(configPath string, args []string) {
 
 // importCommand imports memories from a JSON export file.
 func importCommand(configPath, filePath string, args []string) {
-	_, db, _, _ := initRuntime(configPath)
+	_, db, _ := initBase(configPath)
 	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()
@@ -116,7 +116,7 @@ func importCommand(configPath, filePath string, args []string) {
 
 // backupCommand creates a timestamped backup with retention.
 func backupCommand(configPath string) {
-	_, db, _, _ := initRuntime(configPath)
+	_, db, _ := initBase(configPath)
 	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()

--- a/cmd/mnemonic/insights.go
+++ b/cmd/mnemonic/insights.go
@@ -10,7 +10,7 @@ import (
 
 // insightsCommand displays recent metacognition observations.
 func insightsCommand(configPath string) {
-	_, db, _, _ := initRuntime(configPath)
+	_, db, _ := initBase(configPath)
 	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()

--- a/cmd/mnemonic/purge.go
+++ b/cmd/mnemonic/purge.go
@@ -75,7 +75,7 @@ func purgeCommand(configPath string) {
 // cleanupCommand scans raw_memories for paths matching exclude patterns and
 // bulk-marks them as processed, then archives any encoded memories derived from them.
 func cleanupCommand(configPath string, args []string) {
-	cfg, db, _, _ := initRuntime(configPath)
+	cfg, db, _ := initBase(configPath)
 	defer func() { _ = db.Close() }()
 
 	ctx := context.Background()

--- a/cmd/mnemonic/runtime.go
+++ b/cmd/mnemonic/runtime.go
@@ -88,9 +88,9 @@ func convertSourceWeights(src map[string]float64) map[string]float32 {
 	return out
 }
 
-// initRuntime loads config, opens store and LLM for CLI commands.
-// The returned Provider includes training data capture if enabled in config.
-func initRuntime(configPath string) (*config.Config, *sqlite.SQLiteStore, llm.Provider, *slog.Logger) {
+// initBase loads config, opens the database, and creates a logger.
+// No LLM provider is created — use this for commands that only need data access.
+func initBase(configPath string) (*config.Config, *sqlite.SQLiteStore, *slog.Logger) {
 	cfg, err := config.Load(configPath)
 	if err != nil {
 		die(exitConfig, fmt.Sprintf("loading config: %v", err), "mnemonic diagnose")
@@ -108,6 +108,15 @@ func initRuntime(configPath string) (*config.Config, *sqlite.SQLiteStore, llm.Pr
 		die(exitDatabase, fmt.Sprintf("opening database: %v", err), "mnemonic diagnose")
 	}
 
+	return cfg, db, log
+}
+
+// initRuntime loads config, opens store, and creates an LLM provider for CLI commands
+// that need inference (consolidate, dream, meta-cycle, remember, recall).
+// The returned Provider includes training data capture if enabled in config.
+func initRuntime(configPath string) (*config.Config, *sqlite.SQLiteStore, llm.Provider, *slog.Logger) {
+	cfg, db, log := initBase(configPath)
+
 	provider := newLLMProvider(cfg)
 
 	// Wrap with training data capture if enabled
@@ -116,6 +125,53 @@ func initRuntime(configPath string) (*config.Config, *sqlite.SQLiteStore, llm.Pr
 	}
 
 	return cfg, db, provider, log
+}
+
+// newMCPProvider creates an LLM provider suitable for MCP processes.
+// MCP processes handle occasional encoding (remember) and rare synthesis (recall),
+// so they should avoid loading GPU models when possible.
+//
+// Strategy:
+//  1. If an API endpoint is configured, use it directly — zero VRAM cost.
+//  2. If air-gapped (no API endpoint), create an embedded provider with deferred
+//     model loading. Models load on first Complete()/Embed() call, not at startup.
+//     MCP sessions that never call remember pay zero VRAM.
+func newMCPProvider(cfg *config.Config) llm.Provider {
+	if cfg.LLM.Endpoint != "" {
+		slog.Info("MCP using API provider for encoding", "endpoint", cfg.LLM.Endpoint)
+		return newAPIProvider(cfg)
+	}
+
+	// Air-gapped fallback: deferred embedded provider.
+	if cfg.LLM.Provider == "embedded" {
+		slog.Info("MCP using deferred embedded provider (no API endpoint configured)")
+		ep := llm.NewEmbeddedProvider(llm.EmbeddedProviderConfig{
+			ModelsDir:      cfg.LLM.Embedded.ModelsDir,
+			ChatModelFile:  cfg.LLM.Embedded.ChatModelFile,
+			EmbedModelFile: cfg.LLM.Embedded.EmbedModelFile,
+			ChatTemplate:   cfg.LLM.Embedded.ChatTemplate,
+			ContextSize:    cfg.LLM.Embedded.ContextSize,
+			GPULayers:      cfg.LLM.Embedded.GPULayers,
+			Threads:        cfg.LLM.Embedded.Threads,
+			BatchSize:      cfg.LLM.Embedded.BatchSize,
+			MaxTokens:      cfg.LLM.MaxTokens,
+			Temperature:    float32(cfg.LLM.Temperature),
+			MaxConcurrent:  cfg.LLM.MaxConcurrent,
+		})
+		backend := llamacpp.NewBackend()
+		if backend != nil {
+			ep.DeferLoad(func() llm.Backend {
+				return llamacpp.NewBackend()
+			})
+		} else {
+			slog.Warn("embedded provider selected but llama.cpp not compiled in")
+		}
+		return ep
+	}
+
+	// No endpoint, no embedded — nothing to provide.
+	slog.Warn("MCP has no LLM provider configured (no endpoint, not embedded)")
+	return newAPIProvider(cfg)
 }
 
 // toConsolidationConfig converts the global config's consolidation settings to the agent's config.

--- a/internal/llm/embedded.go
+++ b/internal/llm/embedded.go
@@ -93,6 +93,12 @@ type EmbeddedProvider struct {
 	embedBackend   Backend
 	sem            chan struct{}
 	backendFactory func() Backend
+
+	// Lazy loading: DeferLoad stores the factory without loading models.
+	// The first Complete() or Embed() call triggers the actual load via sync.Once.
+	deferredFactory func() Backend
+	loadOnce        sync.Once
+	loadErr         error
 }
 
 // EmbeddedProviderConfig holds the configuration for creating an EmbeddedProvider.
@@ -183,6 +189,32 @@ func (p *EmbeddedProvider) LoadModels(backendFactory func() Backend) error {
 	return nil
 }
 
+// DeferLoad stores the backend factory for lazy initialization.
+// Unlike LoadModels, this does NOT load the models into memory immediately.
+// The first call to Complete() or Embed() triggers the actual model load.
+// Use this for processes that may never need inference (e.g., MCP servers
+// in air-gapped mode where most sessions only read, not write).
+func (p *EmbeddedProvider) DeferLoad(backendFactory func() Backend) {
+	p.mu.Lock()
+	defer p.mu.Unlock()
+	p.backendFactory = backendFactory
+	p.deferredFactory = backendFactory
+}
+
+// ensureLoaded triggers lazy model loading if DeferLoad was used.
+// Thread-safe via sync.Once — the first caller loads, all others block until done.
+// Returns nil immediately if models were loaded eagerly via LoadModels.
+func (p *EmbeddedProvider) ensureLoaded() error {
+	if p.deferredFactory == nil {
+		return nil // eager-loaded or no factory configured
+	}
+	p.loadOnce.Do(func() {
+		slog.Info("lazy-loading embedded models on first inference call")
+		p.loadErr = p.LoadModels(p.deferredFactory)
+	})
+	return p.loadErr
+}
+
 // acquire blocks until a concurrency slot is available or ctx is cancelled.
 func (p *EmbeddedProvider) acquire(ctx context.Context) error {
 	select {
@@ -260,6 +292,10 @@ func stopSequenceForTemplate(template string) string {
 
 // Complete sends a completion request to the in-process backend.
 func (p *EmbeddedProvider) Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error) {
+	if err := p.ensureLoaded(); err != nil {
+		return CompletionResponse{}, fmt.Errorf("lazy load failed: %w", err)
+	}
+
 	if err := p.acquire(ctx); err != nil {
 		return CompletionResponse{}, fmt.Errorf("embedded provider busy: %w", err)
 	}
@@ -370,6 +406,10 @@ func (p *EmbeddedProvider) Embed(ctx context.Context, text string) ([]float32, e
 func (p *EmbeddedProvider) BatchEmbed(ctx context.Context, texts []string) ([][]float32, error) {
 	if len(texts) == 0 {
 		return [][]float32{}, nil
+	}
+
+	if err := p.ensureLoaded(); err != nil {
+		return nil, fmt.Errorf("lazy load failed: %w", err)
 	}
 
 	if err := p.acquire(ctx); err != nil {

--- a/internal/llm/embedded_test.go
+++ b/internal/llm/embedded_test.go
@@ -3,6 +3,7 @@ package llm
 import (
 	"context"
 	"os"
+	"sync"
 	"testing"
 )
 
@@ -329,6 +330,226 @@ func TestEmbeddedProviderBatchEmbedEmpty(t *testing.T) {
 	}
 	if len(result) != 0 {
 		t.Errorf("expected empty result, got %d", len(result))
+	}
+}
+
+func TestDeferLoadDoesNotLoadImmediately(t *testing.T) {
+	dir := t.TempDir()
+	chatFile := "chat.gguf"
+	if err := writeTestFile(dir, chatFile); err != nil {
+		t.Fatalf("creating test file: %v", err)
+	}
+
+	loadCount := 0
+	p := NewEmbeddedProvider(EmbeddedProviderConfig{
+		ModelsDir:     dir,
+		ChatModelFile: chatFile,
+		MaxTokens:     256,
+		Temperature:   0.3,
+		MaxConcurrent: 1,
+	})
+
+	p.DeferLoad(func() Backend {
+		loadCount++
+		return &mockBackend{}
+	})
+
+	// After DeferLoad, no backend should be loaded
+	if loadCount != 0 {
+		t.Fatalf("DeferLoad triggered %d model loads, expected 0", loadCount)
+	}
+
+	// Health should report not ready (no model loaded yet)
+	ctx := context.Background()
+	if err := p.Health(ctx); err == nil {
+		t.Fatal("expected Health to fail before first use with DeferLoad")
+	}
+
+	// ActiveModel should show not loaded
+	status := p.ActiveModel()
+	if status.Loaded {
+		t.Fatal("ActiveModel.Loaded should be false before first use")
+	}
+}
+
+func TestDeferLoadTriggersOnFirstComplete(t *testing.T) {
+	dir := t.TempDir()
+	chatFile := "chat.gguf"
+	if err := writeTestFile(dir, chatFile); err != nil {
+		t.Fatalf("creating test file: %v", err)
+	}
+
+	loadCount := 0
+	p := NewEmbeddedProvider(EmbeddedProviderConfig{
+		ModelsDir:     dir,
+		ChatModelFile: chatFile,
+		MaxTokens:     256,
+		Temperature:   0.3,
+		MaxConcurrent: 1,
+	})
+
+	p.DeferLoad(func() Backend {
+		loadCount++
+		return &mockBackend{}
+	})
+
+	ctx := context.Background()
+
+	// First Complete() triggers lazy load
+	resp, err := p.Complete(ctx, CompletionRequest{
+		Messages: []Message{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete failed: %v", err)
+	}
+	if resp.Content != `{"summary": "test"}` {
+		t.Errorf("unexpected content: %s", resp.Content)
+	}
+	if loadCount != 1 {
+		t.Fatalf("expected exactly 1 model load on first Complete, got %d", loadCount)
+	}
+
+	// Second Complete() should NOT trigger another load
+	_, err = p.Complete(ctx, CompletionRequest{
+		Messages: []Message{{Role: "user", Content: "again"}},
+	})
+	if err != nil {
+		t.Fatalf("second Complete failed: %v", err)
+	}
+	if loadCount != 1 {
+		t.Fatalf("expected still 1 model load after second Complete, got %d", loadCount)
+	}
+}
+
+func TestDeferLoadTriggersOnFirstEmbed(t *testing.T) {
+	dir := t.TempDir()
+	chatFile := "chat.gguf"
+	if err := writeTestFile(dir, chatFile); err != nil {
+		t.Fatalf("creating test file: %v", err)
+	}
+
+	loadCount := 0
+	p := NewEmbeddedProvider(EmbeddedProviderConfig{
+		ModelsDir:     dir,
+		ChatModelFile: chatFile,
+		MaxTokens:     256,
+		Temperature:   0.3,
+		MaxConcurrent: 1,
+	})
+
+	p.DeferLoad(func() Backend {
+		loadCount++
+		return &mockBackend{}
+	})
+
+	ctx := context.Background()
+
+	// First Embed() triggers lazy load
+	emb, err := p.Embed(ctx, "test")
+	if err != nil {
+		t.Fatalf("Embed failed: %v", err)
+	}
+	if len(emb) != 3 {
+		t.Errorf("expected 3-dim embedding, got %d", len(emb))
+	}
+	if loadCount != 1 {
+		t.Fatalf("expected exactly 1 model load on first Embed, got %d", loadCount)
+	}
+}
+
+func TestDeferLoadConcurrentAccess(t *testing.T) {
+	dir := t.TempDir()
+	chatFile := "chat.gguf"
+	if err := writeTestFile(dir, chatFile); err != nil {
+		t.Fatalf("creating test file: %v", err)
+	}
+
+	var mu sync.Mutex
+	loadCount := 0
+	p := NewEmbeddedProvider(EmbeddedProviderConfig{
+		ModelsDir:     dir,
+		ChatModelFile: chatFile,
+		MaxTokens:     256,
+		Temperature:   0.3,
+		MaxConcurrent: 10, // allow concurrent access
+	})
+
+	p.DeferLoad(func() Backend {
+		mu.Lock()
+		loadCount++
+		mu.Unlock()
+		return &mockBackend{}
+	})
+
+	ctx := context.Background()
+
+	// Launch 10 goroutines that all call Complete concurrently
+	var wg sync.WaitGroup
+	errs := make(chan error, 10)
+	for range 10 {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			_, err := p.Complete(ctx, CompletionRequest{
+				Messages: []Message{{Role: "user", Content: "hello"}},
+			})
+			if err != nil {
+				errs <- err
+			}
+		}()
+	}
+
+	wg.Wait()
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("concurrent Complete failed: %v", err)
+	}
+
+	// sync.Once guarantees exactly 1 load despite 10 concurrent callers
+	mu.Lock()
+	got := loadCount
+	mu.Unlock()
+	if got != 1 {
+		t.Fatalf("expected exactly 1 model load with 10 concurrent callers, got %d", got)
+	}
+}
+
+func TestEagerLoadSkipsEnsureLoaded(t *testing.T) {
+	dir := t.TempDir()
+	chatFile := "chat.gguf"
+	if err := writeTestFile(dir, chatFile); err != nil {
+		t.Fatalf("creating test file: %v", err)
+	}
+
+	p := NewEmbeddedProvider(EmbeddedProviderConfig{
+		ModelsDir:     dir,
+		ChatModelFile: chatFile,
+		MaxTokens:     256,
+		Temperature:   0.3,
+		MaxConcurrent: 1,
+	})
+
+	// Eager load (the daemon path)
+	err := p.LoadModels(func() Backend { return &mockBackend{} })
+	if err != nil {
+		t.Fatalf("LoadModels failed: %v", err)
+	}
+
+	// deferredFactory should be nil — ensureLoaded is a no-op
+	if p.deferredFactory != nil {
+		t.Fatal("deferredFactory should be nil after eager LoadModels")
+	}
+
+	ctx := context.Background()
+	resp, err := p.Complete(ctx, CompletionRequest{
+		Messages: []Message{{Role: "user", Content: "hello"}},
+	})
+	if err != nil {
+		t.Fatalf("Complete failed: %v", err)
+	}
+	if resp.Content != `{"summary": "test"}` {
+		t.Errorf("unexpected content: %s", resp.Content)
 	}
 }
 


### PR DESCRIPTION
## Summary

- MCP processes (`mnemonic mcp`, spawned per Claude Code session) were unconditionally loading the embedded LLM into GPU memory (~4GB each). With 2-3 sessions open, VRAM hit 12-13GB of 16GB, starving the daemon and crashing inference.
- Split `initRuntime` into `initBase` (config+db+log, no LLM) and `initRuntime` (adds eager LLM). MCP now uses `newMCPProvider()` which prefers the API endpoint (zero VRAM) with lazy-loaded embedded fallback for air-gapped mode.
- Added `DeferLoad()`/`ensureLoaded()` to `EmbeddedProvider` using `sync.Once` for thread-safe lazy initialization — models load on first `Complete()`/`Embed()` call, not at construction.
- Switched 8 read-only CLI commands (`export`, `import`, `backup`, `purge`, `cleanup`, `dedup`, `reset-patterns`, `insights`, `autopilot`) from `initRuntime` to `initBase` — they were loading a 4GB GPU model they never used.

**Result**: daemon 4.1GB VRAM (unchanged), each MCP process 0 VRAM (was ~4GB). Total VRAM with multiple sessions: ~5GB (was ~13GB).

## Test plan

- [x] All existing tests pass
- [x] 5 new tests for lazy loading: deferred load, first-Complete trigger, first-Embed trigger, concurrent access (10 goroutines, sync.Once guarantees 1 load), eager-load bypass
- [x] `golangci-lint run` clean
- [x] Verified with `rocm-smi --showpids`: daemon loads model (4.1GB), MCP processes show 0 VRAM
- [x] MCP tools (recall, remember) still functional after fix
- [x] Built with `ROCM=1 make build-embedded`

🤖 Generated with [Claude Code](https://claude.com/claude-code)