### PR TITLE
feat: SPLICE API for CRISPR-LM (edit/status/tensor/complete) + Gemma 4 template fix

### DIFF
--- a/internal/api/routes/complete.go
+++ b/internal/api/routes/complete.go
@@ -1,0 +1,86 @@
+package routes
+
+import (
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"time"
+
+	"github.com/appsprout-dev/mnemonic/internal/llm"
+)
+
+// completeRequest is the JSON body for POST /api/v1/complete.
+type completeRequest struct {
+	Prompt      string        `json:"prompt,omitempty"`
+	Messages    []llm.Message `json:"messages,omitempty"`
+	System      string        `json:"system,omitempty"`
+	MaxTokens   int           `json:"max_tokens,omitempty"`
+	Temperature float32       `json:"temperature,omitempty"`
+}
+
+// HandleComplete handles POST /api/v1/complete
+// Raw LLM completion endpoint — bypasses retrieval for controlled testing.
+func HandleComplete(provider llm.Provider, log *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if provider == nil {
+			writeError(w, http.StatusServiceUnavailable, "LLM provider not available", "LLM_UNAVAILABLE")
+			return
+		}
+
+		var req completeRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error(), "COMPLETE_BAD_REQUEST")
+			return
+		}
+
+		// Build messages
+		var messages []llm.Message
+		if len(req.Messages) > 0 {
+			messages = req.Messages
+		} else if req.Prompt != "" {
+			if req.System != "" {
+				messages = append(messages, llm.Message{Role: "system", Content: req.System})
+			}
+			messages = append(messages, llm.Message{Role: "user", Content: req.Prompt})
+		} else {
+			writeError(w, http.StatusBadRequest, "prompt or messages is required", "COMPLETE_EMPTY")
+			return
+		}
+
+		maxTokens := req.MaxTokens
+		if maxTokens <= 0 {
+			maxTokens = 64
+		}
+
+		temperature := req.Temperature
+		if temperature <= 0 {
+			temperature = 0.0
+		}
+
+		start := time.Now()
+		resp, err := provider.Complete(r.Context(), llm.CompletionRequest{
+			Messages:    messages,
+			MaxTokens:   maxTokens,
+			Temperature: temperature,
+		})
+		if err != nil {
+			log.Error("complete failed", "error", err)
+			writeError(w, http.StatusInternalServerError, "completion failed: "+err.Error(), "COMPLETE_ERROR")
+			return
+		}
+
+		elapsed := time.Since(start)
+		log.Info("complete", "tokens", resp.CompletionTokens, "elapsed", elapsed)
+
+		writeJSON(w, http.StatusOK, map[string]any{
+			"content":           resp.Content,
+			"stop_reason":       resp.StopReason,
+			"tokens_used":       resp.TokensUsed,
+			"prompt_tokens":     resp.PromptTokens,
+			"completion_tokens": resp.CompletionTokens,
+			"mean_prob":         resp.MeanProb,
+			"min_prob":          resp.MinProb,
+			"elapsed_ms":        elapsed.Milliseconds(),
+		})
+	}
+}

--- a/internal/api/routes/splice.go
+++ b/internal/api/routes/splice.go
@@ -1,0 +1,112 @@
+package routes
+
+import (
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math"
+	"net/http"
+	"strconv"
+	"time"
+
+	"github.com/appsprout-dev/mnemonic/internal/llm"
+)
+
+// HandleSpliceEdit handles POST /api/v1/splice/edit
+// Accepts gate bias edits and applies them to the running model.
+func HandleSpliceEdit(mgr llm.ModelManager, log *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if mgr == nil {
+			writeError(w, http.StatusServiceUnavailable, "model manager not available", "SPLICE_UNAVAILABLE")
+			return
+		}
+
+		se := mgr.SpokeEditor()
+		if se == nil {
+			writeError(w, http.StatusServiceUnavailable, "spoke editor not available (model may not have spokes)", "SPLICE_NO_SPOKES")
+			return
+		}
+
+		var req struct {
+			GateBiases map[string]float64 `json:"gate_biases"` // layer -> value
+		}
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error(), "SPLICE_BAD_REQUEST")
+			return
+		}
+
+		if len(req.GateBiases) == 0 {
+			writeError(w, http.StatusBadRequest, "no edits provided (need gate_biases)", "SPLICE_EMPTY")
+			return
+		}
+
+		start := time.Now()
+		applied := 0
+		var errors []string
+
+		for layerStr, value := range req.GateBiases {
+			layer, err := strconv.Atoi(layerStr)
+			if err != nil {
+				errors = append(errors, fmt.Sprintf("invalid layer %q: %v", layerStr, err))
+				continue
+			}
+
+			if err := se.SetSpokeGateBias(layer, float32(value)); err != nil {
+				errors = append(errors, fmt.Sprintf("layer %d: %v", layer, err))
+				continue
+			}
+			applied++
+		}
+
+		elapsed := time.Since(start)
+		log.Info("splice edit", "applied", applied, "errors", len(errors), "elapsed", elapsed)
+
+		resp := map[string]any{
+			"status":     "ok",
+			"applied":    applied,
+			"elapsed_us": elapsed.Microseconds(),
+		}
+		if len(errors) > 0 {
+			resp["errors"] = errors
+		}
+		writeJSON(w, http.StatusOK, resp)
+	}
+}
+
+// HandleSpliceStatus handles GET /api/v1/splice/status
+// Returns current gate bias values for all spoke layers.
+func HandleSpliceStatus(mgr llm.ModelManager, log *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if mgr == nil {
+			writeError(w, http.StatusServiceUnavailable, "model manager not available", "SPLICE_UNAVAILABLE")
+			return
+		}
+
+		se := mgr.SpokeEditor()
+		if se == nil {
+			writeError(w, http.StatusServiceUnavailable, "spoke editor not available", "SPLICE_NO_SPOKES")
+			return
+		}
+
+		// Read gate biases for layers 0-34 (Gemma 4 has 35 layers)
+		// Try up to 128 layers and stop at first failure
+		biases := make(map[string]any)
+		for layer := 0; layer < 128; layer++ {
+			value, err := se.GetSpokeGateBias(layer)
+			if err != nil {
+				break // no more spoke layers
+			}
+			sigmoid := 1.0 / (1.0 + math.Exp(-float64(value)))
+			biases[strconv.Itoa(layer)] = map[string]any{
+				"gate_bias": value,
+				"sigmoid":   sigmoid,
+			}
+		}
+
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status":   "ok",
+			"n_layers": len(biases),
+			"layers":   biases,
+		})
+	}
+}

--- a/internal/api/routes/splice_tensor.go
+++ b/internal/api/routes/splice_tensor.go
@@ -1,0 +1,114 @@
+package routes
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math"
+	"net/http"
+	"time"
+
+	"github.com/appsprout-dev/mnemonic/internal/llm"
+)
+
+// spokeTensorRequest is the JSON body for POST /api/v1/splice/tensor.
+type spokeTensorRequest struct {
+	Name  string `json:"name"`            // tensor name, e.g. "blk.5.spoke.w_up_fused.weight"
+	Data  string `json:"data"`            // base64-encoded tensor bytes
+	Dtype string `json:"dtype,omitempty"` // "f32" for auto-quantization, empty for raw bytes
+}
+
+// HandleSpliceTensor handles POST /api/v1/splice/tensor
+// Sets spoke tensor data by name. Data is base64-encoded.
+//
+// When dtype is empty (default): raw bytes matching the tensor's stored type.
+// When dtype is "f32": F32 floats that will be auto-quantized to the tensor's
+// native type (F16, RQ4, etc.). This enables training in F32/F16 and pushing
+// directly to a quantized model without a GGUF rebuild.
+func HandleSpliceTensor(mgr llm.ModelManager, log *slog.Logger) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if mgr == nil {
+			writeError(w, http.StatusServiceUnavailable, "model manager not available", "SPLICE_UNAVAILABLE")
+			return
+		}
+
+		se := mgr.SpokeEditor()
+		if se == nil {
+			writeError(w, http.StatusServiceUnavailable, "spoke editor not available", "SPLICE_NO_SPOKES")
+			return
+		}
+
+		var req spokeTensorRequest
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeError(w, http.StatusBadRequest, "invalid JSON: "+err.Error(), "SPLICE_BAD_REQUEST")
+			return
+		}
+
+		if req.Name == "" {
+			writeError(w, http.StatusBadRequest, "tensor name is required", "SPLICE_EMPTY_NAME")
+			return
+		}
+
+		if req.Data == "" {
+			writeError(w, http.StatusBadRequest, "tensor data is required", "SPLICE_EMPTY_DATA")
+			return
+		}
+
+		data, err := base64.StdEncoding.DecodeString(req.Data)
+		if err != nil {
+			writeError(w, http.StatusBadRequest, fmt.Sprintf("invalid base64 data: %v", err), "SPLICE_BAD_DATA")
+			return
+		}
+
+		start := time.Now()
+
+		if req.Dtype == "f32" {
+			// Interpret data as F32 floats, auto-quantize to tensor's native type
+			if len(data)%4 != 0 {
+				writeError(w, http.StatusBadRequest, "f32 data must be a multiple of 4 bytes", "SPLICE_BAD_DATA")
+				return
+			}
+			nelem := len(data) / 4
+			floats := make([]float32, nelem)
+			for i := range floats {
+				floats[i] = math.Float32frombits(
+					uint32(data[i*4]) | uint32(data[i*4+1])<<8 |
+						uint32(data[i*4+2])<<16 | uint32(data[i*4+3])<<24,
+				)
+			}
+			if err := se.SetSpokeTensorF32(req.Name, floats); err != nil {
+				log.Error("splice tensor f32 set failed", "name", req.Name, "nelem", nelem, "error", err)
+				writeError(w, http.StatusInternalServerError, "tensor set failed: "+err.Error(), "SPLICE_TENSOR_ERROR")
+				return
+			}
+			elapsed := time.Since(start)
+			log.Info("splice tensor f32 set", "name", req.Name, "nelem", nelem, "elapsed", elapsed)
+			writeJSON(w, http.StatusOK, map[string]any{
+				"status":     "ok",
+				"name":       req.Name,
+				"nelem":      nelem,
+				"dtype":      "f32",
+				"elapsed_us": elapsed.Microseconds(),
+			})
+			return
+		}
+
+		// Raw bytes path (original behavior)
+		if err := se.SetSpokeTensor(req.Name, data); err != nil {
+			log.Error("splice tensor set failed", "name", req.Name, "error", err)
+			writeError(w, http.StatusInternalServerError, "tensor set failed: "+err.Error(), "SPLICE_TENSOR_ERROR")
+			return
+		}
+
+		elapsed := time.Since(start)
+		log.Info("splice tensor set", "name", req.Name, "bytes", len(data), "elapsed", elapsed)
+
+		writeJSON(w, http.StatusOK, map[string]any{
+			"status":     "ok",
+			"name":       req.Name,
+			"bytes":      len(data),
+			"elapsed_us": elapsed.Microseconds(),
+		})
+	}
+}

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -140,6 +140,16 @@ func (s *Server) registerRoutes() {
 	s.mux.HandleFunc("GET /api/v1/models/active", routes.HandleActiveModel(s.deps.ModelManager, s.deps.Log))
 	s.mux.HandleFunc("POST /api/v1/models/active", routes.HandleSwapModel(s.deps.ModelManager, s.deps.Log))
 
+	// SPLICE: spoke tensor editing
+	s.mux.HandleFunc("POST /api/v1/splice/edit", routes.HandleSpliceEdit(s.deps.ModelManager, s.deps.Log))
+	s.mux.HandleFunc("GET /api/v1/splice/status", routes.HandleSpliceStatus(s.deps.ModelManager, s.deps.Log))
+
+	// SPLICE Phase 2: spoke tensor editing
+	s.mux.HandleFunc("POST /api/v1/splice/tensor", routes.HandleSpliceTensor(s.deps.ModelManager, s.deps.Log))
+
+	// Raw completion (bypasses retrieval — for CRISPR-LM controlled testing)
+	s.mux.HandleFunc("POST /api/v1/complete", routes.HandleComplete(s.deps.LLM, s.deps.Log))
+
 	// LLM usage monitoring
 	s.mux.HandleFunc("GET /api/v1/llm/usage", routes.HandleLLMUsage(s.deps.Store, s.deps.Log))
 

--- a/internal/llm/embedded.go
+++ b/internal/llm/embedded.go
@@ -262,30 +262,26 @@ func formatPromptChatML(messages []Message) string {
 	return b.String()
 }
 
-// formatPromptGemma formats messages using Gemma's chat template.
-// Maps "system" role to user turn (Gemma doesn't have a system role — system
-// instructions go in the first user turn).
+// formatPromptGemma formats messages using Gemma 4's chat template.
+// Gemma 4 uses <|turn> / <turn|> tokens (not <start_of_turn> / <end_of_turn>).
+// Maps "system" role to a system turn (Gemma 4 supports system role natively).
 func formatPromptGemma(messages []Message) string {
 	var b strings.Builder
 	for _, msg := range messages {
-		role := msg.Role
-		if role == "system" {
-			role = "user"
-		}
-		b.WriteString("<start_of_turn>")
-		b.WriteString(role)
+		b.WriteString("<|turn>")
+		b.WriteString(msg.Role)
 		b.WriteByte('\n')
 		b.WriteString(msg.Content)
-		b.WriteString("<end_of_turn>\n")
+		b.WriteString("<turn|>\n")
 	}
-	b.WriteString("<start_of_turn>model\n")
+	b.WriteString("<|turn>model\n")
 	return b.String()
 }
 
 // stopSequenceForTemplate returns the EOS token for the given chat template.
 func stopSequenceForTemplate(template string) string {
 	if template == "gemma" {
-		return "<end_of_turn>"
+		return "<turn|>"
 	}
 	return "<|im_end|>"
 }
@@ -696,6 +692,18 @@ func (p *EmbeddedProvider) Close() error {
 
 	if len(errs) > 0 {
 		return fmt.Errorf("closing embedded provider: %v", errs)
+	}
+	return nil
+}
+
+// SpokeEditor returns the chat backend as a SpokeEditor if it supports
+// spoke tensor editing (SPLICE). Returns nil if not supported.
+func (p *EmbeddedProvider) SpokeEditor() SpokeEditor {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+
+	if se, ok := p.chatBackend.(SpokeEditor); ok {
+		return se
 	}
 	return nil
 }

--- a/internal/llm/embedded_test.go
+++ b/internal/llm/embedded_test.go
@@ -309,9 +309,9 @@ func TestFormatPrompt(t *testing.T) {
 		t.Errorf("formatPrompt(chatml) mismatch:\ngot:  %q\nwant: %q", got, expected)
 	}
 
-	// Gemma format — system role mapped to user turn
+	// Gemma 4 format — <|turn>/<turn|> tokens, native system role
 	gotGemma := formatPrompt(messages, "gemma")
-	expectedGemma := "<start_of_turn>user\nYou are helpful.<end_of_turn>\n<start_of_turn>user\nHello<end_of_turn>\n<start_of_turn>model\n"
+	expectedGemma := "<|turn>system\nYou are helpful.<turn|>\n<|turn>user\nHello<turn|>\n<|turn>model\n"
 	if gotGemma != expectedGemma {
 		t.Errorf("formatPrompt(gemma) mismatch:\ngot:  %q\nwant: %q", gotGemma, expectedGemma)
 	}

--- a/internal/llm/llamacpp/backend.go
+++ b/internal/llm/llamacpp/backend.go
@@ -13,6 +13,7 @@ import "C"
 import (
 	"context"
 	"fmt"
+	"runtime"
 	"sync"
 	"unsafe"
 
@@ -148,4 +149,86 @@ func (b *Backend) Close() error {
 		b.model = nil
 	}
 	return nil
+}
+
+// --- SPLICE: Spoke tensor hot-swap ---
+
+// SetSpokeGateBias sets the gate bias for a single spoke layer.
+func (b *Backend) SetSpokeGateBias(layer int, value float32) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.model == nil {
+		return fmt.Errorf("model not loaded")
+	}
+
+	rc := C.mnm_set_spoke_gate_bias(b.model, C.int(layer), C.float(value))
+	if rc != 0 {
+		return fmt.Errorf("set spoke gate bias failed (layer=%d, rc=%d)", layer, rc)
+	}
+	return nil
+}
+
+// SetSpokeTensor sets arbitrary tensor data by name (raw bytes, must match tensor size).
+func (b *Backend) SetSpokeTensor(name string, data []byte) error {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.model == nil {
+		return fmt.Errorf("model not loaded")
+	}
+
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+
+	rc := C.mnm_set_spoke_tensor(b.model, cname, unsafe.Pointer(&data[0]), C.int(len(data)))
+	if rc != 0 {
+		return fmt.Errorf("set spoke tensor failed (name=%s, rc=%d)", name, rc)
+	}
+	return nil
+}
+
+// SetSpokeTensorF32 sets tensor data from F32 floats with automatic quantization.
+// The data is quantized to the tensor's native type (F16, RQ4, etc.) before writing.
+// Pins the goroutine to the current OS thread for ROCm/HIP context affinity.
+func (b *Backend) SetSpokeTensorF32(name string, data []float32) error {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.model == nil {
+		return fmt.Errorf("model not loaded")
+	}
+
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+
+	rc := C.mnm_set_spoke_tensor_f32(b.model, cname, (*C.float)(unsafe.Pointer(&data[0])), C.int(len(data)))
+	if rc != 0 {
+		return fmt.Errorf("set spoke tensor f32 failed (name=%s, rc=%d)", name, rc)
+	}
+	return nil
+}
+
+// GetSpokeGateBias reads the current gate bias for a spoke layer.
+func (b *Backend) GetSpokeGateBias(layer int) (float32, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+
+	if b.model == nil {
+		return 0, fmt.Errorf("model not loaded")
+	}
+
+	name := fmt.Sprintf("blk.%d.spoke.gate_bias", layer)
+	cname := C.CString(name)
+	defer C.free(unsafe.Pointer(cname))
+
+	var value float32
+	rc := C.mnm_get_spoke_tensor(b.model, cname, unsafe.Pointer(&value), C.int(4))
+	if rc != 0 {
+		return 0, fmt.Errorf("get spoke gate bias failed (layer=%d, rc=%d)", layer, int(rc))
+	}
+	return value, nil
 }

--- a/internal/llm/llamacpp/csrc/bridge.cpp
+++ b/internal/llm/llamacpp/csrc/bridge.cpp
@@ -277,6 +277,33 @@ mnm_embedding_result mnm_embed(mnm_model *m, const char *text) {
     return result;
 }
 
+int mnm_set_spoke_gate_bias(mnm_model *m, int layer, float value) {
+    if (!m || !m->model) return -1;
+
+    char name[64];
+    snprintf(name, sizeof(name), "blk.%d.spoke.gate_bias", layer);
+
+    return llama_model_set_tensor_data(m->model, name, &value, 0, sizeof(float));
+}
+
+int mnm_set_spoke_tensor(mnm_model *m, const char *name, const void *data, int nbytes) {
+    if (!m || !m->model || !name || !data) return -1;
+
+    return llama_model_set_tensor_data(m->model, name, data, 0, (size_t)nbytes);
+}
+
+int mnm_set_spoke_tensor_f32(mnm_model *m, const char *name, const float *data, int nelem) {
+    if (!m || !m->model || !name || !data) return -1;
+
+    return llama_model_set_tensor_data_f32(m->model, name, data, (int64_t)nelem);
+}
+
+int mnm_get_spoke_tensor(mnm_model *m, const char *name, void *data, int nbytes) {
+    if (!m || !m->model || !name || !data) return -1;
+
+    return llama_model_get_tensor_data(m->model, name, data, 0, (size_t)nbytes);
+}
+
 void mnm_free_string(char *s) { free(s); }
 void mnm_free_floats(float *f) { free(f); }
 

--- a/internal/llm/llamacpp/csrc/bridge.h
+++ b/internal/llm/llamacpp/csrc/bridge.h
@@ -53,6 +53,20 @@ mnm_completion_result mnm_complete(
 // Generate an embedding vector for the given text.
 mnm_embedding_result mnm_embed(mnm_model *m, const char *text);
 
+// SPLICE: spoke tensor hot-swap
+// Set a single gate_bias for a spoke layer. Returns 0 on success.
+int mnm_set_spoke_gate_bias(mnm_model *m, int layer, float value);
+
+// Set arbitrary tensor data by name (raw bytes, must match tensor size). Returns 0 on success.
+int mnm_set_spoke_tensor(mnm_model *m, const char *name, const void *data, int nbytes);
+
+// Set tensor from F32 data with automatic quantization to native type.
+// nelem = total number of float32 elements. Returns 0 on success.
+int mnm_set_spoke_tensor_f32(mnm_model *m, const char *name, const float *data, int nelem);
+
+// Get tensor data by name. Returns 0 on success.
+int mnm_get_spoke_tensor(mnm_model *m, const char *name, void *data, int nbytes);
+
 // Free helpers
 void mnm_free_string(char *s);
 void mnm_free_floats(float *f);

--- a/internal/llm/provider.go
+++ b/internal/llm/provider.go
@@ -131,6 +131,18 @@ type ModelManager interface {
 
 	// ProviderMode returns the current mode ("embedded" or "api").
 	ProviderMode() string
+
+	// SpokeEditor returns the spoke editor if available (SPLICE), or nil.
+	SpokeEditor() SpokeEditor
+}
+
+// SpokeEditor is the interface for SPLICE spoke tensor editing.
+// Implemented by the llamacpp Backend when spokes are present.
+type SpokeEditor interface {
+	SetSpokeGateBias(layer int, value float32) error
+	GetSpokeGateBias(layer int) (float32, error)
+	SetSpokeTensor(name string, data []byte) error
+	SetSpokeTensorF32(name string, data []float32) error
 }
 
 // ErrProviderUnavailable is returned when the LLM backend is not reachable.

--- a/internal/llm/switchable.go
+++ b/internal/llm/switchable.go
@@ -148,3 +148,8 @@ func (s *SwitchableProvider) ProviderMode() string {
 	}
 	return "embedded"
 }
+
+// SpokeEditor delegates to the embedded provider's spoke editor.
+func (s *SwitchableProvider) SpokeEditor() SpokeEditor {
+	return s.embedded.SpokeEditor()
+}

--- a/tests/splice_test.cpp
+++ b/tests/splice_test.cpp
@@ -1,0 +1,200 @@
+// SPLICE Phase 1 verification: prove that modifying a spoke gate_bias
+// changes model output between inference batches.
+//
+// Build:
+//   g++ -std=c++17 -O2 tests/splice_test.cpp -o bin/splice_test \
+//       -Ithird_party/llama.cpp/include -Ithird_party/llama.cpp/ggml/include \
+//       -Lthird_party/llama.cpp/build/src -lllama \
+//       -Lthird_party/llama.cpp/build/ggml/src -lggml -lggml-base -lggml-cpu \
+//       -lm -lstdc++ -lpthread -fopenmp
+//
+// Run:
+//   ./bin/splice_test models/gemma4-e2b-exp31-spokes-f16.gguf
+
+#include "llama.h"
+#include "ggml-backend.h"
+
+#include <cmath>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+#include <vector>
+
+static std::string generate(llama_context * ctx, const llama_vocab * vocab,
+                            const char * prompt, int max_tokens) {
+    // Tokenize
+    int n = strlen(prompt);
+    std::vector<llama_token> tokens(n + 64);
+    int n_tokens = llama_tokenize(vocab, prompt, n, tokens.data(), tokens.size(), false, true);
+    if (n_tokens < 0) {
+        tokens.resize(-n_tokens);
+        n_tokens = llama_tokenize(vocab, prompt, n, tokens.data(), tokens.size(), false, true);
+    }
+    tokens.resize(n_tokens);
+
+    // Clear KV cache
+    llama_memory_clear(llama_get_memory(ctx), true);
+
+    // Decode prompt
+    int n_batch = llama_n_batch(ctx);
+    for (int i = 0; i < n_tokens; i += n_batch) {
+        int chunk = std::min(n_tokens - i, n_batch);
+        llama_batch batch = llama_batch_init(chunk, 0, 1);
+        for (int j = 0; j < chunk; j++) {
+            int idx = batch.n_tokens;
+            batch.token[idx] = tokens[i + j];
+            batch.pos[idx] = i + j;
+            batch.n_seq_id[idx] = 1;
+            batch.seq_id[idx][0] = 0;
+            batch.logits[idx] = (i + j == n_tokens - 1) ? 1 : 0;
+            batch.n_tokens++;
+        }
+        llama_decode(ctx, batch);
+        llama_batch_free(batch);
+    }
+
+    // Set up greedy sampler (deterministic)
+    auto sparams = llama_sampler_chain_default_params();
+    llama_sampler * smpl = llama_sampler_chain_init(sparams);
+    llama_sampler_chain_add(smpl, llama_sampler_init_greedy());
+
+    // Generate
+    std::string output;
+    int n_pos = n_tokens;
+    for (int i = 0; i < max_tokens; i++) {
+        llama_token new_token = llama_sampler_sample(smpl, ctx, -1);
+        if (llama_vocab_is_eog(vocab, new_token)) break;
+
+        char buf[256];
+        int len = llama_token_to_piece(vocab, new_token, buf, sizeof(buf), 0, true);
+        if (len > 0) output.append(buf, len);
+
+        llama_batch batch = llama_batch_init(1, 0, 1);
+        batch.token[0] = new_token;
+        batch.pos[0] = n_pos++;
+        batch.n_seq_id[0] = 1;
+        batch.seq_id[0][0] = 0;
+        batch.logits[0] = 1;
+        batch.n_tokens = 1;
+        llama_decode(ctx, batch);
+        llama_batch_free(batch);
+    }
+
+    llama_sampler_free(smpl);
+    return output;
+}
+
+int main(int argc, char ** argv) {
+    if (argc < 2) {
+        fprintf(stderr, "Usage: %s <model.gguf>\n", argv[0]);
+        return 1;
+    }
+
+    const char * model_path = argv[1];
+    const char * prompt = "Summarize the following text in JSON format:\n\nThe quick brown fox jumped over the lazy dog near the river bank on a sunny afternoon.\n\nJSON:";
+    const int n_layers = 35;
+    const int max_tokens = 30;
+
+    printf("SPLICE Phase 1 Test\n");
+    printf("===================\n");
+    printf("Model: %s\n", model_path);
+    printf("Prompt: \"%s\"\n", prompt);
+    printf("Strategy: disable ALL %d spoke layers\n\n", n_layers);
+
+    // Init
+    llama_backend_init();
+
+    auto mparams = llama_model_default_params();
+    mparams.n_gpu_layers = 99;
+
+    printf("Loading model...\n");
+    llama_model * model = llama_model_load_from_file(model_path, mparams);
+    if (!model) {
+        fprintf(stderr, "Failed to load model\n");
+        return 1;
+    }
+
+    auto cparams = llama_context_default_params();
+    cparams.n_ctx = 512;
+    cparams.n_batch = 512;
+    cparams.n_threads = 4;
+    cparams.n_threads_batch = 4;
+
+    llama_context * ctx = llama_init_from_model(model, cparams);
+    if (!ctx) {
+        fprintf(stderr, "Failed to create context\n");
+        return 1;
+    }
+
+    const llama_vocab * vocab = llama_model_get_vocab(model);
+
+    // Save original gate biases for all layers
+    float original_biases[35];
+    printf("Reading original gate biases:\n");
+    for (int il = 0; il < n_layers; il++) {
+        char tname[64];
+        snprintf(tname, sizeof(tname), "blk.%d.spoke.gate_bias", il);
+        int rc = llama_model_get_tensor_data(model, tname, &original_biases[il], 0, sizeof(float));
+        if (rc != 0) {
+            printf("  WARNING: could not read layer %d (rc=%d)\n", il, rc);
+            original_biases[il] = 0.0f;
+        }
+    }
+    printf("  Layer  0: %.4f (sigmoid=%.3f)\n", original_biases[0], 1.0f/(1.0f+expf(-original_biases[0])));
+    printf("  Layer 17: %.4f (sigmoid=%.3f)\n", original_biases[17], 1.0f/(1.0f+expf(-original_biases[17])));
+    printf("  Layer 34: %.4f (sigmoid=%.3f)\n", original_biases[34], 1.0f/(1.0f+expf(-original_biases[34])));
+
+    // --- Generation 1: original spokes ---
+    printf("\n--- Generation 1 (original spokes) ---\n");
+    std::string out1 = generate(ctx, vocab, prompt, max_tokens);
+    printf("Output: \"%s\"\n", out1.c_str());
+
+    // --- Disable ALL spokes ---
+    printf("\n--- Disabling ALL %d spoke layers (gate_bias = -10.0) ---\n", n_layers);
+    float disabled_bias = -10.0f;
+    for (int il = 0; il < n_layers; il++) {
+        char tname[64];
+        snprintf(tname, sizeof(tname), "blk.%d.spoke.gate_bias", il);
+        int rc = llama_model_set_tensor_data(model, tname, &disabled_bias, 0, sizeof(float));
+        if (rc != 0) {
+            fprintf(stderr, "  FAILED to set layer %d (rc=%d)\n", il, rc);
+        }
+    }
+    printf("All spokes disabled.\n");
+
+    // --- Generation 2: all spokes disabled ---
+    printf("\n--- Generation 2 (ALL spokes disabled) ---\n");
+    std::string out2 = generate(ctx, vocab, prompt, max_tokens);
+    printf("Output: \"%s\"\n", out2.c_str());
+
+    // --- Restore ALL original biases ---
+    printf("\n--- Restoring ALL original gate biases ---\n");
+    for (int il = 0; il < n_layers; il++) {
+        char tname[64];
+        snprintf(tname, sizeof(tname), "blk.%d.spoke.gate_bias", il);
+        llama_model_set_tensor_data(model, tname, &original_biases[il], 0, sizeof(float));
+    }
+    printf("All spokes restored.\n");
+
+    // --- Generation 3: restored ---
+    printf("\n--- Generation 3 (restored) ---\n");
+    std::string out3 = generate(ctx, vocab, prompt, max_tokens);
+    printf("Output: \"%s\"\n", out3.c_str());
+
+    // Verdict
+    printf("\n===================\n");
+    printf("RESULTS:\n");
+    printf("  Gen1 == Gen2: %s\n", (out1 == out2) ? "SAME (FAIL — spokes had no effect)" : "DIFFERENT (PASS — disabling spokes changed output)");
+    printf("  Gen1 == Gen3: %s\n", (out1 == out3) ? "SAME (PASS — restore worked)" : "DIFFERENT (FAIL — restore didn't work)");
+
+    bool pass = (out1 != out2) && (out1 == out3);
+    printf("\n  SPLICE Phase 1: %s\n", pass ? "PASS" : "FAIL");
+
+    // Cleanup
+    llama_free(ctx);
+    llama_model_free(model);
+    llama_backend_free();
+
+    return pass ? 0 : 1;
+}


### PR DESCRIPTION
## Summary

Enables [crispr-lm](https://github.com/appsprout-dev/crispr-lm) to drive the running daemon's embedded LLM for controlled experiments — the unblocker for the direct F32 tensor push deployment path.

**Four new HTTP endpoints:**

| Route | Purpose |
|---|---|
| `POST /api/v1/splice/edit` | Set `gate_bias` on one or more spoke layers |
| `GET  /api/v1/splice/status` | Read current `gate_bias` values for all spoke layers |
| `POST /api/v1/splice/tensor` | Push spoke tensor data by name — raw bytes, or F32 with auto-quantization to the tensor's native type (F16/RQ4/etc.) |
| `POST /api/v1/complete` | Raw LLM completion, bypasses retrieval (CRISPR-LM controlled testing) |

**Wiring:** adds a `SpokeEditor` accessor that threads from `SwitchableProvider` → `EmbeddedProvider` → the llama.cpp backend, so HTTP routes reach spoke weights without importing the backend directly.

**Gemma 4 chat template fix:** Gemma 4 E2B uses `<|turn>/<turn|>` tokens with a native `system` role, not the Gemma 2/3 `<start_of_turn>/<end_of_turn>` pair. Verified against EXP-008/010/011 and live in the running daemon for ~2 days.

**Submodule bump (`third_party/llama.cpp` → `b7c617a03`):** adds the member-function declarations for `llama_model::{get,set}_tensor_data` that were missing from `src/llama-model.h`. The previous pin (`875c9418f`) had the `.cpp` definitions but no header declarations — it only built against a dirty working tree. Fixes clean-checkout builds.

## Test plan

- [x] `go build` clean
- [x] `go vet ./...` clean
- [x] `go test ./...` — all packages pass, including the updated `TestFormatPrompt` for the Gemma 4 template
- [x] `golangci-lint run ./internal/api/... ./internal/llm/...` — 0 issues
- [ ] Smoke test against daemon: `POST /api/v1/splice/status` on a live Gemma 4 E2B spoke model
- [ ] Smoke test `POST /api/v1/splice/tensor` with `dtype: f32` against an RQ4 tensor
- [ ] Run `tests/splice_test.cpp` against `models/gemma4-e2b-exp31-spokes-f16.gguf`

🤖 Generated with [Claude Code](https://claude.com/claude-code)