### PR TITLE
docs: refresh CLAUDE.md + rules for Gemma 4 production & crispr-lm coupling

### DIFF
--- a/.claude/rules/llm-inference.md
+++ b/.claude/rules/llm-inference.md
@@ -1,15 +1,23 @@
 # LLM Inference — llama-server Usage
 
+Production inference happens **in-process** via the daemon's embedded llama.cpp backend — not via `llama-server`. These notes apply to standalone `llama-server` runs for evaluation, spoke validation, or debugging outside the daemon.
+
 ## Chat Template Is Required
 
-All models need their chat template applied for instruction following. Use `/v1/chat/completions` (not `/completion`) for any model that hasn't been specifically trained on our raw prompt format (only Qwen + spokes qualifies).
+All models need their chat template applied for instruction following. Use `/v1/chat/completions` for any model that hasn't been specifically trained on our raw prompt format.
 
 - **`/v1/chat/completions`** — applies model's native template. Use for all evaluations and new model testing.
-- **`/completion`** — raw text, no template. Only for production with spoke-trained models.
+- **`/completion`** — raw text, no template. Only for production models with spoke-trained raw prompt format.
 
-## Thinking Mode
+### Gemma 4 E2B (current production)
 
-Qwen 3.5 models default to thinking mode, which consumes the entire token budget on reasoning before producing output. Disable it for structured output tasks:
+- Chat template uses `<|turn>` / `<turn|>` tokens with a native `system` role. NOT the Gemma 2/3 `<start_of_turn>`/`<end_of_turn>` pair.
+- No thinking mode — the chat template block above does not apply.
+- When the daemon formats prompts itself (`formatPromptGemma` in `internal/llm/embedded.go`), it emits the Gemma 4 tokens directly.
+
+### Qwen 3.5 (retired in prod, still useful for comparison)
+
+- Thinking mode on by default — consumes token budget on reasoning. Disable for structured output:
 
 ```json
 {"chat_template_kwargs": {"enable_thinking": false}}
@@ -25,7 +33,8 @@ Test with thinking enabled as a separate condition — reasoning may improve fai
 
 ## Before Starting llama-server
 
-1. Stop the mnemonic daemon: `systemctl --user stop mnemonic`
-2. Kill any stale MCP processes: `pkill -f "mnemonic mcp"`
-3. Check VRAM: `rocm-smi --showmeminfo vram | grep Used`
-4. Baseline VRAM is ~800MB (compositor) + up to ~3.5GB (VS Code GPU). ~12GB usable.
+1. **Ask the user first** if the daemon needs to be stopped. crispr-lm may be actively editing the running daemon via splice API — a daemon stop kills that work.
+2. Stop the mnemonic daemon: `systemctl --user stop mnemonic` (only with authorization).
+3. Kill any stale MCP processes: `pkill -f "mnemonic mcp"`.
+4. Check VRAM: `rocm-smi --showmeminfo vram | grep Used`.
+5. Baseline VRAM is ~800MB (compositor) + up to ~3.5GB (VS Code GPU). ~12GB usable.

--- a/.claude/rules/testing-against-daemon.md
+++ b/.claude/rules/testing-against-daemon.md
@@ -1,15 +1,33 @@
 # Testing Against the Running Daemon
 
-## The Daemon Is Always Running
+## The Daemon Is Always Running — and Live-Edited
 
 Mnemonic runs as a systemd user service (`mnemonic.service`), started at boot. Assume it is running unless told otherwise. After testing, always leave the daemon in a running state.
 
-## After Any Code Change
+Critically, the daemon is NOT stateless between restarts. Other agents (primarily **crispr-lm**) edit the loaded model at runtime via `POST /api/v1/splice/tensor` — pushing corrective spoke weights directly into the in-process GGUF buffer. A restart discards all of that work.
 
-The running daemon serves the old binary until you rebuild and restart:
+## Before Rebuilding or Restarting
 
-1. `make build` — rebuild the binary
-2. `systemctl --user restart mnemonic` — restart the daemon to pick up changes
-3. Verify the fix is live — hit the API, check the dashboard (`http://127.0.0.1:9999/`), or exercise whatever was changed
+1. **Ask the user first.** Never restart `mnemonic.service` without explicit authorization.
+2. **Check for in-flight crispr-lm activity.** Use the mnemonic MCP tools to check recent crispr-lm handoffs/memories, or just ask. If a sweep is running (e.g. EXP-011), a restart corrupts it.
+3. **Check what binary is loaded.** `GET /api/v1/health` returns `llm_available` — if `false`, something is already wrong before you rebuild.
 
-This applies to all changes: Go code, embedded assets (dashboard HTML via `//go:embed`), API routes, MCP tools, agent logic — everything is compiled into a single binary.
+## Correct Build Commands
+
+The daemon runs an embedded llama.cpp backend with GPU offload. Build targets:
+
+```bash
+ROCM=1 make build-embedded     # Daemon binary: Go + CGo bridge + llama.cpp w/ HIP. USE THIS for daemon restarts.
+make build                      # Plain Go binary — NO embedded LLM. For CLI/test utilities only.
+```
+
+`make build` alone produces a daemon with `llm_available: false` — the chat model cannot load because the llamacpp backend isn't compiled in. If you see that health status after a restart, the binary was built without embedded.
+
+## After Authorized Rebuild + Restart
+
+1. `ROCM=1 make build-embedded` — produce the right binary.
+2. `systemctl --user restart mnemonic` — pick up changes (only with user OK).
+3. Verify `GET /api/v1/health` returns `llm_available: true` within a few seconds of first inference call (lazy-loaded on first `complete` or agent cycle).
+4. Notify whoever was editing the model that a restart happened, so they can re-push their spoke edits.
+
+This applies to all code changes: Go, embedded assets, API routes, MCP tools, agent logic — all compile into a single binary.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -13,7 +13,8 @@ Mnemonic is a local-first, air-gapped semantic memory system built in Go. It use
 ## Build & Test
 
 ```bash
-make build                    # go build ...
+ROCM=1 make build-embedded    # Daemon with embedded llama.cpp + GPU. USE THIS for daemon binaries.
+make build                    # Plain build (no embedded LLM) — only for CLI/test utilities.
 make test                     # go test ./... -v
 make check                    # go fmt + go vet
 make run                      # Build and run in foreground (serve mode)
@@ -21,7 +22,11 @@ make lifecycle-test           # Build + run full lifecycle simulation
 golangci-lint run             # Lint (uses .golangci.yml config)
 ```
 
+The daemon loads its chat model in-process via the CGo bridge to the custom llama.cpp fork — `make build` alone produces a binary with `llm_available: false`. Use `ROCM=1 make build-embedded` whenever you plan to restart the systemd service.
+
 **Version** is injected via ldflags from `Makefile` (managed by release-please). The binary var is in `cmd/mnemonic/main.go`.
+
+**Before restarting the daemon:** ask first. The daemon is a live runtime that other agents (especially crispr-lm — see Coupled Projects below) actively edit via the splice API. A restart discards in-memory spoke edits. See `.claude/rules/testing-against-daemon.md`.
 
 ## Project Layout
 
@@ -65,9 +70,8 @@ sdk/                   Python agent SDK (self-evolving assistant)
   agent/evolution/     Agent evolution data (created at runtime, gitignored)
   agent/evolution/examples/  Example evolution data for reference
 models/                GGUF model files (gitignored)
-  qwen3.5-2b/         HuggingFace Qwen 3.5 2B weights
-  qwen35-2b-f16.gguf  Base Qwen 3.5 2B in GGUF format
-  qwen35-2b-spokes-f16.gguf  Qwen 3.5 2B + trained encoding spokes
+  gemma4-e2b-exp31-spokes-*.gguf  Production: Gemma 4 E2B base + EXP-31 spokes
+  qwen35-2b-spokes-*.gguf         Retired: Qwen 3.5 2B + EXP-20 spokes
 training/              Mnemonic-LM training infrastructure
   scripts/             Training, evaluation, data generation, GGUF export
   configs/             Data mix config (pretrain_mix.yaml)
@@ -101,13 +105,15 @@ Felix-LM is a hub-and-spoke architecture for language models. The "central post"
 
 The architecture supports hot-swappable task-specific spoke sets: encoding spokes, synthesis spokes, retrieval spokes, all sharing the same frozen post. This is the Felix-LM vision: one backbone, many specialized tools.
 
-**Current state:** Qwen 3.5 2B is the production encoding model (100% schema, 7/7 stress test). Deployed via custom llama.cpp fork at 95 tok/s on RX 7800 XT. Gemma 4 E2B spoke training is active (EXP-31, branch `feat/gemma-e2b-spokes`). See `training/docs/experiment_registry.md` for EXP-1 through EXP-31.
+**Current state:** Gemma 4 E2B + EXP-31 spokes (all-RQ4 quant) is the production encoding model, deployed 2026-04-13. Loaded in-process via the custom llama.cpp fork with ROCm on RX 7800 XT (~3GB VRAM). The config.yaml `chat_model_file` may be stale — the daemon overrides via the Model Control Center API. Qwen 3.5 2B production is retired. See `training/docs/experiment_registry.md` for EXP-1 through EXP-31+.
+
+Only `task_type: encoding` is in EXP-31's training mix (`training/data/finetune_gemma4_v7_faithful/`). LLM-gated code paths that ask for other schemas (pattern identification, insight synthesis, etc.) are out-of-distribution for the current spoke — this is a known coverage gap, not a code bug.
 
 **Critical Gemma 4 training note:** On transformers <5.5.3, HF's `gradient_checkpointing_enable()` forces `use_cache=False`, which breaks ISWA KV sharing layers (garbage output, PPL 2.7M). Fixed upstream in transformers 5.5.3 (huggingface/transformers#45312). Our `SpokeWrappedLayer` has its own gradient checkpointing (`TrainingCache` + custom checkpoint) as a safety net regardless of transformers version.
 
 ### Inference
 
-Custom llama.cpp fork (`third_party/llama.cpp/`) with Felix-LM spoke support in `src/models/qwen35.cpp`. Spoke GGUF at `models/qwen35-2b-spokes-f16.gguf`. Build with `-DGGML_HIP=ON`. Export via `training/scripts/export_qwen35_spokes.py`.
+Custom llama.cpp fork (`third_party/llama.cpp/`, branch `felix`) with Felix-LM spoke support in `src/models/qwen35.cpp` (legacy) and Gemma 4 spoke paths. Production GGUFs at `models/gemma4-e2b-exp31-spokes-rq4-*.gguf`. Build with `-DGGML_HIP=ON` (handled by `ROCM=1 make build-embedded`). Live spoke tensor editing via `POST /api/v1/splice/tensor` (F32 with auto-quantization, or raw bytes). Export via `training/scripts/export_gemma4_spokes.py` / `export_qwen35_spokes.py`.
 
 ### Training
 
@@ -116,6 +122,10 @@ Scripts in `training/scripts/`, require `source ~/Projects/felixlm/.venv/bin/act
 Current datasets: Qwen `training/data/finetune_qwen_v6/` (4,255 train / 472 eval), Gemma `training/data/finetune_gemma4_v7_faithful/` (5,238 train / 581 eval). Design paper: `~/Projects/felixlm/docs/felix_lm_design.tex`.
 
 All experiments must be pre-registered in `training/docs/experiment_registry.md`. See `.claude/rules/scientific-method.md` and `.claude/rules/experiment-logging.md`.
+
+## Coupled Projects
+
+**crispr-lm** (`~/Projects/crispr-lm`) is mnemonic's model-editing sibling: logit-lens diagnosis identifies where knowledge lives in the spoke, KL-penalized corrective training (kl_weight≈0.3, lr≈1e-4, ~20 steps) produces patches, and `POST /api/v1/splice/tensor` pushes F32 weights into the running daemon (auto-quantized to RQ4 in ~0.1s). End-to-end fix cycle is ~20s vs ~216s for a GGUF rebuild. It may be actively editing the daemon at any moment — check crispr-lm session handoffs in mnemonic memory before a restart.
 
 ## Known Issues
 

--- a/internal/api/routes/complete.go
+++ b/internal/api/routes/complete.go
@@ -11,11 +11,12 @@ import (
 
 // completeRequest is the JSON body for POST /api/v1/complete.
 type completeRequest struct {
-	Prompt      string        `json:"prompt,omitempty"`
-	Messages    []llm.Message `json:"messages,omitempty"`
-	System      string        `json:"system,omitempty"`
-	MaxTokens   int           `json:"max_tokens,omitempty"`
-	Temperature float32       `json:"temperature,omitempty"`
+	Prompt         string              `json:"prompt,omitempty"`
+	Messages       []llm.Message       `json:"messages,omitempty"`
+	System         string              `json:"system,omitempty"`
+	MaxTokens      int                 `json:"max_tokens,omitempty"`
+	Temperature    float32             `json:"temperature,omitempty"`
+	ResponseFormat *llm.ResponseFormat `json:"response_format,omitempty"`
 }
 
 // HandleComplete handles POST /api/v1/complete
@@ -59,9 +60,10 @@ func HandleComplete(provider llm.Provider, log *slog.Logger) http.HandlerFunc {
 
 		start := time.Now()
 		resp, err := provider.Complete(r.Context(), llm.CompletionRequest{
-			Messages:    messages,
-			MaxTokens:   maxTokens,
-			Temperature: temperature,
+			Messages:       messages,
+			MaxTokens:      maxTokens,
+			Temperature:    temperature,
+			ResponseFormat: req.ResponseFormat,
 		})
 		if err != nil {
 			log.Error("complete failed", "error", err)


### PR DESCRIPTION
## Summary

Two things had gone stale in CLAUDE.md and the related rule files to the point where they were actively misleading work in-session:

- **Production model**: docs still called Qwen 3.5 2B \"the production encoding model,\" with Gemma 4 E2B framed as in-training. Gemma 4 E2B + EXP-31 spokes has been in production since 2026-04-13 and Qwen is retired.
- **Daemon build & restart**: the documented loop was \`make build\` + \`systemctl restart mnemonic\`. Both wrong for this repo — plain \`make build\` omits the \`llamacpp\`/\`rocm\` build tags (health shows \`llm_available: false\`), and restarting the daemon destroys in-memory spoke edits that crispr-lm actively pushes via \`POST /api/v1/splice/tensor\`.

This PR refreshes those docs, adds a Coupled Projects section for crispr-lm, and rewrites \`.claude/rules/testing-against-daemon.md\` to require confirmation before restart and the correct build target (\`ROCM=1 make build-embedded\`). \`.claude/rules/llm-inference.md\` gets a Gemma 4 section (new chat tokens \`<|turn>\`/\`<turn|>\`, native system role, no thinking mode) and marks the Qwen-specific notes as retired-but-kept-for-reference.

Also bundles a small API passthrough: \`POST /api/v1/complete\` now accepts an optional \`response_format\` field forwarded to the LLM provider. Lets crispr-lm (and debugging) reproduce schema-constrained production calls against the running daemon without going through consolidation cycles. Three-line change in \`internal/api/routes/complete.go\`.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/api/...\` passes
- [x] \`golangci-lint run ./internal/api/routes/\` — 0 issues
- [ ] Once daemon is next restarted (with authorization), verify \`POST /api/v1/complete\` with a \`response_format.type=\"json_schema\"\` body returns grammar-constrained output

🤖 Generated with [Claude Code](https://claude.com/claude-code)