### PR TITLE
fix: curriculum_runs stored time.Time.String() output, unparseable on read

### DIFF
--- a/internal/store/sqlite/continuous_learning.go
+++ b/internal/store/sqlite/continuous_learning.go
@@ -4,11 +4,60 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/appsprout-dev/mnemonic/internal/store"
 	"github.com/google/uuid"
 )
+
+// formatSQLTime serializes a time.Time as an RFC3339Nano UTC string, stripping
+// any monotonic-clock component. Zero times return an empty string. Used when
+// binding DATETIME columns so stored values round-trip cleanly through
+// time.Parse — passing a raw time.Time risks the driver falling back to
+// time.Time.String(), which includes a " m=+..." monotonic suffix that is not
+// parseable.
+func formatSQLTime(t time.Time) string {
+	if t.IsZero() {
+		return ""
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+// formatSQLTimePtr is formatSQLTime for nullable columns. Nil or zero returns
+// nil so SQLite stores NULL.
+func formatSQLTimePtr(t *time.Time) any {
+	if t == nil || t.IsZero() {
+		return nil
+	}
+	return t.UTC().Format(time.RFC3339Nano)
+}
+
+// parseSQLTime parses a time string stored by SQLite. Handles RFC3339 variants,
+// the SQLite default layout, and legacy rows written via time.Time.String()
+// whose trailing " m=+..." monotonic suffix is not parseable by time.Parse.
+func parseSQLTime(raw string) (time.Time, error) {
+	if i := strings.Index(raw, " m=+"); i >= 0 {
+		raw = raw[:i]
+	}
+	if i := strings.Index(raw, " m=-"); i >= 0 {
+		raw = raw[:i]
+	}
+	formats := []string{
+		time.RFC3339Nano,
+		time.RFC3339,
+		"2006-01-02 15:04:05.999999999 -0700 MST",
+		"2006-01-02 15:04:05 -0700 MST",
+		"2006-01-02 15:04:05-07:00",
+		"2006-01-02T15:04:05Z",
+	}
+	for _, f := range formats {
+		if t, err := time.Parse(f, raw); err == nil {
+			return t, nil
+		}
+	}
+	return time.Time{}, fmt.Errorf("no matching format for %q", raw)
+}
 
 func (s *SQLiteStore) WriteVerificationResult(ctx context.Context, memoryID string, epr float64, fr float64, flags []string) error {
 	// Store SQL NULL for empty/nil flags, JSON array for non-empty
@@ -276,9 +325,9 @@ func (s *SQLiteStore) WriteCurriculumRun(ctx context.Context, run store.Curricul
 		`INSERT INTO curriculum_runs (id, started_at, completed_at, corrections_attempted, corrections_passed,
 		     corrections_failed, entries_reclassified, training_batch_path, status, created_at)
 		 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
-		run.ID, run.StartedAt, run.CompletedAt,
+		run.ID, formatSQLTime(run.StartedAt), formatSQLTimePtr(run.CompletedAt),
 		run.CorrectionsAttempted, run.CorrectionsPassed, run.CorrectionsFailed,
-		run.EntriesReclassified, run.TrainingBatchPath, run.Status, time.Now(),
+		run.EntriesReclassified, run.TrainingBatchPath, run.Status, formatSQLTime(time.Now()),
 	)
 	if err != nil {
 		return fmt.Errorf("writing curriculum run %s: %w", run.ID, err)
@@ -292,7 +341,7 @@ func (s *SQLiteStore) UpdateCurriculumRun(ctx context.Context, run store.Curricu
 		 SET completed_at = ?, corrections_attempted = ?, corrections_passed = ?,
 		     corrections_failed = ?, entries_reclassified = ?, training_batch_path = ?, status = ?
 		 WHERE id = ?`,
-		run.CompletedAt, run.CorrectionsAttempted, run.CorrectionsPassed,
+		formatSQLTimePtr(run.CompletedAt), run.CorrectionsAttempted, run.CorrectionsPassed,
 		run.CorrectionsFailed, run.EntriesReclassified, run.TrainingBatchPath, run.Status, run.ID,
 	)
 	if err != nil {
@@ -312,24 +361,9 @@ func (s *SQLiteStore) GetLastCurriculumRunTime(ctx context.Context) (time.Time, 
 	if raw == nil || *raw == "" {
 		return time.Time{}, nil
 	}
-	// Try multiple time formats — SQLite + Go's time.Time.String() output
-	formats := []string{
-		time.RFC3339Nano,
-		time.RFC3339,
-		"2006-01-02 15:04:05-07:00",
-		"2006-01-02T15:04:05Z",
-		"2006-01-02 15:04:05 -0700 MST",
-	}
-	var t time.Time
-	var parseErr error
-	for _, f := range formats {
-		t, parseErr = time.Parse(f, *raw)
-		if parseErr == nil {
-			break
-		}
-	}
-	if parseErr != nil {
-		return time.Time{}, fmt.Errorf("parsing curriculum run time %q: %w", *raw, parseErr)
+	t, err := parseSQLTime(*raw)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parsing curriculum run time %q: %w", *raw, err)
 	}
 	return t, nil
 }

--- a/internal/store/sqlite/continuous_learning_test.go
+++ b/internal/store/sqlite/continuous_learning_test.go
@@ -191,6 +191,58 @@ func TestCurriculumRunLifecycle(t *testing.T) {
 	}
 }
 
+func TestGetLastCurriculumRunTime_LegacyMonotonicFormat(t *testing.T) {
+	s := createTestStore(t)
+	defer func() { _ = s.Close() }()
+	ctx := context.Background()
+
+	// Simulate a row written by the old buggy code path: a value that looks
+	// like time.Time.String() output, complete with the " m=+..." monotonic
+	// clock suffix that is not parseable by time.Parse.
+	legacy := "2026-04-14 00:22:17.933215768 -0400 EDT m=+91.373505619"
+	_, err := s.db.ExecContext(ctx,
+		`INSERT INTO curriculum_runs (id, started_at, status) VALUES (?, ?, ?)`,
+		"legacy-run", legacy, "completed",
+	)
+	if err != nil {
+		t.Fatalf("inserting legacy row: %v", err)
+	}
+
+	got, err := s.GetLastCurriculumRunTime(ctx)
+	if err != nil {
+		t.Fatalf("GetLastCurriculumRunTime on legacy row: %v", err)
+	}
+	if got.IsZero() {
+		t.Fatalf("expected parsed time, got zero")
+	}
+	want := time.Date(2026, 4, 14, 0, 22, 17, 933215768, time.FixedZone("-0400", -4*3600))
+	if !got.Equal(want) {
+		t.Errorf("parsed time mismatch:\n  got  %v\n  want %v", got, want)
+	}
+}
+
+func TestFormatAndParseSQLTime_RoundTrip(t *testing.T) {
+	// Ensure new writes use RFC3339Nano and parseSQLTime reads them back
+	// faithfully with no monotonic-clock artifact.
+	orig := time.Now()
+	formatted := formatSQLTime(orig)
+	if formatted == "" {
+		t.Fatal("formatSQLTime returned empty for non-zero time")
+	}
+	parsed, err := parseSQLTime(formatted)
+	if err != nil {
+		t.Fatalf("parseSQLTime(%q): %v", formatted, err)
+	}
+	if !parsed.Equal(orig) {
+		t.Errorf("round-trip mismatch:\n  got  %v\n  want %v", parsed, orig)
+	}
+	// Zero time should serialize to "" and parse back as zero via the
+	// empty-string branch in GetLastCurriculumRunTime.
+	if s := formatSQLTime(time.Time{}); s != "" {
+		t.Errorf("expected empty string for zero time, got %q", s)
+	}
+}
+
 func TestListNeedsImprovement_RespectsLimit(t *testing.T) {
 	s := createTestStore(t)
 	defer func() { _ = s.Close() }()


### PR DESCRIPTION
## Summary

Every consolidation cycle was logging:

```
curriculum generation phase failed: parsing curriculum run time
"2026-04-14 00:22:17.933215768 -0400 EDT m=+91.373505619":
 extra text: " m=+91.373505619"
```

**Cause:** \`WriteCurriculumRun\` / \`UpdateCurriculumRun\` bound \`run.StartedAt\` and \`run.CompletedAt\` directly to DATETIME columns. Under the driver/Go version in production, that path falls back to \`time.Time.String()\` when serializing, which appends Go's monotonic-clock suffix \` m=+...\`. \`GetLastCurriculumRunTime\` then tried five RFC3339 / SQLite layouts against that string and every one failed — so the curriculum cooldown check errored out on every consolidation tick and the curriculum generator stayed dark.

**Fix:**
- New \`formatSQLTime\` / \`formatSQLTimePtr\` helpers — explicit \`time.Format(RFC3339Nano)\` on write, stripping monotonic artifacts.
- New \`parseSQLTime\` helper — tolerates all the old layouts **and** strips \`\" m=+...\"\` / \`\" m=-...\"\` suffixes off legacy bad rows already in the DB, so the curriculum generator comes back to life without a manual DB fixup.
- \`WriteCurriculumRun\`, \`UpdateCurriculumRun\`, and \`GetLastCurriculumRunTime\` all route through the new helpers.

## Test plan

- [x] \`go test -tags sqlite_fts5 ./internal/store/sqlite/ -run \"Curriculum|SQLTime\" -v\` — \`TestCurriculumRunLifecycle\`, \`TestGetLastCurriculumRunTime_LegacyMonotonicFormat\`, \`TestFormatAndParseSQLTime_RoundTrip\` all pass
- [x] \`go test ./...\` — full suite green
- [x] \`go vet ./...\` — clean
- [x] \`golangci-lint run ./internal/store/sqlite/\` — 0 issues
- [ ] After next authorized daemon restart, confirm the \`curriculum generation phase failed\` log line disappears and the curriculum runs table gets a cleanly-formatted new row

🤖 Generated with [Claude Code](https://claude.com/claude-code)