### PR TITLE
fix(consolidation): sample large clusters + raise MaxTokens for identifyPattern

### DIFF
--- a/cmd/mnemonic/runtime.go
+++ b/cmd/mnemonic/runtime.go
@@ -193,6 +193,7 @@ func toConsolidationConfig(cfg *config.Config) consolidation.ConsolidationConfig
 		MergeSimilarityThreshold:      cfg.Consolidation.MergeSimilarityThreshold,
 		PatternMatchThreshold:         cfg.Consolidation.PatternMatchThreshold,
 		PatternMatchMinConceptOverlap: cfg.Consolidation.PatternMatchMinConceptOverlap,
+		MaxClusterSampleForLLM:        cfg.Consolidation.MaxClusterSampleForLLM,
 		PatternStrengthIncrement:      float32(cfg.Consolidation.PatternStrengthIncrement),
 		PatternIncrementCap:       float32(cfg.Consolidation.PatternIncrementCap),
 		LargeClusterBonus:         float32(cfg.Consolidation.LargeClusterBonus),

--- a/internal/agent/consolidation/agent.go
+++ b/internal/agent/consolidation/agent.go
@@ -41,6 +41,7 @@ type ConsolidationConfig struct {
 	MergeSimilarityThreshold      float64 // cosine threshold for memory merge clustering (default 0.85)
 	PatternMatchThreshold         float64 // cosine threshold for cluster→pattern matching (default 0.70)
 	PatternMatchMinConceptOverlap int     // min shared concepts required for cluster→pattern match (default 2) — prevents super-attractor behavior
+	MaxClusterSampleForLLM        int     // max cluster memories shown to the LLM for identifyPattern (default 10) — prevents JSON truncation on huge clusters
 	PatternStrengthIncrement      float32 // strength gain per new evidence (default 0.03)
 	PatternIncrementCap      float32 // max single-cycle strength gain (default 0.15)
 	LargeClusterBonus        float32 // multiplier for clusters >= LargeClusterMinSize (default 1.3)
@@ -87,6 +88,7 @@ func DefaultConfig() ConsolidationConfig {
 		MergeSimilarityThreshold:      0.85,
 		PatternMatchThreshold:         0.70,
 		PatternMatchMinConceptOverlap: 2,
+		MaxClusterSampleForLLM:        10,
 		PatternStrengthIncrement:      0.03,
 		PatternIncrementCap:       0.15,
 		LargeClusterBonus:         1.3,
@@ -1232,19 +1234,36 @@ type patternResponse struct {
 }
 
 // identifyPattern asks the LLM whether a cluster of memories represents a recurring pattern.
+// For large clusters, only a salience-ranked sample is shown to the LLM; the full cluster
+// is still used for evidence tracking by the caller.
 func (ca *ConsolidationAgent) identifyPattern(ctx context.Context, cluster []store.Memory, project string) (*store.Pattern, error) {
-	// Build prompt with quality signals
-	var summaries strings.Builder
-	allConcepts := make(map[string]bool)
-	for i, mem := range cluster {
-		qualityInfo := fmt.Sprintf("salience:%.2f, accessed:%d", mem.Salience, mem.AccessCount)
-		fmt.Fprintf(&summaries, "%d. [%s] %s (concepts: %s)\n", i+1, qualityInfo, mem.Summary, strings.Join(mem.Concepts, ", "))
-		for _, c := range mem.Concepts {
-			allConcepts[c] = true
-		}
+	sample := cluster
+	sampleCap := agentutil.IntOr(ca.config.MaxClusterSampleForLLM, 10)
+	if len(cluster) > sampleCap {
+		ranked := make([]store.Memory, len(cluster))
+		copy(ranked, cluster)
+		sort.Slice(ranked, func(i, j int) bool {
+			return ranked[i].Salience > ranked[j].Salience
+		})
+		sample = ranked[:sampleCap]
+		ca.log.Info("pattern extraction: sampled large cluster for LLM",
+			"project", project, "full_size", len(cluster), "sample_size", len(sample))
 	}
 
-	prompt := fmt.Sprintf(`Look at these %d memories together. Is there a recurring theme here — something that keeps happening, a habit forming, a lesson being learned (or not learned)?
+	// Build prompt with quality signals from the sample
+	var summaries strings.Builder
+	for i, mem := range sample {
+		qualityInfo := fmt.Sprintf("salience:%.2f, accessed:%d", mem.Salience, mem.AccessCount)
+		fmt.Fprintf(&summaries, "%d. [%s] %s (concepts: %s)\n", i+1, qualityInfo, mem.Summary, strings.Join(mem.Concepts, ", "))
+	}
+
+	intro := fmt.Sprintf("Look at these %d memories together.", len(sample))
+	if len(cluster) > len(sample) {
+		intro = fmt.Sprintf("Look at these %d memories (sampled by salience from a cluster of %d) together.",
+			len(sample), len(cluster))
+	}
+
+	prompt := fmt.Sprintf(`%s Is there a recurring theme here — something that keeps happening, a habit forming, a lesson being learned (or not learned)?
 
 I'm curious whether these point to a pattern: a practice this person keeps returning to, an error they keep encountering, a decision style they favor, or a workflow that's emerging.
 
@@ -1254,14 +1273,14 @@ Memories:
 Respond with ONLY a JSON object:
 {"is_pattern": true/false, "title": "a descriptive name for the pattern", "description": "what the pattern is and why it matters", "pattern_type": "recurring_error|code_practice|decision_pattern|workflow|temporal_sequence", "concepts": ["key", "concepts"]}
 
-If these memories are just coincidentally similar but don't reveal a real pattern, set is_pattern to false. Only call it a pattern if it genuinely recurs.`, len(cluster), summaries.String())
+If these memories are just coincidentally similar but don't reveal a real pattern, set is_pattern to false. Only call it a pattern if it genuinely recurs.`, intro, summaries.String())
 
 	req := llm.CompletionRequest{
 		Messages: []llm.Message{
 			{Role: "system", Content: "You are a pattern detector. Identify recurring patterns in memories. Output JSON only."},
 			{Role: "user", Content: prompt},
 		},
-		MaxTokens:   200,
+		MaxTokens:   500,
 		Temperature: 0.3,
 		ResponseFormat: &llm.ResponseFormat{
 			Type: "json_schema",

--- a/internal/agent/consolidation/agent_test.go
+++ b/internal/agent/consolidation/agent_test.go
@@ -6,6 +6,7 @@ import (
 	"log/slog"
 	"math"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -1338,6 +1339,110 @@ func TestFindMatchingPattern_ConceptGate(t *testing.T) {
 	}
 	if sim < 0.9 {
 		t.Errorf("expected high cosine similarity on the matched pattern, got %v", sim)
+	}
+}
+
+// TestIdentifyPattern_LargeClusterSampled verifies that when a cluster
+// exceeds MaxClusterSampleForLLM, only the top-salience sample is shown to
+// the LLM (preventing JSON truncation) while MaxTokens provides enough
+// budget for a complete response.
+func TestIdentifyPattern_LargeClusterSampled(t *testing.T) {
+	ms := newMockStore()
+	mlp := newMockLLMProvider()
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	cfg := DefaultConfig()
+	cfg.MaxClusterSampleForLLM = 5
+
+	mlp.completeFn = func(ctx context.Context, req llm.CompletionRequest) (llm.CompletionResponse, error) {
+		return llm.CompletionResponse{Content: `{"is_pattern":true,"title":"t","description":"d","pattern_type":"workflow","concepts":["a"]}`}, nil
+	}
+
+	agent := NewConsolidationAgent(ms, mlp, cfg, log)
+
+	// 20 memories, salience running 0.01..1.00 so the top 5 are easy to verify.
+	cluster := make([]store.Memory, 20)
+	for i := 0; i < 20; i++ {
+		cluster[i] = store.Memory{
+			ID:        fmt.Sprintf("m%02d", i),
+			Summary:   fmt.Sprintf("memory %d", i),
+			Salience:  float32(i+1) * 0.05, // m19 = 1.00, m00 = 0.05
+			Concepts:  []string{"c1"},
+			Embedding: []float32{1, 0, 0, 0},
+		}
+	}
+
+	_, err := agent.identifyPattern(context.Background(), cluster, "test")
+	if err != nil {
+		t.Fatalf("identifyPattern: %v", err)
+	}
+
+	if len(mlp.completions) != 1 {
+		t.Fatalf("expected 1 LLM completion call, got %d", len(mlp.completions))
+	}
+
+	req := mlp.completions[0]
+	if req.MaxTokens < 400 {
+		t.Errorf("expected MaxTokens >= 400 (enough for full pattern response), got %d", req.MaxTokens)
+	}
+
+	prompt := req.Messages[1].Content
+	// Only top-5-salience memories (m15..m19) should appear in the prompt.
+	// m00..m14 must NOT appear. Check both directions to catch off-by-one errors.
+	for i := 15; i < 20; i++ {
+		want := fmt.Sprintf("memory %d", i)
+		if !strings.Contains(prompt, want) {
+			t.Errorf("expected prompt to contain %q (top-salience memory), but it did not", want)
+		}
+	}
+	for i := 0; i < 15; i++ {
+		unwant := fmt.Sprintf("memory %d (", i)
+		if strings.Contains(prompt, unwant) {
+			t.Errorf("did NOT expect prompt to contain %q (below sample cap), but it did", unwant)
+		}
+	}
+	// The prompt should mention the full cluster size alongside the sample size.
+	if !strings.Contains(prompt, "cluster of 20") {
+		t.Errorf("expected prompt to disclose the full cluster size (20), got:\n%s", prompt)
+	}
+}
+
+// TestIdentifyPattern_SmallClusterUnsampled verifies that clusters at or below
+// the sample cap are passed to the LLM in full, with the original prompt
+// framing (no sampling disclosure).
+func TestIdentifyPattern_SmallClusterUnsampled(t *testing.T) {
+	ms := newMockStore()
+	mlp := newMockLLMProvider()
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+
+	cfg := DefaultConfig()
+	cfg.MaxClusterSampleForLLM = 10
+
+	mlp.completeFn = func(ctx context.Context, req llm.CompletionRequest) (llm.CompletionResponse, error) {
+		return llm.CompletionResponse{Content: `{"is_pattern":true,"title":"t","description":"d","pattern_type":"workflow","concepts":["a"]}`}, nil
+	}
+
+	agent := NewConsolidationAgent(ms, mlp, cfg, log)
+
+	cluster := []store.Memory{
+		{ID: "m1", Summary: "alpha", Salience: 0.9, Concepts: []string{"c1"}, Embedding: []float32{1, 0}},
+		{ID: "m2", Summary: "beta", Salience: 0.8, Concepts: []string{"c1"}, Embedding: []float32{1, 0}},
+		{ID: "m3", Summary: "gamma", Salience: 0.7, Concepts: []string{"c1"}, Embedding: []float32{1, 0}},
+	}
+
+	_, err := agent.identifyPattern(context.Background(), cluster, "test")
+	if err != nil {
+		t.Fatalf("identifyPattern: %v", err)
+	}
+
+	prompt := mlp.completions[0].Messages[1].Content
+	for _, name := range []string{"alpha", "beta", "gamma"} {
+		if !strings.Contains(prompt, name) {
+			t.Errorf("expected prompt to contain %q, it did not", name)
+		}
+	}
+	if strings.Contains(prompt, "sampled by salience") {
+		t.Error("did not expect sampling disclosure on a small cluster")
 	}
 }
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -245,6 +245,7 @@ type ConsolidationConfig struct {
 	MergeSimilarityThreshold      float64 `yaml:"merge_similarity_threshold"`
 	PatternMatchThreshold         float64 `yaml:"pattern_match_threshold"`
 	PatternMatchMinConceptOverlap int     `yaml:"pattern_match_min_concept_overlap"`
+	MaxClusterSampleForLLM        int     `yaml:"max_cluster_sample_for_llm"`
 	PatternStrengthIncrement      float64 `yaml:"pattern_strength_increment"`
 	PatternIncrementCap           float64 `yaml:"pattern_increment_cap"`
 	LargeClusterBonus             float64 `yaml:"large_cluster_bonus"`
@@ -737,6 +738,7 @@ func Default() *Config {
 			MergeSimilarityThreshold:      0.85,
 			PatternMatchThreshold:         0.70,
 			PatternMatchMinConceptOverlap: 2,
+			MaxClusterSampleForLLM:        10,
 			PatternStrengthIncrement:      0.03,
 			PatternIncrementCap:       0.15,
 			LargeClusterBonus:         1.3,


### PR DESCRIPTION
## Summary

PR #412 broke the super-attractor so clusters finally reach \`identifyPattern\` again. That immediately exposed the next layer: in production, \`findConceptClusters\` happily builds clusters of 30-47 memories (entire projects, or cross-project lumps). At cluster_size=30, the LLM gets 30 memory summaries in the prompt and tries to describe them all in a **200-token** response window — it truncates mid-JSON, the parse fails, cluster is dropped with a WARN.

Observed this morning (2026-04-17) at 12:01 UTC (\`cluster_size: 30\`, mnemonic) and 12:03 UTC (\`cluster_size: 47\`, cross-project), both \`failed to parse pattern response: unexpected end of JSON input\`.

## Fix

- \`identifyPattern\` now salience-ranks the cluster and keeps only the top \`MaxClusterSampleForLLM\` (default **10**) memories in the LLM prompt. The full cluster is still handed back to the caller for evidence tracking — only the LLM's view is sampled. The prompt intro is updated to disclose when sampling happened (\`...sampled by salience from a cluster of N...\`) so the LLM knows it's seeing a representative subset.
- \`MaxTokens\` raised from **200 → 500**. Empirical ceiling for a coherent \`pattern_response\` from Gemma 4 E2B + EXP-31 spokes is ~160-200 tokens on a clean cluster; 500 gives comfortable headroom for the description tail.
- New config field \`MaxClusterSampleForLLM\` wired through \`internal/config\` → \`ConsolidationConfig\` via \`cmd/mnemonic/runtime.go\`.
- INFO log when sampling fires: \`project, full_size, sample_size\` — so we can see how often clusters overflow and by how much. If size-50 keeps appearing, that signals the upstream clustering is too coarse (separate bug).

## Validation

Rebuilt (\`ROCM=1 make build-embedded\`) and restarted with user authorization. Watched one cycle (12:44:49 - 12:46:18 UTC):

- \`sampled large cluster for LLM\` fired for clusters of \`full_size: 30\` (mnemonic) and \`full_size: 13\` (crispr-lm), sampled to 10.
- **Zero** \`failed to parse pattern response\` events in the cycle (previously every large cluster failed).
- LLM calls completed successfully in ~5-8s each, well under the ctx budget.
- \`patterns: 0\` at cycle end — but this turned out to mean every successfully-generated pattern was **absorbed by the second-stage dedup** into existing pattern \`3dece9c9\` \"Developing a Self-Contained LLM Architecture\" via embedding similarity 0.82-0.92. That's a **separate** bug (second-stage dedup has no concept gate; mirror image of what #412 fixed for the first-stage) and will land as its own PR.

## Test plan

- [x] \`go test -run \"IdentifyPattern\" ./internal/agent/consolidation/ -v\` — two tests:
  - \`TestIdentifyPattern_LargeClusterSampled\`: 20-memory cluster sampled to top-5 by salience; MaxTokens ≥ 400; prompt discloses full cluster size
  - \`TestIdentifyPattern_SmallClusterUnsampled\`: 3-memory cluster passes through untouched
- [x] \`go test ./...\` — full suite green
- [x] \`go vet\` clean, \`golangci-lint\` 0 issues
- [x] **Production validation against the running daemon** — sampling logs fire, no truncation errors, LLM calls succeed

## What this does NOT do

- **Does not fix the second-stage dedup**. Every LLM-generated pattern is currently absorbed into an attractor via embedding similarity only. That's the same architectural class of bug as #412 and needs the same class of fix (concept-overlap requirement for the second-stage dedup) in a separate PR.
- **Does not touch \`findConceptClusters\`**. Size-47 cross-project clusters still happen upstream — the sample just means the LLM never sees them full. Fixing overly-greedy clustering is a separate ticket.

🤖 Generated with [Claude Code](https://claude.com/claude-code)