### PR TITLE
fix(consolidation): concept-overlap gate on second-stage dedup

### DIFF
--- a/internal/agent/consolidation/agent.go
+++ b/internal/agent/consolidation/agent.go
@@ -948,37 +948,30 @@ func (ca *ConsolidationAgent) processPatternClusters(ctx context.Context, cluste
 			continue
 		}
 
-		// Second dedup: compare the new pattern's embedding AND title against existing patterns.
-		// Two signals: embedding cosine >= 0.80 OR title Jaccard >= 0.6.
-		// This catches duplicates where embeddings differ but titles are near-identical.
+		// Second dedup: compare the new pattern against existing patterns on
+		// embedding-or-title similarity AND concept overlap. The concept gate
+		// (added after PR #413 validation) prevents a dominant existing pattern
+		// from absorbing topically-unrelated LLM outputs whose title+embedding
+		// happen to sit close to it in the retrieval space — same architectural
+		// issue fixed for the first-stage match in PR #412.
 		if len(pattern.Embedding) > 0 {
 			existingPatterns, searchErr := ca.store.SearchPatternsByEmbedding(ctx, pattern.Embedding, 5)
 			if searchErr == nil {
 				foundDup := false
-				for i := range existingPatterns {
-					ep := &existingPatterns[i]
-					if len(ep.Embedding) == 0 {
-						continue
-					}
-					embSim := agentutil.CosineSimilarity(pattern.Embedding, ep.Embedding)
-					titleSim := normalizedTitleSimilarity(pattern.Title, ep.Title)
-					if isDuplicate(pattern.Title, ep.Title, pattern.Embedding, ep.Embedding, 0.5, 0.75) {
-						for _, mem := range qualified {
-							if !containsString(ep.EvidenceIDs, mem.ID) {
-								ep.EvidenceIDs = append(ep.EvidenceIDs, mem.ID)
-							}
+				minOverlap := agentutil.IntOr(ca.config.PatternMatchMinConceptOverlap, 2)
+				ep := ca.findSecondStageDuplicate(pattern, existingPatterns, minOverlap)
+				if ep != nil {
+					for _, mem := range qualified {
+						if !containsString(ep.EvidenceIDs, mem.ID) {
+							ep.EvidenceIDs = append(ep.EvidenceIDs, mem.ID)
 						}
-						ep.Strength = min32(ep.Strength+0.03, 1.0)
-						ep.AccessCount++
-						ep.LastAccessed = time.Now()
-						ep.UpdatedAt = time.Now()
-						_ = ca.store.UpdatePattern(ctx, *ep)
-						ca.log.Info("dedup: merged new pattern into existing",
-							"existing_id", ep.ID, "existing_title", ep.Title,
-							"emb_sim", embSim, "title_sim", titleSim)
-						foundDup = true
-						break
 					}
+					ep.Strength = min32(ep.Strength+0.03, 1.0)
+					ep.AccessCount++
+					ep.LastAccessed = time.Now()
+					ep.UpdatedAt = time.Now()
+					_ = ca.store.UpdatePattern(ctx, *ep)
+					foundDup = true
 				}
 				if foundDup {
 					continue
@@ -1174,6 +1167,47 @@ func (ca *ConsolidationAgent) findMatchingPattern(ctx context.Context, cluster [
 	}
 
 	return nil, 0, fmt.Errorf("no close match")
+}
+
+// findSecondStageDuplicate scans candidate patterns (returned by
+// SearchPatternsByEmbedding) and returns the first one that qualifies as a
+// duplicate of the newly-generated pattern. A duplicate must pass BOTH:
+//   - isDuplicate on (title, embedding) at the long-standing thresholds
+//     (embedding cosine >= 0.75 OR title Jaccard >= 0.5, with an AND variant
+//     for short titles), AND
+//   - concept overlap >= minOverlap with the new pattern.
+//
+// The concept gate is the key change relative to the pre-PR behavior, which
+// used similarity alone and silently absorbed topically-unrelated LLM outputs
+// into a single attractor pattern. Rejections are logged at INFO so the
+// operator can see when the gate fires. Returns a pointer into the provided
+// slice so the caller can mutate+persist the match; nil when nothing matches.
+func (ca *ConsolidationAgent) findSecondStageDuplicate(pattern *store.Pattern, candidates []store.Pattern, minOverlap int) *store.Pattern {
+	for i := range candidates {
+		ep := &candidates[i]
+		if len(ep.Embedding) == 0 {
+			continue
+		}
+		embSim := agentutil.CosineSimilarity(pattern.Embedding, ep.Embedding)
+		titleSim := normalizedTitleSimilarity(pattern.Title, ep.Title)
+		if !isDuplicate(pattern.Title, ep.Title, pattern.Embedding, ep.Embedding, 0.5, 0.75) {
+			continue
+		}
+		conceptOverlap := countConceptOverlap(pattern.Concepts, ep.Concepts)
+		if conceptOverlap < minOverlap {
+			ca.log.Info("dedup: rejected similarity match on concept gate",
+				"existing_id", ep.ID, "existing_title", ep.Title,
+				"emb_sim", embSim, "title_sim", titleSim,
+				"concept_overlap", conceptOverlap, "min_required", minOverlap)
+			continue
+		}
+		ca.log.Info("dedup: merged new pattern into existing",
+			"existing_id", ep.ID, "existing_title", ep.Title,
+			"emb_sim", embSim, "title_sim", titleSim,
+			"concept_overlap", conceptOverlap)
+		return ep
+	}
+	return nil
 }
 
 // collectClusterConcepts returns the deduplicated set of concepts across all

--- a/internal/agent/consolidation/agent_test.go
+++ b/internal/agent/consolidation/agent_test.go
@@ -1342,6 +1342,75 @@ func TestFindMatchingPattern_ConceptGate(t *testing.T) {
 	}
 }
 
+// TestFindSecondStageDuplicate_ConceptGateAccepts verifies that the
+// second-stage dedup merges into an existing pattern only when BOTH the
+// similarity signal fires AND concepts overlap by at least minOverlap.
+func TestFindSecondStageDuplicate_ConceptGateAccepts(t *testing.T) {
+	ms := newMockStore()
+	mlp := &mockLLMProvider{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	agent := NewConsolidationAgent(ms, mlp, DefaultConfig(), log)
+
+	newPat := &store.Pattern{
+		Title:     "Recurring Nil-Guard Drift in Go Event Loop",
+		Embedding: []float32{0.9, 0.1, 0, 0},
+		Concepts:  []string{"go", "nil-guard", "event-bus"},
+	}
+	existing := []store.Pattern{
+		{
+			ID:        "other-topic",
+			Title:     "Modular Model Migration Workflow",
+			Embedding: []float32{0.95, 0.05, 0, 0}, // high embedding sim, no shared concepts
+			Concepts:  []string{"llm", "migration", "adapter"},
+		},
+		{
+			ID:        "real-dup",
+			Title:     "Defensive Nil Guarding in Go Event Loops",
+			Embedding: []float32{0.88, 0.1, 0.05, 0}, // lower sim but concepts match
+			Concepts:  []string{"go", "nil-guard", "event-bus"},
+		},
+	}
+
+	match := agent.findSecondStageDuplicate(newPat, existing, 2)
+	if match == nil {
+		t.Fatal("expected a concept-compatible match, got nil")
+	}
+	if match.ID != "real-dup" {
+		t.Errorf("expected match to be real-dup (concept-compatible), got %s", match.ID)
+	}
+}
+
+// TestFindSecondStageDuplicate_ConceptGateRejects verifies that a new pattern
+// is NOT merged into an existing attractor when their embeddings match but
+// concepts do not — the core behavior that protects against the kind of
+// "every new pattern folded into Developing a Self-Contained LLM Architecture"
+// attractor we observed during PR #413 validation.
+func TestFindSecondStageDuplicate_ConceptGateRejects(t *testing.T) {
+	ms := newMockStore()
+	mlp := &mockLLMProvider{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	agent := NewConsolidationAgent(ms, mlp, DefaultConfig(), log)
+
+	newPat := &store.Pattern{
+		Title:     "Splice Tensor API for CRISPR-LM",
+		Embedding: []float32{1, 0, 0, 0},
+		Concepts:  []string{"crispr-lm", "splice", "api"},
+	}
+	existing := []store.Pattern{
+		{
+			ID:        "attractor",
+			Title:     "Developing a Self-Contained LLM Architecture",
+			Embedding: []float32{0.98, 0.05, 0, 0}, // 0.82+ cosine, easily above 0.75
+			Concepts:  []string{"llm", "architecture", "workflow"},
+		},
+	}
+
+	match := agent.findSecondStageDuplicate(newPat, existing, 2)
+	if match != nil {
+		t.Errorf("expected concept gate to reject attractor match, got match=%s", match.ID)
+	}
+}
+
 // TestIdentifyPattern_LargeClusterSampled verifies that when a cluster
 // exceeds MaxClusterSampleForLLM, only the top-salience sample is shown to
 // the LLM (preventing JSON truncation) while MaxTokens provides enough


### PR DESCRIPTION
## Summary

#412 fixed the first-stage super-attractor. #413 fixed identifyPattern truncation. PR #413's production validation exposed a **second super-attractor**, this time on the *post-LLM* dedup path.

Pattern 3dece9c9 \"Developing a Self-Contained LLM Architecture\" was absorbing every LLM-generated pattern via embedding cosine 0.82-0.92, regardless of whether the new pattern's concepts overlapped at all. Same architectural bug as the first stage, same fix: add concept-overlap as a required gate alongside the existing similarity check.

## Fix

- Extracted the dedup loop in \`processPatternClusters\` into a new method \`ConsolidationAgent.findSecondStageDuplicate(pattern, candidates, minOverlap) *store.Pattern\`.
- A candidate qualifies as a duplicate only when it passes BOTH:
  - existing \`isDuplicate\` similarity check (embedding cosine >= 0.75 OR title Jaccard >= 0.5 for long titles; AND for short titles) — unchanged thresholds, and
  - concept overlap >= \`PatternMatchMinConceptOverlap\` (default 2, reused from #412).
- Rejection logs at INFO with emb_sim / title_sim / concept_overlap / min_required — same structure as the first-stage gate's log. Merge logs now include concept_overlap for symmetry.

## Validation

Rebuilt (\`ROCM=1 make build-embedded\`) and restarted with authorization. Watched one cycle (12:53:46 - 12:55:51 UTC).

**Result: \`patterns: 5\`** (previously stuck at 0 on successive cycles).

Five new, topically distinct patterns were created:

| id | title | evidence |
|---|---|---|
| 55998fd2 | Temporal sequence of session handoffs | 30 |
| b8ed7358 | The transition to and utilization of the Gemma 4 E2B encoding provider | 3 |
| 4757f37d | Building a High-Fidelity LLM Training and Debugging Workflow | 7 |
| — | Strategic LLM Optimization and Quality Assurance | new |
| — | The Emergence of the CRISPR-LM Research and Logit-Lens Breakthrough | new |

The log shows the gate firing against 3dece9c9 multiple times at emb_sim 0.83-0.93 with concept_overlap 0-1 — exactly the attractor behavior #413 validation surfaced. The abstraction agent cycle also shows \`patterns_evaluated: 1\` (vs 0 in prior cycles), meaning downstream cognitive agents are starting to get real input.

## Test plan

- [x] \`go test ./internal/agent/consolidation/ -run \"FindSecondStageDuplicate|FindMatchingPattern|IdentifyPattern\" -v\`:
  - \`TestFindSecondStageDuplicate_ConceptGateAccepts\`: concept-compatible candidate is picked over a higher-embedding-sim attractor with zero concept overlap
  - \`TestFindSecondStageDuplicate_ConceptGateRejects\`: attractor at cosine 0.99 with zero concept overlap is correctly rejected
- [x] \`go test ./...\` — full suite green
- [x] \`go vet\` clean, \`golangci-lint\` 0 issues
- [x] Production validation against the running daemon — 5 new patterns created in one cycle, rejection logs confirm the gate is firing as designed

## Known newly-visible issues (NOT in this PR)

- **\`embedded provider busy: context canceled\`** on 4 of 9 LLM attempts at cycle end. Concurrency/timeout issue in the embedded backend when the cycle runs long (124s this cycle). Not a regression — these clusters were previously silently absorbed. Needs its own investigation.
- The two stale super-attractors (\`Modular Model Migration Workflow\` at access_count 2988, \`Developing a Self-Contained LLM Architecture\` at 27) are still in the DB. Stage 4 decision: delete / decay naturally / re-embed from current evidence — separate discussion once the gates have stabilized.
- Abstraction agent still shows \`principles_created: 0, axioms_created: 0, abstractions_demoted: 8\`. Thread C hasn't been characterized yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)