### PR TITLE
fix(abstraction): concept-overlap gate on findSimilarAbstraction

### DIFF
--- a/cmd/mnemonic/serve.go
+++ b/cmd/mnemonic/serve.go
@@ -549,6 +549,7 @@ func serveCommand(configPath string) {
 			ConfidenceSignificantDecay: cfg.Abstraction.ConfidenceSignificantDecay,
 			ConfidenceSevereDecay:      cfg.Abstraction.ConfidenceSevereDecay,
 			GroundingFloor:             cfg.Abstraction.GroundingFloor,
+			DedupMinConceptOverlap:     cfg.Abstraction.DedupMinConceptOverlap,
 		}, log)
 
 		if err := abstractionAgent.Start(rootCtx, bus); err != nil {

--- a/internal/agent/abstraction/agent.go
+++ b/internal/agent/abstraction/agent.go
@@ -26,6 +26,11 @@ type AbstractionConfig struct {
 	ConfidenceSignificantDecay float32
 	ConfidenceSevereDecay      float32
 	GroundingFloor             float32
+	// DedupMinConceptOverlap is the minimum number of shared concepts required
+	// for findSimilarAbstraction to treat a new principle/axiom as a duplicate
+	// of an existing abstraction. Prevents the same embedding-only attractor
+	// behavior fixed for consolidation in PRs #412 and #414. Default: 2.
+	DedupMinConceptOverlap int
 }
 
 type AbstractionAgent struct {
@@ -174,6 +179,10 @@ func (aa *AbstractionAgent) runCycle(ctx context.Context) (*CycleReport, error) 
 
 // synthesizePrinciples loads strong patterns, clusters by embedding similarity, and asks LLM to synthesize principles.
 func (aa *AbstractionAgent) synthesizePrinciples(ctx context.Context, report *CycleReport) error {
+	minOverlap := aa.config.DedupMinConceptOverlap
+	if minOverlap <= 0 {
+		minOverlap = 2
+	}
 	patterns, err := aa.store.ListPatterns(ctx, "", 50) // all projects
 	if err != nil {
 		return fmt.Errorf("failed to list patterns: %w", err)
@@ -225,7 +234,7 @@ func (aa *AbstractionAgent) synthesizePrinciples(ctx context.Context, report *Cy
 		// Dedup: compare the synthesized principle's own embedding against existing ones.
 		// Using 0.85 threshold since both are text-derived embeddings in the same space.
 		if len(principle.Embedding) > 0 {
-			if match := findSimilarAbstraction(existingPrinciples, principle.Embedding, principle.Title, 0.85); match != nil {
+			if match := findSimilarAbstraction(existingPrinciples, principle.Concepts, principle.Embedding, principle.Title, 0.85, minOverlap, aa.log); match != nil {
 				// Strengthen the existing principle instead of creating a duplicate
 				match.Confidence = min32(match.Confidence+0.05, 1.0)
 				match.AccessCount++
@@ -269,6 +278,10 @@ func (aa *AbstractionAgent) synthesizePrinciples(ctx context.Context, report *Cy
 
 // synthesizeAxioms clusters level-2 abstractions and synthesizes level-3 axioms.
 func (aa *AbstractionAgent) synthesizeAxioms(ctx context.Context, report *CycleReport) error {
+	minOverlap := aa.config.DedupMinConceptOverlap
+	if minOverlap <= 0 {
+		minOverlap = 2
+	}
 	principles, err := aa.store.ListAbstractions(ctx, 2, 500)
 	if err != nil {
 		return fmt.Errorf("failed to list principles: %w", err)
@@ -317,7 +330,7 @@ func (aa *AbstractionAgent) synthesizeAxioms(ctx context.Context, report *CycleR
 
 		// Dedup: compare the synthesized axiom's own embedding against existing ones
 		if len(axiom.Embedding) > 0 {
-			if match := findSimilarAbstraction(existingAxioms, axiom.Embedding, axiom.Title, 0.85); match != nil {
+			if match := findSimilarAbstraction(existingAxioms, axiom.Concepts, axiom.Embedding, axiom.Title, 0.85, minOverlap, aa.log); match != nil {
 				match.Confidence = min32(match.Confidence+0.05, 1.0)
 				match.AccessCount++
 				match.UpdatedAt = time.Now()
@@ -751,23 +764,74 @@ func clusterAbstractions(abstractions []store.Abstraction, threshold float32) []
 	return clusters
 }
 
-// findSimilarAbstraction returns the first existing abstraction with embedding similarity >= threshold
-// or high title similarity, checking both active and fading states.
-func findSimilarAbstraction(existing []store.Abstraction, embedding []float32, title string, threshold float32) *store.Abstraction {
+// findSimilarAbstraction returns the first existing abstraction that is a true
+// duplicate of the new one: similarity check (embedding cosine >= threshold OR
+// title Jaccard >= 0.6) AND concept overlap >= minConceptOverlap.
+//
+// The concept-overlap gate is the fix for the same attractor bug repaired in
+// consolidation by PRs #412 and #414: without it, a dominant existing
+// abstraction whose embedding happens to sit near the new principle's
+// embedding will absorb topically-unrelated new abstractions indefinitely.
+// Rejections are logged at INFO so operators can see when the gate fires.
+//
+// A logger pointer is accepted (may be nil) so the function remains easy to
+// call from tests without mocking the agent's logger.
+func findSimilarAbstraction(existing []store.Abstraction, concepts []string, embedding []float32, title string, threshold float32, minConceptOverlap int, log *slog.Logger) *store.Abstraction {
 	for i, abs := range existing {
 		if abs.State != "active" && abs.State != "fading" {
 			continue
 		}
-		// Embedding similarity check
-		if len(abs.Embedding) > 0 && len(embedding) > 0 && agentutil.CosineSimilarity(abs.Embedding, embedding) >= threshold {
-			return &existing[i]
+		var embSim float32
+		if len(abs.Embedding) > 0 && len(embedding) > 0 {
+			embSim = agentutil.CosineSimilarity(abs.Embedding, embedding)
 		}
-		// Title similarity fallback (word-level Jaccard)
-		if title != "" && abs.Title != "" && titleJaccard(title, abs.Title) >= 0.6 {
-			return &existing[i]
+		titleSim := float32(0)
+		if title != "" && abs.Title != "" {
+			titleSim = titleJaccard(title, abs.Title)
 		}
+		similar := embSim >= threshold || titleSim >= 0.6
+		if !similar {
+			continue
+		}
+		overlap := countConceptOverlap(concepts, abs.Concepts)
+		if overlap < minConceptOverlap {
+			if log != nil {
+				log.Info("abstraction dedup: rejected similarity match on concept gate",
+					"existing_id", abs.ID, "existing_title", abs.Title,
+					"emb_sim", embSim, "title_sim", titleSim,
+					"concept_overlap", overlap, "min_required", minConceptOverlap)
+			}
+			continue
+		}
+		if log != nil {
+			log.Info("abstraction dedup: merged new into existing",
+				"existing_id", abs.ID, "existing_title", abs.Title,
+				"emb_sim", embSim, "title_sim", titleSim,
+				"concept_overlap", overlap)
+		}
+		return &existing[i]
 	}
 	return nil
+}
+
+// countConceptOverlap returns the number of concepts shared between two slices
+// (case-insensitive, whitespace-trimmed). Local copy to keep the abstraction
+// package self-contained.
+func countConceptOverlap(a, b []string) int {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	set := make(map[string]bool, len(a))
+	for _, c := range a {
+		set[strings.ToLower(strings.TrimSpace(c))] = true
+	}
+	shared := 0
+	for _, c := range b {
+		if set[strings.ToLower(strings.TrimSpace(c))] {
+			shared++
+		}
+	}
+	return shared
 }
 
 // titleJaccard computes word-level Jaccard similarity between two titles.

--- a/internal/agent/abstraction/agent_test.go
+++ b/internal/agent/abstraction/agent_test.go
@@ -1,0 +1,118 @@
+package abstraction
+
+import (
+	"io"
+	"log/slog"
+	"testing"
+
+	"github.com/appsprout-dev/mnemonic/internal/store"
+)
+
+// silentLogger returns a logger that discards output. Used so tests do not
+// spam stderr with the INFO-level dedup logs from findSimilarAbstraction.
+func silentLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+// TestFindSimilarAbstraction_ConceptGateRejectsAttractor verifies that an
+// existing abstraction whose embedding is nearly identical to the new one
+// but whose concepts do not overlap is NOT returned as a duplicate — the
+// attractor behavior that caused consolidation patterns to be absorbed into
+// one dominant pattern before PRs #412/#414. Same fix pattern applied here.
+func TestFindSimilarAbstraction_ConceptGateRejectsAttractor(t *testing.T) {
+	attractor := store.Abstraction{
+		ID:        "attractor",
+		Title:     "Building a Self-Contained LLM Architecture",
+		State:     "active",
+		Embedding: []float32{1, 0, 0, 0},
+		Concepts:  []string{"llm", "architecture", "workflow"},
+	}
+	existing := []store.Abstraction{attractor}
+
+	// New abstraction: same embedding, zero shared concepts.
+	match := findSimilarAbstraction(existing,
+		[]string{"crispr-lm", "splice", "api"},
+		[]float32{1, 0, 0, 0},
+		"Splice Tensor API for CRISPR-LM",
+		0.85, 2, silentLogger())
+
+	if match != nil {
+		t.Errorf("expected concept gate to reject attractor (no shared concepts), got match=%s", match.ID)
+	}
+}
+
+// TestFindSimilarAbstraction_ConceptGateAcceptsGenuineDup verifies that when
+// both similarity AND concept overlap hold, the function returns the match.
+func TestFindSimilarAbstraction_ConceptGateAcceptsGenuineDup(t *testing.T) {
+	original := store.Abstraction{
+		ID:        "real-dup",
+		Title:     "Defensive Nil Guarding in Go Event Loops",
+		State:     "active",
+		Embedding: []float32{0.9, 0.1, 0, 0},
+		Concepts:  []string{"go", "nil-guard", "event-bus"},
+	}
+	existing := []store.Abstraction{original}
+
+	match := findSimilarAbstraction(existing,
+		[]string{"go", "nil-guard", "event-bus", "panic"},
+		[]float32{0.92, 0.08, 0, 0}, // cosine ~= 1.0
+		"Event-Bus Nil Guards Prevent Go Panics",
+		0.85, 2, silentLogger())
+
+	if match == nil {
+		t.Fatal("expected concept-matched duplicate, got nil")
+	}
+	if match.ID != "real-dup" {
+		t.Errorf("expected real-dup match, got %s", match.ID)
+	}
+}
+
+// TestFindSimilarAbstraction_ArchivedIsSkipped verifies that abstractions in
+// state other than active/fading are skipped regardless of similarity. This
+// is existing behavior — the test documents it.
+func TestFindSimilarAbstraction_ArchivedIsSkipped(t *testing.T) {
+	archived := store.Abstraction{
+		ID:        "archived",
+		Title:     "Old Principle",
+		State:     "archived",
+		Embedding: []float32{1, 0, 0, 0},
+		Concepts:  []string{"go", "nil-guard"},
+	}
+	existing := []store.Abstraction{archived}
+
+	match := findSimilarAbstraction(existing,
+		[]string{"go", "nil-guard"},
+		[]float32{1, 0, 0, 0},
+		"Old Principle",
+		0.85, 2, silentLogger())
+
+	if match != nil {
+		t.Errorf("expected archived abstraction to be skipped, got match=%s", match.ID)
+	}
+}
+
+// TestFindSimilarAbstraction_TitleMatchStillNeedsConcepts is the sharp-edges
+// test: the title-Jaccard fallback path (titleSim >= 0.6) must also pass the
+// concept gate. Without this, a principle with a near-identical title but
+// different topic could still be merged. Previously the title fallback was an
+// escape hatch from any concept discipline.
+func TestFindSimilarAbstraction_TitleMatchStillNeedsConcepts(t *testing.T) {
+	existing := []store.Abstraction{{
+		ID:        "title-clone",
+		Title:     "Recurring Optimization Workflow",
+		State:     "active",
+		Embedding: []float32{0.1, 0.9, 0, 0}, // low embedding similarity
+		Concepts:  []string{"quant", "gpu", "benchmark"},
+	}}
+
+	// Near-identical title (Jaccard > 0.6) but zero shared concepts.
+	match := findSimilarAbstraction(existing,
+		[]string{"auth", "session", "cookies"},
+		[]float32{0.9, 0.1, 0, 0},
+		"Recurring Optimization Workflow",
+		0.85, 2, silentLogger())
+
+	if match != nil {
+		t.Errorf("expected concept gate to reject title-only match, got %s", match.ID)
+	}
+}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -382,6 +382,7 @@ type AbstractionConfig struct {
 	ConfidenceSignificantDecay float32       `yaml:"confidence_significant_decay"` // grounding multiplier for significant decay (default: 0.7)
 	ConfidenceSevereDecay      float32       `yaml:"confidence_severe_decay"`      // grounding multiplier for severe decay (default: 0.5)
 	GroundingFloor             float32       `yaml:"grounding_floor"`              // confidence floor for young abstractions (default: 0.5)
+	DedupMinConceptOverlap     int           `yaml:"dedup_min_concept_overlap"`    // min shared concepts for abstraction dedup match (default: 2)
 }
 
 // OrchestratorConfig configures the autonomous orchestrator.
@@ -852,6 +853,7 @@ func Default() *Config {
 			ConfidenceSignificantDecay: 0.7,
 			ConfidenceSevereDecay:      0.5,
 			GroundingFloor:             0.5,
+			DedupMinConceptOverlap:     2,
 		},
 		Orchestrator: OrchestratorConfig{
 			Enabled:                 true,


### PR DESCRIPTION
## Summary

Thread C characterization (post PR #414) found the same architectural bug consolidation had in two places: \`findSimilarAbstraction\` decides whether a newly-synthesized principle/axiom is a duplicate using embedding cosine + title Jaccard alone. No concept gate. A dominant abstraction whose embedding happens to sit near a new principle's embedding absorbs it silently — identical attractor dynamic to the one PRs #412 and #414 fixed for consolidation.

Observed production state before this PR: every abstraction cycle reports \`principles_created: 0, axioms_created: 0\`, downstream of a pipeline that has started producing 5-7 fresh patterns per cycle since #414. Also, 5 level-3 axioms in the DB at confidence 0.5 with access counts clustered at 2-22 — the attractor shape.

## Fix

Same shape as PRs #412 and #414, applied to \`internal/agent/abstraction\`:

- \`findSimilarAbstraction\` now takes the new abstraction's concepts and a \`minConceptOverlap\` parameter. A candidate qualifies as a duplicate only when it passes BOTH the similarity check (embedding cosine >= 0.85 OR title Jaccard >= 0.6) AND shares >= \`minConceptOverlap\` concepts with the new abstraction.
- The title-Jaccard fallback path (previously a concept-discipline escape hatch) now also passes through the concept gate — pinned by \`TestFindSimilarAbstraction_TitleMatchStillNeedsConcepts\`.
- Rejections and merges are logged at INFO with \`emb_sim\` / \`title_sim\` / \`concept_overlap\` / \`min_required\` — same structure as the consolidation gate logs.
- Logger threaded through the signature (may be nil so tests don't mock it).

## Config plumbing

- New \`AbstractionConfig.DedupMinConceptOverlap\` (default 2), wired through \`internal/config\` → \`cmd/mnemonic/serve.go\`. Matches consolidation's \`PatternMatchMinConceptOverlap\` in both default and semantics.
- Package-private \`countConceptOverlap\` lives in the abstraction package alongside the gate (consolidation has its own; dreaming has \`countSharedConcepts\`). One-package rename if we ever unify.

## Validation (path B)

Rebuilt (\`ROCM=1 make build-embedded\`) and restarted with authorization. Watched one abstraction cycle:

- \`patterns_evaluated: 1, principles_created: 0, axioms_created: 0, abstractions_demoted: 8\` — unchanged from pre-fix. No regression.
- **The concept gate is unreachable in the current production state**: the pattern DB has 24 patterns, only **1 at strength >= 0.7** (the existing \`MinStrength\` threshold). \`synthesizePrinciples\` returns early when \`len(strong) < 2\`, so no principle synthesis is attempted and the gate has nothing to guard.
- The gate is a defensive correctness fix: it activates when the pipeline has multiple strong patterns (natural accumulation + decay fix) or when \`MinStrength\` is tuned. Unit tests pin the behavior.

## Test plan

- [x] \`go test ./internal/agent/abstraction/ -v\`:
  - \`TestFindSimilarAbstraction_ConceptGateRejectsAttractor\` — attractor at cosine 1.0 with zero shared concepts is correctly rejected
  - \`TestFindSimilarAbstraction_ConceptGateAcceptsGenuineDup\` — concept-compatible near-duplicate is accepted
  - \`TestFindSimilarAbstraction_ArchivedIsSkipped\` — pre-existing behavior preserved
  - \`TestFindSimilarAbstraction_TitleMatchStillNeedsConcepts\` — title-Jaccard fallback also goes through the concept gate
- [x] \`go test ./...\` full suite green
- [x] \`go vet\` clean, \`golangci-lint\` 0 issues
- [x] **Production validation** against the running daemon — no regression; gate in place and ready.

## Does NOT touch

- **\`synthesizePrinciples\` \`MinStrength\` filter** at line 185 (config tuning, not architecture; separate conversation).
- **\`verifyGrounding\` demotion loop** — the 8 grounding-starved abstractions cycling through demotion every tick. Separate issue.
- **Dreaming** — Thread B comes after this lands.
- **Stale axioms in the DB** — the Stage 4 cleanup decision is still pending.

🤖 Generated with [Claude Code](https://claude.com/claude-code)