### PR TITLE
fix(abstraction): lower MinStrength default 0.7 → 0.5 to unblock principle synthesis

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -425,8 +425,10 @@ abstraction:
   interval: "2h"
 
   # Minimum pattern strength to consider for principle synthesis (0.0-1.0)
-  # Patterns start at 0.5 — set below that to let fresh patterns qualify
-  min_strength: 0.4
+  # Patterns start at 0.5. Setting to 0.5 lets any non-decayed pattern qualify —
+  # the consolidation concept gates (PRs #412/#414) keep junk out at pattern
+  # creation time, so trusting patterns at the starting line is fine.
+  min_strength: 0.5
 
   # Maximum LLM calls per abstraction cycle
   max_llm_calls: 10

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -373,7 +373,7 @@ type AbstractionConfig struct {
 	Enabled                    bool          `yaml:"enabled"`
 	IntervalRaw                string        `yaml:"interval"`
 	Interval                   time.Duration `yaml:"-"`
-	MinStrength                float32       `yaml:"min_strength"`                 // minimum pattern strength to consider
+	MinStrength                float32       `yaml:"min_strength"`                 // minimum pattern strength to consider (default: 0.5 — equal to a pattern's initial strength, so any non-decayed pattern qualifies; tightened attractors via PRs #412/#414/#415 make this trustworthy)
 	MaxLLMCalls                int           `yaml:"max_llm_calls"`                // budget per cycle
 	StartupDelaySec            int           `yaml:"startup_delay_sec"`            // seconds before first cycle (default: 300)
 	DefaultConfidence          float32       `yaml:"default_confidence"`           // fallback confidence for principles (default: 0.6)
@@ -844,7 +844,7 @@ func Default() *Config {
 			Enabled:                    true,
 			IntervalRaw:                "6h",
 			Interval:                   6 * time.Hour,
-			MinStrength:                0.7,
+			MinStrength:                0.5,
 			MaxLLMCalls:                5,
 			StartupDelaySec:            300,
 			DefaultConfidence:          0.6,


### PR DESCRIPTION
## Summary

Post-PR #415 validation found that the abstraction agent's principle/axiom synthesis pipeline was completely dark in production. The dedup concept gate PR #415 added was correct, but never exercised — because upstream, \`synthesizePrinciples\` filters patterns by \`p.Strength >= MinStrength\` (default 0.7) and returns early when fewer than 2 qualify.

In the current DB, exactly **1** pattern sits at strength ≥ 0.7. Everything else is clustered at 0.45-0.63 — barely above or at the 0.5 initial strength. So the pipeline gets `len(strong) = 1`, returns early, and no principles are ever attempted.

## Why 0.7 was too strict

Pattern strength starts at 0.5 and grows by `0.03 * log2(1 + new_evidence)` per cycle (capped at 0.15). To reach 0.7 naturally needs ~7-10 strengthening cycles with real new evidence each time.

Before PRs #412/#414, the super-attractor absorbed every cluster and ballooned past 0.95 easily, while real patterns were denied evidence and decayed. `MinStrength=0.7` made sense as \"wait for a truly dominant pattern.\" With PRs #412/#414/#415 in place, strengthening is distributed across many real patterns; each grows slower; fewer cross 0.7; the old threshold starves the whole pipeline.

## Fix

Lower `MinStrength` default from **0.7 → 0.5**. Rationale: 0.5 is the initial strength. \"Any pattern that hasn't decayed below its initial strength is worth abstracting.\" The consolidation concept gates (PR #412 first-stage, PR #414 second-stage) already filter out junk at pattern creation, so we can trust patterns at the starting line.

- [internal/config/config.go](internal/config/config.go) — Go default 0.7 → 0.5. Added rationale to the field comment.
- [config.example.yaml](config.example.yaml) — aligned from 0.4 (older calibration) to 0.5. Updated the explanatory comment.

`MaxLLMCalls` budget (default 5) still caps per-cycle work, so the increase in eligible patterns cannot produce runaway LLM usage.

## Validation (path B)

Rebuilt with `ROCM=1 make build-embedded`. Updated the daemon's \`./config.yaml\` to 0.5 and restarted with explicit authorization.

Cycle result at 13:41 UTC:

```
principle synthesized  title=\"Structured LLM Development and Debugging\"  source_patterns=4
abstraction cycle completed  patterns_evaluated=7  principles_created=1  axioms_created=0  abstractions_demoted=8  duration_ms=71459
```

**First principle ever synthesized** post-fix. `patterns_evaluated` jumped from 1 to 7. Duration rose from ~40s to 71s — real LLM work happening now.

`axioms_created: 0` is expected: axioms synthesize from level-2 principles clustered together, and we just created principle #1. A few more cycles and axiom synthesis should also activate.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` — full suite green
- [x] `golangci-lint run ./internal/config/` — 0 issues
- [x] **Live validation**: principle synthesized on first cycle post-fix. `patterns_evaluated` 1 → 7. No regressions in consolidation/dreaming cycles.

## Does NOT touch

- `len(strong) < 2` early-return at line 200 — still required. Preserves \"principle = pattern-across-patterns\" invariant.
- Per-cluster `len(cluster) < 2` check.
- The PR #415 concept gate — this PR just increases the candidates flowing into it.
- The `abstractions_demoted=8` loop (grounding-starved abstractions cycling through demotion without archival). Separate issue.

## Follow-ups after merge

The daemon is already running with \`min_strength: 0.5\` in its local \`config.yaml\`. Fresh installs from the repo will pick up 0.5 via the example. Existing deployments with explicit \`min_strength: 0.7\` in their yaml stay at 0.7 until operators update — document if we publish release notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)