### PR TITLE
feat(dreaming): INFO logs for four silent-drop gates

### DIFF
--- a/internal/agent/dreaming/agent.go
+++ b/internal/agent/dreaming/agent.go
@@ -53,6 +53,14 @@ type DreamReport struct {
 	PatternLinks             int
 	InsightsGenerated        int
 	NoisyMemoriesDemoted     int
+
+	// Observability counters — rejections by silent gates. Used to characterize
+	// whether dreaming phases are under- or over-filtering candidates.
+	CrossPollinateRejectedConcept int
+	CrossProjectRejectedEmbedding int
+	CrossProjectRejectedConcept   int
+	PatternLinkRejectedConcept    int
+	InsightRejectedLLM            int
 }
 
 func NewDreamingAgent(s store.Store, llmProv llm.Provider, cfg DreamingConfig, log *slog.Logger) *DreamingAgent {
@@ -127,6 +135,11 @@ func (da *DreamingAgent) loop() {
 				"pattern_links", report.PatternLinks,
 				"insights_generated", report.InsightsGenerated,
 				"noisy_memories_demoted", report.NoisyMemoriesDemoted,
+				"cross_pollinate_rejected_concept", report.CrossPollinateRejectedConcept,
+				"cross_project_rejected_embedding", report.CrossProjectRejectedEmbedding,
+				"cross_project_rejected_concept", report.CrossProjectRejectedConcept,
+				"pattern_link_rejected_concept", report.PatternLinkRejectedConcept,
+				"insight_rejected_llm", report.InsightRejectedLLM,
 			)
 		}
 	}
@@ -325,23 +338,36 @@ func (da *DreamingAgent) crossPollinate(ctx context.Context, replayed []store.Me
 		}
 
 		for _, candidate := range related {
-			if !linkedIDs[candidate.ID] && countSharedConcepts(mem.Concepts, candidate.Concepts) >= 2 {
-				newAssoc := store.Association{
-					SourceID:      mem.ID,
-					TargetID:      candidate.ID,
-					Strength:      0.3,
-					RelationType:  "similar",
-					CreatedAt:     time.Now(),
-					LastActivated: time.Now(),
-				}
-
-				if err := da.store.CreateAssociation(ctx, newAssoc); err != nil {
-					da.log.Warn("failed to create association", "source_id", mem.ID, "target_id", candidate.ID, "error", err)
-					continue
-				}
-
-				report.NewAssociationsCreated++
+			if linkedIDs[candidate.ID] {
+				continue
 			}
+			overlap := countSharedConcepts(mem.Concepts, candidate.Concepts)
+			if overlap < 2 {
+				da.log.Info("dreaming.crossPollinate concept-gate reject",
+					"memory_id", mem.ID,
+					"candidate_id", candidate.ID,
+					"overlap", overlap,
+					"required", 2,
+				)
+				report.CrossPollinateRejectedConcept++
+				continue
+			}
+
+			newAssoc := store.Association{
+				SourceID:      mem.ID,
+				TargetID:      candidate.ID,
+				Strength:      0.3,
+				RelationType:  "similar",
+				CreatedAt:     time.Now(),
+				LastActivated: time.Now(),
+			}
+
+			if err := da.store.CreateAssociation(ctx, newAssoc); err != nil {
+				da.log.Warn("failed to create association", "source_id", mem.ID, "target_id", candidate.ID, "error", err)
+				continue
+			}
+
+			report.NewAssociationsCreated++
 		}
 	}
 
@@ -431,11 +457,29 @@ func (da *DreamingAgent) crossProjectLink(ctx context.Context, replayed []store.
 				continue
 			}
 			if result.Score < 0.75 {
+				da.log.Info("dreaming.crossProjectLink embedding-gate reject",
+					"memory_id", mem.ID,
+					"candidate_id", result.Memory.ID,
+					"candidate_project", result.Memory.Project,
+					"score", result.Score,
+					"required", 0.75,
+				)
+				report.CrossProjectRejectedEmbedding++
 				continue
 			}
 
 			// Require at least 1 shared concept to avoid spurious embedding-only links
-			if countSharedConcepts(mem.Concepts, result.Memory.Concepts) < 1 {
+			overlap := countSharedConcepts(mem.Concepts, result.Memory.Concepts)
+			if overlap < 1 {
+				da.log.Info("dreaming.crossProjectLink concept-gate reject",
+					"memory_id", mem.ID,
+					"candidate_id", result.Memory.ID,
+					"candidate_project", result.Memory.Project,
+					"score", result.Score,
+					"overlap", overlap,
+					"required", 1,
+				)
+				report.CrossProjectRejectedConcept++
 				continue
 			}
 
@@ -487,7 +531,16 @@ func (da *DreamingAgent) linkToPatterns(ctx context.Context, replayed []store.Me
 			}
 
 			// Require at least 1 shared concept to validate pattern relevance
-			if countSharedConcepts(mem.Concepts, pattern.Concepts) < 1 {
+			overlap := countSharedConcepts(mem.Concepts, pattern.Concepts)
+			if overlap < 1 {
+				da.log.Info("dreaming.linkToPatterns concept-gate reject",
+					"memory_id", mem.ID,
+					"pattern_id", pattern.ID,
+					"pattern_title", pattern.Title,
+					"overlap", overlap,
+					"required", 1,
+				)
+				report.PatternLinkRejectedConcept++
 				continue
 			}
 
@@ -555,6 +608,7 @@ func (da *DreamingAgent) generateInsights(ctx context.Context, replayed []store.
 			continue
 		}
 		if insight == nil {
+			report.InsightRejectedLLM++
 			continue
 		}
 
@@ -673,6 +727,13 @@ Only share an insight if it's genuinely illuminating — something that makes yo
 	}
 
 	if !result.HasInsight || result.Title == "" || result.Insight == "" {
+		da.log.Info("dreaming.synthesizeInsight LLM-gate reject",
+			"cluster_size", len(cluster),
+			"memory_ids", memoryIDs,
+			"has_insight", result.HasInsight,
+			"title_empty", result.Title == "",
+			"insight_empty", result.Insight == "",
+		)
 		return nil, nil
 	}
 

--- a/internal/agent/dreaming/agent_test.go
+++ b/internal/agent/dreaming/agent_test.go
@@ -2,6 +2,7 @@ package dreaming
 
 import (
 	"context"
+	"io"
 	"log/slog"
 	"testing"
 	"time"
@@ -20,7 +21,7 @@ func TestNewDreamingAgent(t *testing.T) {
 		AssociationBoostFactor: 1.15,
 		NoisePruneThreshold:    0.15,
 	}
-	logger := slog.New(slog.NewTextHandler(nil, nil))
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	agent := NewDreamingAgent(mockStore, nil, config, logger)
 
@@ -203,7 +204,7 @@ func TestDreamingAgentName(t *testing.T) {
 	config := DreamingConfig{
 		Interval: 3 * time.Hour,
 	}
-	logger := slog.New(slog.NewTextHandler(nil, nil))
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	agent := NewDreamingAgent(mockStore, nil, config, logger)
 
@@ -218,7 +219,7 @@ func TestDreamingAgentName(t *testing.T) {
 // but zero shared concepts.
 func TestCrossProjectLinkRequiresConceptOverlap(t *testing.T) {
 	ms := &crossProjectMockStore{}
-	logger := slog.New(slog.NewTextHandler(nil, nil))
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	config := DreamingConfig{
 		Interval:               3 * time.Hour,
 		BatchSize:              20,
@@ -262,13 +263,17 @@ func TestCrossProjectLinkRequiresConceptOverlap(t *testing.T) {
 	if ms.associationsCreated != 0 {
 		t.Fatalf("expected 0 associations created, got %d", ms.associationsCreated)
 	}
+	// Observability: the concept-gate reject should have been counted.
+	if report.CrossProjectRejectedConcept != 1 {
+		t.Fatalf("expected 1 concept-gate rejection, got %d", report.CrossProjectRejectedConcept)
+	}
 }
 
 // TestCrossProjectLinkCreatesWithConceptOverlap verifies that crossProjectLink
 // creates an association when memories share at least 1 concept.
 func TestCrossProjectLinkCreatesWithConceptOverlap(t *testing.T) {
 	ms := &crossProjectMockStore{}
-	logger := slog.New(slog.NewTextHandler(nil, nil))
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	config := DreamingConfig{
 		Interval:               3 * time.Hour,
 		BatchSize:              20,
@@ -314,7 +319,7 @@ func TestCrossProjectLinkCreatesWithConceptOverlap(t *testing.T) {
 // does not boost a pattern when the memory shares no concepts with it.
 func TestLinkToPatternsRequiresConceptOverlap(t *testing.T) {
 	ms := &patternLinkMockStore{}
-	logger := slog.New(slog.NewTextHandler(nil, nil))
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	config := DreamingConfig{
 		Interval:               3 * time.Hour,
 		BatchSize:              20,
@@ -351,6 +356,56 @@ func TestLinkToPatternsRequiresConceptOverlap(t *testing.T) {
 	}
 	if ms.patternsUpdated != 0 {
 		t.Fatalf("expected 0 patterns updated, got %d", ms.patternsUpdated)
+	}
+	// Observability: the concept-gate reject should have been counted.
+	if report.PatternLinkRejectedConcept != 1 {
+		t.Fatalf("expected 1 pattern-link concept-gate rejection, got %d", report.PatternLinkRejectedConcept)
+	}
+}
+
+// TestCrossProjectLinkEmbeddingGateCounter verifies the embedding-gate reject
+// increments the observability counter without creating an association.
+func TestCrossProjectLinkEmbeddingGateCounter(t *testing.T) {
+	ms := &crossProjectMockStore{}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	config := DreamingConfig{
+		Interval:               3 * time.Hour,
+		BatchSize:              20,
+		SalienceThreshold:      0.3,
+		AssociationBoostFactor: 1.15,
+		NoisePruneThreshold:    0.15,
+	}
+	agent := NewDreamingAgent(ms, nil, config, logger)
+
+	memA := store.Memory{
+		ID:        "mem-a",
+		Project:   "project-alpha",
+		Concepts:  []string{"golang", "testing"},
+		Embedding: []float32{0.9, 0.1, 0.0},
+	}
+	memB := store.Memory{
+		ID:        "mem-b",
+		Project:   "project-beta",
+		Concepts:  []string{"golang", "testing"},
+		Embedding: []float32{0.3, 0.7, 0.1},
+	}
+
+	// Score below the 0.75 embedding threshold.
+	ms.embeddingResults = []store.RetrievalResult{{Memory: memB, Score: 0.5}}
+
+	report := &DreamReport{}
+	if err := agent.crossProjectLink(context.Background(), []store.Memory{memA}, report); err != nil {
+		t.Fatalf("crossProjectLink failed: %v", err)
+	}
+
+	if report.CrossProjectLinks != 0 {
+		t.Fatalf("expected 0 cross-project links, got %d", report.CrossProjectLinks)
+	}
+	if report.CrossProjectRejectedEmbedding != 1 {
+		t.Fatalf("expected 1 embedding-gate rejection, got %d", report.CrossProjectRejectedEmbedding)
+	}
+	if report.CrossProjectRejectedConcept != 0 {
+		t.Fatalf("expected 0 concept-gate rejections (gate not reached), got %d", report.CrossProjectRejectedConcept)
 	}
 }
 


### PR DESCRIPTION
## Summary

Thread B of the post-consolidation/abstraction characterization work. Four silent `continue` paths in the dreaming agent were dropping candidate associations/links/insights with no log line, making it impossible to tell whether thresholds were tuned correctly from production logs alone.

This PR promotes all four to INFO logs and adds aggregate rejection counters to `DreamReport`. No threshold changes — pure observability, matching the "observability first, tuning second" approach used in PRs #412-#416.

## Sites

| File:Line | Phase | Gate |
|---|---|---|
| [agent.go:338](internal/agent/dreaming/agent.go#L338) | `crossPollinate` | `countSharedConcepts >= 2` |
| [agent.go:458](internal/agent/dreaming/agent.go#L458) | `crossProjectLink` | `embedding score >= 0.75` |
| [agent.go:471](internal/agent/dreaming/agent.go#L471) | `crossProjectLink` | `countSharedConcepts >= 1` |
| [agent.go:535](internal/agent/dreaming/agent.go#L535) | `linkToPatterns` | `countSharedConcepts >= 1` |
| [agent.go:730](internal/agent/dreaming/agent.go#L730) | `synthesizeInsight` | LLM `has_insight:false` / empty title/insight |

Each log line carries the memory ID, candidate ID, similarity scores, and overlap count so the filter decision is inspectable from `journalctl -u mnemonic.service`.

New `DreamReport` fields (surfaced in the `dream cycle completed` summary line):
- `CrossPollinateRejectedConcept`
- `CrossProjectRejectedEmbedding`
- `CrossProjectRejectedConcept`
- `PatternLinkRejectedConcept`
- `InsightRejectedLLM`

## Test plan

- [x] `go test ./internal/agent/dreaming/...` — all pass
- [x] `go test ./...` — full suite passes
- [x] `go vet ./...` — clean
- [x] `ROCM=1 make build-embedded` — 86MB daemon binary produced
- [x] Existing rejection tests assert new counters increment
- [x] New `TestCrossProjectLinkEmbeddingGateCounter` covers the sub-0.75 embedding short-circuit
- [ ] After merge + daemon restart: observe 2-3 dream cycles and grep the journal for `dreaming.` INFO lines to characterize which gates dominate. That data drives the next decision on whether any thresholds need retuning.

## Notes

- Pre-existing test loggers used `slog.NewTextHandler(nil, nil)` which panics once any `log.Info` fires inside the function under test. Switched the four affected test fixtures to `io.Discard`.
- The daemon restart needed to collect post-merge characterization data will wipe crispr-lm's in-memory splice edits — requires explicit authorization per `.claude/rules/testing-against-daemon.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)