### PR TITLE
fix(llm): drop misleading "busy" prefix on embedded provider cancel

### DIFF
--- a/internal/llm/embedded.go
+++ b/internal/llm/embedded.go
@@ -293,7 +293,7 @@ func (p *EmbeddedProvider) Complete(ctx context.Context, req CompletionRequest) 
 	}
 
 	if err := p.acquire(ctx); err != nil {
-		return CompletionResponse{}, fmt.Errorf("embedded provider busy: %w", err)
+		return CompletionResponse{}, fmt.Errorf("embedded provider: %w", err)
 	}
 	defer p.release()
 
@@ -409,7 +409,7 @@ func (p *EmbeddedProvider) BatchEmbed(ctx context.Context, texts []string) ([][]
 	}
 
 	if err := p.acquire(ctx); err != nil {
-		return nil, fmt.Errorf("embedded provider busy: %w", err)
+		return nil, fmt.Errorf("embedded provider: %w", err)
 	}
 	defer p.release()
 


### PR DESCRIPTION
## Summary

`acquire(ctx)` in [internal/llm/embedded.go:219-226](internal/llm/embedded.go#L219-L226) can only return `ctx.Err()` — there is no internal queue timeout or contention error path. Wrapping that as `"embedded provider busy: context canceled"` reads as LLM contention when the error is literally always a context cancellation.

## Evidence

Investigated the "4 of 9 LLM attempts per long consolidation cycle get canceled" item from the Thread B/concurrency handoff. All 24 historical busy errors in the local daemon log correlate 1:1 with `systemctl --user stop mnemonic` events:

| Error cluster | Systemd stop |
|---|---|
| 10:02:30 (×2) | 10:02:28 |
| 12:55:51 (×6) | 12:55:51 |
| 13:37:06 (×16) | 13:37:06 |

Zero busy errors during steady-state operation. The 13:37 consolidation cycle blamed for "4 of 9 cancelled" was only 31s long because the daemon was being stopped (started at 13:36:35, cancelled at 13:37:06) — not a long contested cycle.

## Test plan

- [x] `go test ./internal/llm/...` — pass
- [x] `go vet ./...` — clean
- [x] No other code references to "embedded provider busy" remain
- [ ] After deploy: next shutdown will show `"embedded provider: context canceled"` — truthful, no misleading "busy" framing

🤖 Generated with [Claude Code](https://claude.com/claude-code)