### PR TITLE
fix(abstraction): bump MaxTokens 200→500 for principle/axiom synthesis

### DIFF
--- a/internal/agent/abstraction/agent.go
+++ b/internal/agent/abstraction/agent.go
@@ -519,7 +519,7 @@ Set has_principle to false if:
 			{Role: "system", Content: "You are a senior software engineer identifying recurring practices in a codebase. Extract concrete engineering principles from patterns. Output JSON only."},
 			{Role: "user", Content: prompt},
 		},
-		MaxTokens:   200,
+		MaxTokens:   500,
 		Temperature: 0.3,
 		ResponseFormat: &llm.ResponseFormat{
 			Type: "json_schema",
@@ -630,7 +630,7 @@ Set has_axiom to false if:
 			{Role: "system", Content: "You are a senior software engineer synthesizing team engineering standards from observed principles. Output JSON only."},
 			{Role: "user", Content: prompt},
 		},
-		MaxTokens:   200,
+		MaxTokens:   500,
 		Temperature: 0.3,
 		ResponseFormat: &llm.ResponseFormat{
 			Type: "json_schema",


### PR DESCRIPTION
## Summary

Three recent failures in the running daemon log:

\`\`\`
2026-04-17T19:02:29: axiom synthesis failed — failed to parse axiom response: unexpected end of JSON input
2026-04-17T22:03:36: axiom synthesis failed — failed to parse axiom response: unexpected end of JSON input
2026-04-17T22:04:59: axiom synthesis failed — failed to parse axiom response: unexpected end of JSON input
\`\`\`

Root cause: \`MaxTokens=200\` is too tight for the strict JSON schema (\`has_axiom\` + title + 1-2 sentence \`axiom\` + 3-5 concepts + confidence). Multi-word titles plus multi-sentence axiom text push past 200 completion tokens, truncating the JSON mid-output and failing \`json.Unmarshal\`.

Same failure shape and same fix as [PR #413](https://github.com/AppSprout-dev/mnemonic/pull/413) (identifyPattern). Bumped both \`synthesizePrinciple\` and \`synthesizeAxiom\` MaxTokens to 500 for symmetry and headroom.

## Test plan

- [x] \`go test ./internal/agent/abstraction/...\` — pass
- [x] \`go vet ./...\` — clean
- [ ] Next abstraction cycle completes axiom synthesis without JSON truncation

🤖 Generated with [Claude Code](https://claude.com/claude-code)