### PR TITLE
feat(abstraction): streak-based archive supersedes age-based decay exit

### DIFF
--- a/cmd/mnemonic/serve.go
+++ b/cmd/mnemonic/serve.go
@@ -549,7 +549,7 @@ func serveCommand(configPath string) {
 			GroundingFloor:             cfg.Abstraction.GroundingFloor,
 			DedupMinConceptOverlap:     cfg.Abstraction.DedupMinConceptOverlap,
 			ArchiveDecayConfidence:     cfg.Abstraction.ArchiveDecayConfidence,
-			ArchiveDecayMinAge:         cfg.Abstraction.ArchiveDecayMinAge,
+			ArchiveDemotionStreak:      cfg.Abstraction.ArchiveDemotionStreak,
 		}, log)
 
 		if err := abstractionAgent.Start(rootCtx, bus); err != nil {

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -434,17 +434,17 @@ abstraction:
   max_llm_calls: 10
 
   # Archive escape hatch for chronically-demoted abstractions.
-  # Abstractions with low grounding get their confidence multiplied down each
-  # cycle (see confidence_*_decay above). Without an exit path, that leaves
-  # them cycling through demotion forever. These two settings archive any
-  # abstraction that is:
-  #   - state = "active"
-  #   - older than archive_decay_min_age
-  #   - confidence below archive_decay_confidence
-  #   - grounding ratio below 0.3 (same threshold as "significant decay")
-  # Both settings default to the values below if unset.
+  # Each abstraction carries a demotion_streak counter incremented on any
+  # grounding-verification cycle where the grounding ratio falls below the
+  # "healthy" threshold (0.5) and reset to 0 on any healthy cycle. When the
+  # streak reaches archive_demotion_streak AND the abstraction's confidence
+  # has decayed below archive_decay_confidence AND the abstraction is past
+  # the 7-day young-grace window, it is moved to "archived" — breaking the
+  # otherwise-endless demote-forever loop for abstractions stuck in the
+  # 0.1-0.3 grounding band. Streak-based rather than age-based so the exit
+  # remains correct under adaptive-scheduler cadence.
   archive_decay_confidence: 0.2
-  archive_decay_min_age: "336h"  # 14 days
+  archive_demotion_streak: 10
 
 # Orchestrator Configuration (autonomous scheduler and health monitoring)
 orchestrator:

--- a/internal/agent/abstraction/agent.go
+++ b/internal/agent/abstraction/agent.go
@@ -32,13 +32,16 @@ type AbstractionConfig struct {
 	// behavior fixed for consolidation in PRs #412 and #414. Default: 2.
 	DedupMinConceptOverlap int
 	// ArchiveDecayConfidence is the confidence threshold below which a
-	// sufficiently-old abstraction with low grounding is archived instead of
-	// cycled through demotion indefinitely. Default: 0.2.
+	// chronically-demoted abstraction is archived instead of cycled through
+	// demotion indefinitely. Default: 0.2.
 	ArchiveDecayConfidence float32
-	// ArchiveDecayMinAge is the minimum age for an abstraction to be eligible
-	// for decay-driven archival. Protects young abstractions that haven't had
-	// time to re-ground. Default: 14 days.
-	ArchiveDecayMinAge time.Duration
+	// ArchiveDemotionStreak is the number of consecutive grounding-verification
+	// cycles in which the abstraction's grounding ratio must stay below the
+	// "healthy" threshold (0.5) before decay-driven archival fires. Counted
+	// via the DemotionStreak field on the abstraction and reset to 0 on any
+	// healthy cycle. Robust to adaptive scheduler cadence in a way that a
+	// wall-clock age threshold is not. Default: 10.
+	ArchiveDemotionStreak int
 }
 
 type AbstractionAgent struct {
@@ -443,12 +446,28 @@ func (aa *AbstractionAgent) verifyGrounding(ctx context.Context, report *CycleRe
 				groundingFloor = 0.5
 			}
 
+			// Healthy grounding: reset any accumulated streak and skip.
+			// Only write when there is something to reset, to avoid
+			// touching thriving abstractions on every cycle.
+			if groundingRatio >= 0.5 {
+				if abs.DemotionStreak > 0 {
+					abs.DemotionStreak = 0
+					abs.UpdatedAt = time.Now()
+					if err := aa.store.UpdateAbstraction(ctx, abs); err != nil {
+						aa.log.Warn("failed to reset demotion streak", "id", abs.ID, "error", err)
+					}
+				}
+				continue
+			}
+
+			// Any non-healthy cycle is a strike on the streak, regardless of
+			// which decay band the ratio lands in. The streak is the durable
+			// "this abstraction has been failing" signal used for archival.
+			abs.DemotionStreak++
+
 			// Graduated grounding response
 			demotedThisCycle := false
 			switch {
-			case groundingRatio >= 0.5:
-				// Healthy grounding, no action needed
-				continue
 			case groundingRatio >= 0.3:
 				// Moderate decay: reduce confidence slightly
 				abs.Confidence *= moderateDecay
@@ -472,21 +491,22 @@ func (aa *AbstractionAgent) verifyGrounding(ctx context.Context, report *CycleRe
 				abs.Confidence = groundingFloor
 			}
 
-			// Archive escape hatch: abstractions that are old, chronically
-			// under-grounded, and have decayed past the archive threshold
-			// should be archived so they stop cycling through demotion every
-			// pass. Without this, grounding-starved abstractions in the
-			// 0.1-0.3 ratio band shrink toward zero confidence but never
-			// transition out of "active", producing a stuck demotion loop.
+			// Archive escape hatch: any "active" abstraction that has been
+			// non-healthy for N consecutive cycles AND has decayed past the
+			// archive confidence threshold is moved to archived. This is the
+			// only exit from the demote-forever loop for abstractions stuck
+			// in the 0.1-0.3 ratio band that never fall far enough to fade.
+			// Young abstractions (< 7d) are protected via isYoung so newly
+			// created abstractions get time to re-ground.
 			archiveConf := aa.config.ArchiveDecayConfidence
 			if archiveConf <= 0 {
 				archiveConf = 0.2
 			}
-			archiveMinAge := aa.config.ArchiveDecayMinAge
-			if archiveMinAge <= 0 {
-				archiveMinAge = 14 * 24 * time.Hour
+			archiveStreak := aa.config.ArchiveDemotionStreak
+			if archiveStreak <= 0 {
+				archiveStreak = 10
 			}
-			if abs.State == "active" && !isYoung && ageHours >= archiveMinAge.Hours() && abs.Confidence < archiveConf {
+			if abs.State == "active" && !isYoung && abs.DemotionStreak >= archiveStreak && abs.Confidence < archiveConf {
 				abs.State = "archived"
 				report.AbstractionsArchived++
 				if demotedThisCycle {
@@ -500,7 +520,12 @@ func (aa *AbstractionAgent) verifyGrounding(ctx context.Context, report *CycleRe
 				continue
 			}
 			aa.log.Info("abstraction grounding adjusted",
-				"id", abs.ID, "title", abs.Title, "grounding_ratio", groundingRatio, "new_confidence", abs.Confidence, "state", abs.State)
+				"id", abs.ID, "title", abs.Title,
+				"grounding_ratio", groundingRatio,
+				"new_confidence", abs.Confidence,
+				"state", abs.State,
+				"demotion_streak", abs.DemotionStreak,
+			)
 		}
 	}
 

--- a/internal/agent/abstraction/agent_test.go
+++ b/internal/agent/abstraction/agent_test.go
@@ -120,14 +120,18 @@ func TestFindSimilarAbstraction_TitleMatchStillNeedsConcepts(t *testing.T) {
 	}
 }
 
-// groundingMockStore fakes ListAbstractions/GetPattern/GetMemory/UpdateAbstraction
-// so we can exercise verifyGrounding without a real database. The only thing
-// that matters for archival tests is: what state is the abstraction in after
-// the cycle? — which we capture via the updates map.
+// groundingMockStore fakes ListAbstractions / GetMemory / GetPattern /
+// UpdateAbstraction so we can exercise verifyGrounding without a real
+// database. Memories are returned as "archived" by default (grounding ratio
+// drops to 0). Memories whose ID matches activeMemoryID are returned as
+// "active" — letting a test dial groundingRatio via the source-memory list
+// size. The updates map captures the resulting abstraction state after the
+// cycle.
 type groundingMockStore struct {
 	storetest.MockStore
-	abstractions []store.Abstraction
-	updates      map[string]store.Abstraction
+	abstractions   []store.Abstraction
+	activeMemoryID string
+	updates        map[string]store.Abstraction
 }
 
 func (m *groundingMockStore) ListAbstractions(_ context.Context, level, _ int) ([]store.Abstraction, error) {
@@ -140,10 +144,10 @@ func (m *groundingMockStore) ListAbstractions(_ context.Context, level, _ int) (
 	return out, nil
 }
 
-// GetMemory and GetPattern both return ErrNotFound so the grounding ratio is
-// computed entirely from the abstraction's SourceMemoryIDs / SourcePatternIDs
-// counts vs. what we return as active. We want groundingRatio = 0 here.
-func (m *groundingMockStore) GetMemory(_ context.Context, _ string) (store.Memory, error) {
+func (m *groundingMockStore) GetMemory(_ context.Context, id string) (store.Memory, error) {
+	if m.activeMemoryID != "" && id == m.activeMemoryID {
+		return store.Memory{State: "active"}, nil
+	}
 	return store.Memory{State: "archived"}, nil
 }
 
@@ -159,42 +163,124 @@ func (m *groundingMockStore) UpdateAbstraction(_ context.Context, a store.Abstra
 	return nil
 }
 
-// TestVerifyGrounding_ArchivesDecayedOldAbstraction verifies that an abstraction
-// which is (a) old enough, (b) has low grounding, and (c) has already decayed
-// below the archive-confidence threshold is moved to "archived" state instead
-// of being demoted again. Fixes the stuck "abstractions_demoted=8" loop where
-// grounding-starved abstractions would cycle through demotion forever without
-// any archival exit.
-func TestVerifyGrounding_ArchivesDecayedOldAbstraction(t *testing.T) {
-	oldDecayed := store.Abstraction{
-		ID:              "old-decayed",
-		Level:           2,
-		State:           "active",
-		Confidence:      0.25, // will drop to 0.175 after 0.7× decay, below 0.2 threshold
-		AccessCount:     0,
-		CreatedAt:       time.Now().Add(-30 * 24 * time.Hour), // 30 days old
-		SourceMemoryIDs: []string{"mem-a", "mem-b", "mem-c"},  // all will resolve as archived
-	}
-
-	ms := &groundingMockStore{abstractions: []store.Abstraction{oldDecayed}}
-	agent := NewAbstractionAgent(ms, nil, AbstractionConfig{
+// standardStreakConfig is the archival-relevant config used by the streak tests.
+func standardStreakConfig() AbstractionConfig {
+	return AbstractionConfig{
+		ConfidenceModerateDecay:    0.9,
 		ConfidenceSignificantDecay: 0.7,
+		ConfidenceSevereDecay:      0.5,
 		GroundingFloor:             0.5,
 		ArchiveDecayConfidence:     0.2,
-		ArchiveDecayMinAge:         14 * 24 * time.Hour,
-	}, silentLogger())
+		ArchiveDemotionStreak:      3,
+	}
+}
+
+// TestVerifyGrounding_IncrementsStreakOnDemote verifies that a cycle where
+// grounding is below the healthy threshold bumps DemotionStreak by 1 without
+// (yet) archiving, when the streak is still below the archive threshold.
+func TestVerifyGrounding_IncrementsStreakOnDemote(t *testing.T) {
+	a := store.Abstraction{
+		ID:              "streak-1",
+		Level:           2,
+		State:           "active",
+		Confidence:      0.4,
+		DemotionStreak:  0,
+		CreatedAt:       time.Now().Add(-30 * 24 * time.Hour),
+		SourceMemoryIDs: []string{"mem-a", "mem-b"}, // all archived → ratio 0 (severe)
+	}
+
+	ms := &groundingMockStore{abstractions: []store.Abstraction{a}}
+	agent := NewAbstractionAgent(ms, nil, standardStreakConfig(), silentLogger())
 
 	report := &CycleReport{}
 	if err := agent.verifyGrounding(context.Background(), report); err != nil {
 		t.Fatalf("verifyGrounding failed: %v", err)
 	}
 
-	got, ok := ms.updates[oldDecayed.ID]
+	got, ok := ms.updates[a.ID]
+	if !ok {
+		t.Fatalf("expected abstraction update, got none")
+	}
+	if got.DemotionStreak != 1 {
+		t.Errorf("expected DemotionStreak=1, got %d", got.DemotionStreak)
+	}
+	if got.State != "active" {
+		t.Errorf("expected state=active (streak below threshold), got %s", got.State)
+	}
+	if report.AbstractionsArchived != 0 {
+		t.Errorf("expected AbstractionsArchived=0, got %d", report.AbstractionsArchived)
+	}
+}
+
+// TestVerifyGrounding_ResetsStreakOnHealthy verifies that when an abstraction
+// is healthy (ratio >= 0.5), a previously accumulated streak is reset to 0 and
+// the abstraction is left in state=active. The reset must be persisted.
+func TestVerifyGrounding_ResetsStreakOnHealthy(t *testing.T) {
+	a := store.Abstraction{
+		ID:              "streak-reset",
+		Level:           2,
+		State:           "active",
+		Confidence:      0.4,
+		DemotionStreak:  5, // previously accumulated
+		CreatedAt:       time.Now().Add(-30 * 24 * time.Hour),
+		SourceMemoryIDs: []string{"mem-active"}, // 1/1 active → ratio 1.0 (healthy)
+	}
+
+	ms := &groundingMockStore{
+		abstractions:   []store.Abstraction{a},
+		activeMemoryID: "mem-active",
+	}
+	agent := NewAbstractionAgent(ms, nil, standardStreakConfig(), silentLogger())
+
+	report := &CycleReport{}
+	if err := agent.verifyGrounding(context.Background(), report); err != nil {
+		t.Fatalf("verifyGrounding failed: %v", err)
+	}
+
+	got, ok := ms.updates[a.ID]
+	if !ok {
+		t.Fatalf("expected abstraction update (streak reset must persist), got none")
+	}
+	if got.DemotionStreak != 0 {
+		t.Errorf("expected DemotionStreak=0 after healthy cycle, got %d", got.DemotionStreak)
+	}
+	if got.State != "active" {
+		t.Errorf("expected state=active, got %s", got.State)
+	}
+}
+
+// TestVerifyGrounding_ArchivesWhenStreakAndConfidenceThresholdsMet verifies
+// the escape hatch fires when an abstraction is old, below the confidence
+// threshold, and at/past the streak threshold. This is the fix for the stuck
+// "abstractions_demoted=8" loop.
+func TestVerifyGrounding_ArchivesWhenStreakAndConfidenceThresholdsMet(t *testing.T) {
+	a := store.Abstraction{
+		ID:              "ready-to-archive",
+		Level:           2,
+		State:           "active",
+		Confidence:      0.25, // 0.25 * 0.7 = 0.175 < 0.2 after this cycle's decay
+		DemotionStreak:  2,    // +1 this cycle = 3, matches ArchiveDemotionStreak
+		CreatedAt:       time.Now().Add(-30 * 24 * time.Hour),
+		SourceMemoryIDs: []string{"mem-a", "mem-b", "mem-c", "mem-d", "mem-e"}, // 1/5 active → 0.2 ratio (significant)
+	}
+
+	ms := &groundingMockStore{
+		abstractions:   []store.Abstraction{a},
+		activeMemoryID: "mem-a",
+	}
+	agent := NewAbstractionAgent(ms, nil, standardStreakConfig(), silentLogger())
+
+	report := &CycleReport{}
+	if err := agent.verifyGrounding(context.Background(), report); err != nil {
+		t.Fatalf("verifyGrounding failed: %v", err)
+	}
+
+	got, ok := ms.updates[a.ID]
 	if !ok {
 		t.Fatalf("expected abstraction update, got none")
 	}
 	if got.State != "archived" {
-		t.Errorf("expected state=archived, got state=%s (confidence=%v)", got.State, got.Confidence)
+		t.Errorf("expected state=archived (streak=%d, conf=%v), got %s", got.DemotionStreak, got.Confidence, got.State)
 	}
 	if report.AbstractionsArchived != 1 {
 		t.Errorf("expected AbstractionsArchived=1, got %d", report.AbstractionsArchived)
@@ -204,41 +290,33 @@ func TestVerifyGrounding_ArchivesDecayedOldAbstraction(t *testing.T) {
 	}
 }
 
-// TestVerifyGrounding_YoungAbstractionNotArchived verifies the grace-period
-// protection: an abstraction younger than ArchiveDecayMinAge must not be
-// archived even if its confidence is below the threshold. Young abstractions
-// get their confidence floored to GroundingFloor on decay.
+// TestVerifyGrounding_YoungAbstractionNotArchived verifies the isYoung
+// grace period (< 7 days): even with a high streak and low confidence, a
+// young abstraction must not be archived. Young abstractions get a
+// GroundingFloor on confidence.
 func TestVerifyGrounding_YoungAbstractionNotArchived(t *testing.T) {
-	youngDecayed := store.Abstraction{
-		ID:              "young-decayed",
+	young := store.Abstraction{
+		ID:              "young",
 		Level:           2,
 		State:           "active",
 		Confidence:      0.15,
-		AccessCount:     0,
-		CreatedAt:       time.Now().Add(-2 * 24 * time.Hour), // 2 days old, isYoung
-		SourceMemoryIDs: []string{"mem-a", "mem-b"},
+		DemotionStreak:  99,                                    // way past threshold
+		CreatedAt:       time.Now().Add(-2 * 24 * time.Hour),   // 2 days — isYoung
+		SourceMemoryIDs: []string{"mem-a", "mem-b", "mem-c"},
 	}
 
-	ms := &groundingMockStore{abstractions: []store.Abstraction{youngDecayed}}
-	agent := NewAbstractionAgent(ms, nil, AbstractionConfig{
-		ConfidenceSignificantDecay: 0.7,
-		GroundingFloor:             0.5,
-		ArchiveDecayConfidence:     0.2,
-		ArchiveDecayMinAge:         14 * 24 * time.Hour,
-	}, silentLogger())
+	ms := &groundingMockStore{abstractions: []store.Abstraction{young}}
+	agent := NewAbstractionAgent(ms, nil, standardStreakConfig(), silentLogger())
 
 	report := &CycleReport{}
 	if err := agent.verifyGrounding(context.Background(), report); err != nil {
 		t.Fatalf("verifyGrounding failed: %v", err)
 	}
 
-	got, ok := ms.updates[youngDecayed.ID]
+	got, ok := ms.updates[young.ID]
 	if !ok {
 		t.Fatalf("expected abstraction update, got none")
 	}
-	// The young abstraction may still transition to "fading" via existing
-	// severe-decay logic — that is unchanged. What MUST hold: it is not
-	// archived by the new decay-driven archival path.
 	if got.State == "archived" {
 		t.Errorf("expected young abstraction NOT to be archived, got state=%s", got.State)
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -383,9 +383,8 @@ type AbstractionConfig struct {
 	ConfidenceSevereDecay      float32       `yaml:"confidence_severe_decay"`      // grounding multiplier for severe decay (default: 0.5)
 	GroundingFloor             float32       `yaml:"grounding_floor"`              // confidence floor for young abstractions (default: 0.5)
 	DedupMinConceptOverlap     int           `yaml:"dedup_min_concept_overlap"`    // min shared concepts for abstraction dedup match (default: 2)
-	ArchiveDecayConfidence     float32       `yaml:"archive_decay_confidence"`     // confidence threshold below which aged, low-grounded abstractions are archived (default: 0.2)
-	ArchiveDecayMinAgeRaw      string        `yaml:"archive_decay_min_age"`        // minimum age before an abstraction is eligible for decay-driven archival (default: "336h" / 14d)
-	ArchiveDecayMinAge         time.Duration `yaml:"-"`
+	ArchiveDecayConfidence     float32       `yaml:"archive_decay_confidence"`     // confidence threshold below which chronically-demoted abstractions are archived (default: 0.2)
+	ArchiveDemotionStreak      int           `yaml:"archive_demotion_streak"`      // consecutive non-healthy cycles before archival fires (default: 10)
 }
 
 // OrchestratorConfig configures the autonomous orchestrator.
@@ -858,8 +857,7 @@ func Default() *Config {
 			GroundingFloor:             0.5,
 			DedupMinConceptOverlap:     2,
 			ArchiveDecayConfidence:     0.2,
-			ArchiveDecayMinAgeRaw:      "336h",
-			ArchiveDecayMinAge:         14 * 24 * time.Hour,
+			ArchiveDemotionStreak:      10,
 		},
 		Orchestrator: OrchestratorConfig{
 			Enabled:                 true,
@@ -1009,7 +1007,6 @@ func (c *Config) process(configDir string) error {
 		{c.Metacognition.IntervalRaw, &c.Metacognition.Interval, "metacognition.interval"},
 		{c.Dreaming.IntervalRaw, &c.Dreaming.Interval, "dreaming.interval"},
 		{c.Abstraction.IntervalRaw, &c.Abstraction.Interval, "abstraction.interval"},
-		{c.Abstraction.ArchiveDecayMinAgeRaw, &c.Abstraction.ArchiveDecayMinAge, "abstraction.archive_decay_min_age"},
 		{c.Orchestrator.SelfTestIntervalRaw, &c.Orchestrator.SelfTestInterval, "orchestrator.self_test_interval"},
 		{c.Orchestrator.MonitorIntervalRaw, &c.Orchestrator.MonitorInterval, "orchestrator.monitor_interval"},
 		{c.Orchestrator.HealthReportIntervalRaw, &c.Orchestrator.HealthReportInterval, "orchestrator.health_report_interval"},

--- a/internal/store/sqlite/abstractions.go
+++ b/internal/store/sqlite/abstractions.go
@@ -12,7 +12,7 @@ import (
 )
 
 // abstractionColumns is the standard column list for abstraction queries.
-const abstractionColumns = `id, level, title, description, parent_id, source_pattern_ids, source_memory_ids, confidence, concepts, embedding, access_count, state, created_at, updated_at`
+const abstractionColumns = `id, level, title, description, parent_id, source_pattern_ids, source_memory_ids, confidence, concepts, embedding, access_count, state, demotion_streak, created_at, updated_at`
 
 // WriteAbstraction inserts a new abstraction.
 func (s *SQLiteStore) WriteAbstraction(ctx context.Context, a store.Abstraction) error {
@@ -26,7 +26,7 @@ func (s *SQLiteStore) WriteAbstraction(ctx context.Context, a store.Abstraction)
 
 	_, err := s.db.ExecContext(ctx,
 		`INSERT INTO abstractions (`+abstractionColumns+`)
-		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+		VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
 		a.ID,
 		a.Level,
 		a.Title,
@@ -39,6 +39,7 @@ func (s *SQLiteStore) WriteAbstraction(ctx context.Context, a store.Abstraction)
 		embeddingBlob,
 		a.AccessCount,
 		a.State,
+		a.DemotionStreak,
 		a.CreatedAt.Format(time.RFC3339),
 		a.UpdatedAt.Format(time.RFC3339),
 	)
@@ -69,7 +70,8 @@ func (s *SQLiteStore) UpdateAbstraction(ctx context.Context, a store.Abstraction
 		`UPDATE abstractions
 		SET level = ?, title = ?, description = ?, parent_id = ?,
 		    source_pattern_ids = ?, source_memory_ids = ?, confidence = ?,
-		    concepts = ?, embedding = ?, access_count = ?, state = ?, updated_at = ?
+		    concepts = ?, embedding = ?, access_count = ?, state = ?,
+		    demotion_streak = ?, updated_at = ?
 		WHERE id = ?`,
 		a.Level,
 		a.Title,
@@ -82,6 +84,7 @@ func (s *SQLiteStore) UpdateAbstraction(ctx context.Context, a store.Abstraction
 		embeddingBlob,
 		a.AccessCount,
 		a.State,
+		a.DemotionStreak,
 		a.UpdatedAt.Format(time.RFC3339),
 		a.ID,
 	)
@@ -199,6 +202,7 @@ func scanAbstractionFrom(s scanner) (store.Abstraction, error) {
 		&embeddingBlob,
 		&a.AccessCount,
 		&a.State,
+		&a.DemotionStreak,
 		&a.CreatedAt,
 		&a.UpdatedAt,
 	)

--- a/internal/store/sqlite/schema.go
+++ b/internal/store/sqlite/schema.go
@@ -10,7 +10,7 @@ import (
 // migration is added. It is written to PRAGMA user_version after InitSchema
 // completes, and read by the pre-migration backup logic to skip backups when
 // the schema is already current.
-const SchemaVersion = 18
+const SchemaVersion = 19
 
 const schema = `
 -- Raw observations before encoding
@@ -665,6 +665,15 @@ INSERT OR IGNORE INTO forum_categories (id, name, slug, description, icon, color
 	}
 	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_training_runs_status ON training_runs(status)`)
 	_, _ = db.Exec(`CREATE INDEX IF NOT EXISTS idx_training_runs_started_at ON training_runs(started_at)`)
+
+	// Migration 019: demotion_streak for abstractions — counts consecutive cycles
+	// in which grounding fell below the "healthy" threshold. Replaces the
+	// earlier wall-clock age heuristic for deciding when to archive a
+	// chronically-decayed abstraction. Reset to 0 on any healthy cycle.
+	_, err = db.Exec(`ALTER TABLE abstractions ADD COLUMN demotion_streak INTEGER NOT NULL DEFAULT 0`)
+	if err != nil && !isAlterTableDuplicateColumn(err) {
+		return fmt.Errorf("failed to add abstractions.demotion_streak column: %w", err)
+	}
 
 	// Record the schema version so pre-migration backups can skip when current.
 	if _, err := db.Exec(fmt.Sprintf("PRAGMA user_version = %d", SchemaVersion)); err != nil {

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -317,8 +317,13 @@ type Abstraction struct {
 	Embedding        []float32 `json:"embedding,omitempty"`
 	AccessCount      int       `json:"access_count"`
 	State            string    `json:"state"` // "active", "fading", "archived"
-	CreatedAt        time.Time `json:"created_at"`
-	UpdatedAt        time.Time `json:"updated_at"`
+	// DemotionStreak counts consecutive grounding-verification cycles in which
+	// the abstraction's grounding ratio fell below the "healthy" threshold.
+	// Reset to 0 on any healthy cycle. Used to trigger archival of chronically
+	// decayed abstractions that would otherwise cycle through demotion forever.
+	DemotionStreak int       `json:"demotion_streak"`
+	CreatedAt      time.Time `json:"created_at"`
+	UpdatedAt      time.Time `json:"updated_at"`
 }
 
 // SessionSummary aggregates metadata about an MCP session.


### PR DESCRIPTION
## Summary

Supersedes the wall-clock age threshold added in #420. Adaptive scheduling makes age-based archival brittle: abstraction cycles run at ~1-2 min intervals idle and much slower under load, so an age threshold either archives too slowly (idle — thousands of pointless demotion cycles) or too aggressively (loaded — genuinely young abstractions punished).

The handoff's original phrasing — *"demoted N cycles in a row AND confidence < X"* — is the right model. This PR implements it by adding a persistent \`DemotionStreak\` counter to each abstraction.

## What changes

**Schema** (migration 019): \`ALTER TABLE abstractions ADD COLUMN demotion_streak INTEGER NOT NULL DEFAULT 0\`. Guarded by \`isAlterTableDuplicateColumn\` for idempotency.

**Domain**: \`store.Abstraction.DemotionStreak\` (int). Insert/update/scan paths updated.

**Agent** ([verifyGrounding](internal/agent/abstraction/agent.go)):

| groundingRatio | Behavior |
|---|---|
| >= 0.5 | Reset \`DemotionStreak\` to 0, persist only if it was > 0, skip |
| < 0.5 | \`DemotionStreak++\`, then graduated decay + possible archive |

Archive fires when:
- \`state == "active"\`
- \`!isYoung\` (7-day grace, unchanged)
- \`DemotionStreak >= ArchiveDemotionStreak\` (default 10)
- \`Confidence < ArchiveDecayConfidence\` (default 0.2, unchanged from #420)

Archive decrements \`AbstractionsDemoted\` to avoid double-counting. The \`abstraction grounding adjusted\` log line now includes \`demotion_streak\` so the escape hatch's progress is visible in production.

**Config**:
- Dropped: \`archive_decay_min_age\`
- Added: \`archive_demotion_streak\` (default 10)
- Unchanged: \`archive_decay_confidence\` (0.2)

## Test plan

- [x] \`TestVerifyGrounding_IncrementsStreakOnDemote\`
- [x] \`TestVerifyGrounding_ResetsStreakOnHealthy\`
- [x] \`TestVerifyGrounding_ArchivesWhenStreakAndConfidenceThresholdsMet\`
- [x] \`TestVerifyGrounding_YoungAbstractionNotArchived\`
- [x] \`go test ./...\` — full suite passes
- [x] \`ROCM=1 make build-embedded\` — clean
- [ ] After deploy: stuck 8 abstractions accumulate streak across ~10 cycles, then archive. \`abstractions_demoted\` drops off; \`abstractions_archived\` reflects the one-time cleanup.

## Migration

Old DBs pick up the column with default 0 on next startup. Stuck abstractions start accumulating streak from 0 post-migration — they archive ~10 cycles later rather than immediately. That's the correct behavior for a brand-new signal: we don't retroactively decide prior cycles were strikes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)