### PR TITLE
feat(consolidation): resurrect archived patterns on re-emergence

### DIFF
--- a/internal/agent/consolidation/agent.go
+++ b/internal/agent/consolidation/agent.go
@@ -977,6 +977,17 @@ func (ca *ConsolidationAgent) processPatternClusters(ctx context.Context, cluste
 					continue
 				}
 			}
+
+			// Third stage: re-emergence detection. When no active pattern matches,
+			// check whether a previously-archived canonical matches on title AND
+			// embedding. If so, resurrect it instead of writing a fresh duplicate.
+			// This is the fix for #423, where patterns like "The Emergence of the
+			// CRISPR-LM Research Workflow" kept being re-created each cycle because
+			// the canonical had decayed to archived and the active-only search
+			// returned nothing. See tryResurrectArchivedPattern for the predicate.
+			if resurrected := ca.tryResurrectArchivedPattern(ctx, pattern, qualified); resurrected != nil {
+				continue
+			}
 		}
 
 		if err := ca.store.WritePattern(ctx, *pattern); err != nil {
@@ -1167,6 +1178,82 @@ func (ca *ConsolidationAgent) findMatchingPattern(ctx context.Context, cluster [
 	}
 
 	return nil, 0, fmt.Errorf("no close match")
+}
+
+// resurrectionTitleSimThreshold is the minimum normalized title similarity
+// required to treat an archived pattern as a re-emergence of the new one.
+// Deliberately stricter than the active-dedup title bar (0.8) — resurrection
+// must be obvious, not just plausible.
+const resurrectionTitleSimThreshold = 0.85
+
+// resurrectionEmbSimThreshold is the minimum cosine embedding similarity for
+// archived-pattern resurrection. Matches the active-dedup bar.
+const resurrectionEmbSimThreshold = 0.9
+
+// resurrectionStrengthFloor is the strength the resurrected pattern is bumped
+// to on re-activation. Well above the fading threshold (0.1) so it survives
+// the next decay pass, but below the ceiling so it must earn its way back up
+// through real evidence accrual.
+const resurrectionStrengthFloor = 0.5
+
+// tryResurrectArchivedPattern checks whether a fading/archived pattern matches
+// the newly-synthesized pattern on both title and embedding. When the match is
+// strong (both gates clear), the archived pattern is re-activated, its evidence
+// merged with the new cluster, and returned. Fixes #423: without this, every
+// time a canonical pattern decays past the archive threshold, the next cluster
+// matching that theme spawns a fresh duplicate.
+//
+// Returns nil when no archived candidate passes the resurrection predicate.
+func (ca *ConsolidationAgent) tryResurrectArchivedPattern(ctx context.Context, pattern *store.Pattern, qualified []store.Memory) *store.Pattern {
+	archived, err := ca.store.SearchArchivedPatternsByEmbedding(ctx, pattern.Embedding, 5)
+	if err != nil || len(archived) == 0 {
+		return nil
+	}
+
+	for i := range archived {
+		ep := &archived[i]
+		if len(ep.Embedding) == 0 {
+			continue
+		}
+		embSim := agentutil.CosineSimilarity(pattern.Embedding, ep.Embedding)
+		titleSim := normalizedTitleSimilarity(pattern.Title, ep.Title)
+		if titleSim < resurrectionTitleSimThreshold || embSim < resurrectionEmbSimThreshold {
+			continue
+		}
+
+		// Merge new evidence into the resurrected pattern.
+		for _, mem := range qualified {
+			if !containsString(ep.EvidenceIDs, mem.ID) {
+				ep.EvidenceIDs = append(ep.EvidenceIDs, mem.ID)
+			}
+		}
+
+		priorState := ep.State
+		priorStrength := ep.Strength
+		ep.State = "active"
+		if ep.Strength < resurrectionStrengthFloor {
+			ep.Strength = resurrectionStrengthFloor
+		}
+		ep.AccessCount++
+		ep.LastAccessed = time.Now()
+		ep.UpdatedAt = time.Now()
+
+		if err := ca.store.UpdatePattern(ctx, *ep); err != nil {
+			ca.log.Warn("failed to resurrect archived pattern",
+				"pattern_id", ep.ID, "error", err)
+			continue
+		}
+
+		ca.log.Info("pattern resurrected from archive",
+			"pattern_id", ep.ID, "title", ep.Title,
+			"prior_state", priorState, "prior_strength", priorStrength,
+			"new_strength", ep.Strength,
+			"emb_sim", embSim, "title_sim", titleSim,
+			"evidence_count", len(ep.EvidenceIDs))
+		return ep
+	}
+
+	return nil
 }
 
 // findSecondStageDuplicate scans candidate patterns (returned by

--- a/internal/agent/consolidation/agent_test.go
+++ b/internal/agent/consolidation/agent_test.go
@@ -36,6 +36,8 @@ type mockStore struct {
 	writeConsolidationFn    func(ctx context.Context, record store.ConsolidationRecord) error
 	getMemoryAttributesFn   func(ctx context.Context, memoryID string) (store.MemoryAttributes, error)
 	searchPatternsByEmbFn   func(ctx context.Context, emb []float32, limit int) ([]store.Pattern, error)
+	searchArchivedByEmbFn   func(ctx context.Context, emb []float32, limit int) ([]store.Pattern, error)
+	updatePatternFn         func(ctx context.Context, p store.Pattern) error
 
 	// Call tracking
 	updateStateCalls         []updateStateCall
@@ -78,6 +80,18 @@ func (m *mockStore) SearchPatternsByEmbedding(ctx context.Context, emb []float32
 		return m.searchPatternsByEmbFn(ctx, emb, limit)
 	}
 	return nil, nil
+}
+func (m *mockStore) SearchArchivedPatternsByEmbedding(ctx context.Context, emb []float32, limit int) ([]store.Pattern, error) {
+	if m.searchArchivedByEmbFn != nil {
+		return m.searchArchivedByEmbFn(ctx, emb, limit)
+	}
+	return nil, nil
+}
+func (m *mockStore) UpdatePattern(ctx context.Context, p store.Pattern) error {
+	if m.updatePatternFn != nil {
+		return m.updatePatternFn(ctx, p)
+	}
+	return nil
 }
 func (m *mockStore) PruneWeakAssociations(ctx context.Context, strengthThreshold float32) (int, error) {
 	m.pruneWeakAssocCalls = append(m.pruneWeakAssocCalls, strengthThreshold)
@@ -1443,6 +1457,134 @@ func TestFindSecondStageDuplicate_StrongTitleMatchBypassesConceptGate(t *testing
 	}
 	if match.ID != "crispr-workflow" {
 		t.Errorf("expected match=crispr-workflow, got %s", match.ID)
+	}
+}
+
+// TestTryResurrectArchivedPattern_StrongMatchResurrects verifies the fix for
+// #423. When a newly-synthesized pattern matches a fading/archived pattern on
+// both title and embedding, the archived one is re-activated, its strength
+// restored above the fading threshold, and new evidence merged in. This breaks
+// the archive → recreate loop where canonical patterns would decay past the
+// archive threshold and the next cluster in the same theme would spawn a fresh
+// duplicate.
+func TestTryResurrectArchivedPattern_StrongMatchResurrects(t *testing.T) {
+	ms := newMockStore()
+	ms.searchArchivedByEmbFn = func(_ context.Context, _ []float32, _ int) ([]store.Pattern, error) {
+		return []store.Pattern{{
+			ID:        "archived-canonical",
+			Title:     "The Emergence of the CRISPR-LM Research Workflow",
+			State:     "archived",
+			Strength:  0.04, // below fading threshold — archived
+			Embedding: []float32{1, 0, 0, 0},
+			Concepts:  []string{"crispr-lm"},
+		}}, nil
+	}
+	var updated *store.Pattern
+	ms.updatePatternFn = func(_ context.Context, p store.Pattern) error {
+		updated = &p
+		return nil
+	}
+
+	mlp := &mockLLMProvider{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	agent := NewConsolidationAgent(ms, mlp, DefaultConfig(), log)
+
+	newPat := &store.Pattern{
+		Title:     "The Emergence of the CRISPR-LM Research Workflow",
+		Embedding: []float32{0.99, 0.01, 0, 0},
+		Concepts:  []string{"crispr-lm", "research"},
+	}
+	qualified := []store.Memory{
+		{ID: "mem-new-1"},
+		{ID: "mem-new-2"},
+	}
+
+	resurrected := agent.tryResurrectArchivedPattern(context.Background(), newPat, qualified)
+	if resurrected == nil {
+		t.Fatal("expected resurrection on strong title+embedding match, got nil")
+	}
+	if resurrected.ID != "archived-canonical" {
+		t.Errorf("expected archived-canonical to be resurrected, got %s", resurrected.ID)
+	}
+	if updated == nil {
+		t.Fatal("expected UpdatePattern to be called")
+	}
+	if updated.State != "active" {
+		t.Errorf("expected state=active after resurrection, got %s", updated.State)
+	}
+	if updated.Strength < resurrectionStrengthFloor {
+		t.Errorf("expected strength >= %.2f after resurrection, got %.3f", resurrectionStrengthFloor, updated.Strength)
+	}
+	if !containsString(updated.EvidenceIDs, "mem-new-1") || !containsString(updated.EvidenceIDs, "mem-new-2") {
+		t.Errorf("expected new evidence IDs merged in, got %v", updated.EvidenceIDs)
+	}
+}
+
+// TestTryResurrectArchivedPattern_WeakTitleMatchRejected verifies that the
+// resurrection predicate is tight: high embedding similarity alone isn't
+// enough to resurrect when titles diverge. Prevents accidentally reviving a
+// broadly-related archived pattern when the new theme is actually different.
+func TestTryResurrectArchivedPattern_WeakTitleMatchRejected(t *testing.T) {
+	ms := newMockStore()
+	ms.searchArchivedByEmbFn = func(_ context.Context, _ []float32, _ int) ([]store.Pattern, error) {
+		return []store.Pattern{{
+			ID:        "archived-unrelated",
+			Title:     "Modular Model Migration Workflow",
+			State:     "archived",
+			Embedding: []float32{1, 0, 0, 0},
+		}}, nil
+	}
+	updateCalled := false
+	ms.updatePatternFn = func(_ context.Context, _ store.Pattern) error {
+		updateCalled = true
+		return nil
+	}
+
+	mlp := &mockLLMProvider{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	agent := NewConsolidationAgent(ms, mlp, DefaultConfig(), log)
+
+	newPat := &store.Pattern{
+		Title:     "Splice Tensor API for CRISPR-LM", // very different title
+		Embedding: []float32{0.99, 0.01, 0, 0},
+	}
+
+	resurrected := agent.tryResurrectArchivedPattern(context.Background(), newPat, nil)
+	if resurrected != nil {
+		t.Errorf("expected weak-title match to be rejected, got %s", resurrected.ID)
+	}
+	if updateCalled {
+		t.Error("expected no UpdatePattern call when resurrection predicate fails")
+	}
+}
+
+// TestTryResurrectArchivedPattern_WeakEmbeddingRejected verifies the
+// resurrection predicate requires high embedding similarity even when titles
+// match. A coincidentally-identical title with a distant embedding vector
+// shouldn't trigger resurrection.
+func TestTryResurrectArchivedPattern_WeakEmbeddingRejected(t *testing.T) {
+	ms := newMockStore()
+	ms.searchArchivedByEmbFn = func(_ context.Context, _ []float32, _ int) ([]store.Pattern, error) {
+		return []store.Pattern{{
+			ID:        "archived-different-embedding",
+			Title:     "The Emergence of the CRISPR-LM Research Workflow",
+			State:     "archived",
+			Embedding: []float32{0.1, 0.9, 0, 0}, // orthogonal-ish to newPat
+		}}, nil
+	}
+
+	mlp := &mockLLMProvider{}
+	log := slog.New(slog.NewTextHandler(os.Stderr, nil))
+	agent := NewConsolidationAgent(ms, mlp, DefaultConfig(), log)
+
+	newPat := &store.Pattern{
+		Title:     "The Emergence of the CRISPR-LM Research Workflow",
+		Embedding: []float32{0.99, 0.01, 0, 0},
+	}
+
+	resurrected := agent.tryResurrectArchivedPattern(context.Background(), newPat, nil)
+	if resurrected != nil {
+		t.Errorf("expected weak-embedding match to be rejected, got %s", resurrected.ID)
 	}
 }
 

--- a/internal/store/sqlite/patterns.go
+++ b/internal/store/sqlite/patterns.go
@@ -316,6 +316,63 @@ func (s *SQLiteStore) SearchPatternsByEmbeddingInProject(ctx context.Context, em
 	return patterns, nil
 }
 
+// SearchArchivedPatternsByEmbedding returns the top-k patterns in fading or
+// archived state ranked by cosine similarity to the given embedding. Used by
+// the consolidation pipeline to detect re-emergence of a previously-archived
+// canonical and resurrect it rather than write a duplicate. Mirrors the
+// in-memory search pattern of SearchPatternsByEmbedding; the state filter is
+// the only meaningful difference.
+func (s *SQLiteStore) SearchArchivedPatternsByEmbedding(ctx context.Context, embedding []float32, limit int) ([]store.Pattern, error) {
+	if len(embedding) == 0 {
+		return nil, fmt.Errorf("embedding cannot be empty")
+	}
+
+	rows, err := s.db.QueryContext(ctx,
+		`SELECT id, embedding FROM patterns WHERE state IN ('fading', 'archived') AND embedding IS NOT NULL AND length(embedding) > 0`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to query archived pattern embeddings: %w", err)
+	}
+	defer func() { _ = rows.Close() }()
+
+	type candidate struct {
+		id    string
+		score float32
+	}
+	var candidates []candidate
+
+	for rows.Next() {
+		var id string
+		var blob []byte
+		if err := rows.Scan(&id, &blob); err != nil {
+			continue
+		}
+		emb := decodeEmbedding(blob)
+		if len(emb) == 0 {
+			continue
+		}
+		score := mathutil.CosineSimilarity(embedding, emb)
+		candidates = append(candidates, candidate{id: id, score: score})
+	}
+
+	sort.Slice(candidates, func(i, j int) bool {
+		return candidates[i].score > candidates[j].score
+	})
+	if len(candidates) > limit {
+		candidates = candidates[:limit]
+	}
+
+	var patterns []store.Pattern
+	for _, c := range candidates {
+		p, err := s.GetPattern(ctx, c.id)
+		if err != nil {
+			continue
+		}
+		patterns = append(patterns, p)
+	}
+
+	return patterns, nil
+}
+
 // ArchivePattern archives a single pattern by ID.
 func (s *SQLiteStore) ArchivePattern(ctx context.Context, id string) error {
 	result, err := s.db.ExecContext(ctx,

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -501,6 +501,11 @@ type PatternStore interface {
 	ListPatterns(ctx context.Context, project string, limit int) ([]Pattern, error)
 	SearchPatternsByEmbedding(ctx context.Context, embedding []float32, limit int) ([]Pattern, error)
 	SearchPatternsByEmbeddingInProject(ctx context.Context, embedding []float32, project string, limit int) ([]Pattern, error)
+	// SearchArchivedPatternsByEmbedding returns fading/archived patterns ranked
+	// by embedding similarity. Used by the consolidation dedup pipeline to
+	// detect re-emergence of a previously archived canonical and resurrect it
+	// rather than spawn a duplicate. See #423.
+	SearchArchivedPatternsByEmbedding(ctx context.Context, embedding []float32, limit int) ([]Pattern, error)
 	ArchivePattern(ctx context.Context, id string) error
 	ArchiveAllPatterns(ctx context.Context) (int, error)
 }

--- a/internal/store/storetest/mock.go
+++ b/internal/store/storetest/mock.go
@@ -242,6 +242,9 @@ func (MockStore) SearchPatternsByEmbedding(context.Context, []float32, int) ([]s
 func (MockStore) SearchPatternsByEmbeddingInProject(context.Context, []float32, string, int) ([]store.Pattern, error) {
 	return nil, nil
 }
+func (MockStore) SearchArchivedPatternsByEmbedding(context.Context, []float32, int) ([]store.Pattern, error) {
+	return nil, nil
+}
 func (MockStore) ArchivePattern(context.Context, string) error    { return nil }
 func (MockStore) ArchiveAllPatterns(context.Context) (int, error) { return 0, nil }
 


### PR DESCRIPTION
Fixes #423.

## Problem

Overnight, 12 identical-title archived patterns for "The Emergence of the CRISPR-LM Research Workflow" accumulated in 20 hours. Root cause: the canonical pattern decays past the archive threshold, `findSecondStageDuplicate`'s `SearchPatternsByEmbedding` filters on `state='active'` only, so the next cluster in that theme gets no dedup match and the LLM synthesizes a fresh duplicate. The archived original stays buried.

## Change

Adds a third-stage resurrection pass after the active-candidate dedup returns nil. When a newly-synthesized pattern matches a fading/archived pattern on BOTH title Jaccard >= 0.85 AND cosine embedding similarity >= 0.9, the archived pattern is:

- marked `state = 'active'`
- bumped to `Strength = 0.5` (above the fading threshold, below the ceiling — has to earn its way back up)
- has the new cluster's evidence IDs merged in
- logs a dedicated \`pattern resurrected from archive\` line with prior/new state

Predicate intentionally tighter than the active-dedup bar (0.8/0.9) so we only resurrect obvious re-emergence, not every archived pattern that happens to sit near the new embedding.

## Interface changes

- \`store.PatternStore\` gains \`SearchArchivedPatternsByEmbedding(ctx, emb, limit) ([]Pattern, error)\`
- \`internal/store/sqlite\` implements it — `state IN ('fading', 'archived')`
- \`MockStore\` and the consolidation \`mockStore\` gain stubs

## Advisory board review

Applied Hickey / Linus / Musk / Karpathy / Hotz lenses:
- **Musk (deleter):** considered relaxing decay instead of adding resurrection. Rejected — the archive is still a useful terminal state for truly-dead themes.
- **Karpathy (empiricist):** if resurrection hits ~80% of the observed recreation cases, we stop generating 10–15 duplicate patterns per day. Measurable.
- **Linus (reviewer):** predicate is logged explicitly so resurrection events are auditable; the previous \`state='active'\` filter was a hidden assumption.
- **Hotz (hacker):** considered a first-stage (pre-LLM) resurrection to skip the LLM call entirely. Deferred — no title is available yet, predicate would have to rely on embedding alone, less safe. LLM title is what confirms the re-emergence.

## Test plan

- [x] Unit tests: strong match resurrects with evidence merge + strength floor; weak title rejected; weak embedding rejected.
- [x] \`golangci-lint run\` — 0 issues.
- [x] \`go test ./...\` — all packages pass.
- [x] \`ROCM=1 make build-embedded\` + daemon restart — health green, llm_available true.
- [ ] Watch next few consolidation cycles for \`pattern resurrected from archive\` log lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)