### PR TITLE
feat(dreaming): rotate replay sample via recent-ID ring buffer

### DIFF
--- a/internal/agent/dreaming/agent.go
+++ b/internal/agent/dreaming/agent.go
@@ -42,7 +42,18 @@ type DreamingAgent struct {
 	wg          sync.WaitGroup
 	stopOnce    sync.Once
 	triggerCh   chan struct{}
+
+	// recentReplayIDs is a FIFO of memory IDs replayed in recent cycles. The
+	// next cycle's replay sample is drawn from the active pool *minus* this set,
+	// rotating through the memory base instead of Groundhog-Day'ing the same
+	// high-created_at window. Holds ~replayRingCycles * BatchSize entries.
+	recentReplayIDs []string
+	recentReplayMu  sync.Mutex
 }
+
+// replayRingCycles is how many cycles' worth of replay IDs to exclude from the
+// next cycle's sample. Higher = wider rotation but faster pool exhaustion.
+const replayRingCycles = 3
 
 type DreamReport struct {
 	Duration                 time.Duration
@@ -254,25 +265,87 @@ func (da *DreamingAgent) runCycle(ctx context.Context) (*DreamReport, error) {
 	return report, nil
 }
 
-// replayMemories performs Phase 1: get top memories by salience and increment their access.
+// replayMemories performs Phase 1: select the next sample of salience-qualifying
+// memories and increment their access. Rotates across cycles by excluding IDs
+// replayed in the last replayRingCycles cycles, so dream phases see fresh
+// substrate instead of re-evaluating the same top-N created_at window. Falls
+// back to previously-excluded memories if the active pool is smaller than the
+// ring, preserving throughput when the DB is small.
 func (da *DreamingAgent) replayMemories(ctx context.Context, report *DreamReport) ([]store.Memory, error) {
-	memories, err := da.store.ListMemories(ctx, "active", da.config.BatchSize, 0)
+	target := da.config.BatchSize
+	if target <= 0 {
+		return nil, nil
+	}
+
+	// Pull a pool wider than the ring so there's always room for fresh picks.
+	poolSize := target * (replayRingCycles + 1)
+	pool, err := da.store.ListMemories(ctx, "active", poolSize, 0)
 	if err != nil {
 		return nil, fmt.Errorf("failed to list active memories: %w", err)
 	}
 
-	var replayed []store.Memory
+	da.recentReplayMu.Lock()
+	excluded := make(map[string]struct{}, len(da.recentReplayIDs))
+	for _, id := range da.recentReplayIDs {
+		excluded[id] = struct{}{}
+	}
+	da.recentReplayMu.Unlock()
 
-	for _, mem := range memories {
-		if mem.Salience >= da.config.SalienceThreshold {
-			if err := da.store.IncrementAccess(ctx, mem.ID); err != nil {
-				da.log.Warn("failed to increment access for memory", "memory_id", mem.ID, "error", err)
+	replayed := make([]store.Memory, 0, target)
+	picked := make(map[string]struct{}, target)
+	newIDs := make([]string, 0, target)
+
+	take := func(mem store.Memory) bool {
+		if err := da.store.IncrementAccess(ctx, mem.ID); err != nil {
+			da.log.Warn("failed to increment access for memory", "memory_id", mem.ID, "error", err)
+			return false
+		}
+		replayed = append(replayed, mem)
+		picked[mem.ID] = struct{}{}
+		newIDs = append(newIDs, mem.ID)
+		report.MemoriesReplayed++
+		return true
+	}
+
+	// Pass 1: fresh picks — salient and not in the recent-replay ring.
+	for _, mem := range pool {
+		if len(replayed) >= target {
+			break
+		}
+		if mem.Salience < da.config.SalienceThreshold {
+			continue
+		}
+		if _, seen := excluded[mem.ID]; seen {
+			continue
+		}
+		take(mem)
+	}
+
+	// Pass 2: fallback — if the pool was smaller than the ring, relax the
+	// rotation filter rather than starve the cycle.
+	if len(replayed) < target {
+		for _, mem := range pool {
+			if len(replayed) >= target {
+				break
+			}
+			if mem.Salience < da.config.SalienceThreshold {
 				continue
 			}
-			replayed = append(replayed, mem)
-			report.MemoriesReplayed++
+			if _, already := picked[mem.ID]; already {
+				continue
+			}
+			take(mem)
 		}
 	}
+
+	// Roll the ring forward: append this cycle's picks, trim to the window.
+	ringCapacity := target * replayRingCycles
+	da.recentReplayMu.Lock()
+	da.recentReplayIDs = append(da.recentReplayIDs, newIDs...)
+	if overflow := len(da.recentReplayIDs) - ringCapacity; overflow > 0 {
+		da.recentReplayIDs = da.recentReplayIDs[overflow:]
+	}
+	da.recentReplayMu.Unlock()
 
 	return replayed, nil
 }

--- a/internal/agent/dreaming/agent_test.go
+++ b/internal/agent/dreaming/agent_test.go
@@ -2,6 +2,7 @@ package dreaming
 
 import (
 	"context"
+	"fmt"
 	"io"
 	"log/slog"
 	"testing"
@@ -412,6 +413,128 @@ func TestCrossProjectLinkEmbeddingGateCounter(t *testing.T) {
 // mockStore embeds the shared base mock and has no overrides.
 type mockStore struct {
 	storetest.MockStore
+}
+
+// replayRotationMockStore returns a fixed pool and records IncrementAccess calls
+// so tests can verify which memories the replay phase selected.
+type replayRotationMockStore struct {
+	storetest.MockStore
+	pool     []store.Memory
+	accessed []string
+}
+
+func (m *replayRotationMockStore) ListMemories(_ context.Context, _ string, limit, offset int) ([]store.Memory, error) {
+	if offset >= len(m.pool) {
+		return nil, nil
+	}
+	end := offset + limit
+	if end > len(m.pool) {
+		end = len(m.pool)
+	}
+	return m.pool[offset:end], nil
+}
+
+func (m *replayRotationMockStore) IncrementAccess(_ context.Context, id string) error {
+	m.accessed = append(m.accessed, id)
+	return nil
+}
+
+// TestReplayMemoriesRotatesAcrossCycles verifies that consecutive replay cycles
+// pick different memories from a large enough pool, instead of replaying the
+// same top-N every cycle.
+func TestReplayMemoriesRotatesAcrossCycles(t *testing.T) {
+	const batchSize = 5
+	// Pool large enough that replayRingCycles*batchSize < poolSize, so the
+	// second cycle can find fresh picks.
+	poolSize := batchSize * (replayRingCycles + 2)
+	pool := make([]store.Memory, poolSize)
+	for i := range pool {
+		pool[i] = store.Memory{
+			ID:       fmt.Sprintf("mem-%02d", i),
+			Salience: 0.9,
+			State:    "active",
+		}
+	}
+
+	ms := &replayRotationMockStore{pool: pool}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	agent := NewDreamingAgent(ms, nil, DreamingConfig{
+		BatchSize:         batchSize,
+		SalienceThreshold: 0.3,
+	}, logger)
+
+	// Cycle 1
+	rep1 := &DreamReport{}
+	out1, err := agent.replayMemories(context.Background(), rep1)
+	if err != nil {
+		t.Fatalf("cycle 1 replay failed: %v", err)
+	}
+	if len(out1) != batchSize {
+		t.Fatalf("cycle 1: expected %d replayed, got %d", batchSize, len(out1))
+	}
+
+	// Cycle 2 — must share no IDs with cycle 1 given pool is large enough.
+	rep2 := &DreamReport{}
+	out2, err := agent.replayMemories(context.Background(), rep2)
+	if err != nil {
+		t.Fatalf("cycle 2 replay failed: %v", err)
+	}
+	if len(out2) != batchSize {
+		t.Fatalf("cycle 2: expected %d replayed, got %d", batchSize, len(out2))
+	}
+
+	cycle1 := make(map[string]struct{}, len(out1))
+	for _, m := range out1 {
+		cycle1[m.ID] = struct{}{}
+	}
+	for _, m := range out2 {
+		if _, repeat := cycle1[m.ID]; repeat {
+			t.Fatalf("cycle 2 replayed memory %q that was in cycle 1 — rotation failed", m.ID)
+		}
+	}
+}
+
+// TestReplayMemoriesFallsBackWhenPoolSmallerThanRing verifies that when the
+// active pool is smaller than the ring buffer, the replay phase still delivers
+// a full batch instead of starving.
+func TestReplayMemoriesFallsBackWhenPoolSmallerThanRing(t *testing.T) {
+	const batchSize = 5
+	// Pool smaller than one batch — forces fallback.
+	pool := make([]store.Memory, batchSize-1)
+	for i := range pool {
+		pool[i] = store.Memory{
+			ID:       fmt.Sprintf("mem-%02d", i),
+			Salience: 0.9,
+			State:    "active",
+		}
+	}
+
+	ms := &replayRotationMockStore{pool: pool}
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	agent := NewDreamingAgent(ms, nil, DreamingConfig{
+		BatchSize:         batchSize,
+		SalienceThreshold: 0.3,
+	}, logger)
+
+	// First cycle replays all available memories.
+	rep1 := &DreamReport{}
+	out1, err := agent.replayMemories(context.Background(), rep1)
+	if err != nil {
+		t.Fatalf("cycle 1 replay failed: %v", err)
+	}
+	if len(out1) != len(pool) {
+		t.Fatalf("cycle 1: expected %d replayed, got %d", len(pool), len(out1))
+	}
+
+	// Second cycle: ring excludes all of them, but fallback should still pick them.
+	rep2 := &DreamReport{}
+	out2, err := agent.replayMemories(context.Background(), rep2)
+	if err != nil {
+		t.Fatalf("cycle 2 replay failed: %v", err)
+	}
+	if len(out2) != len(pool) {
+		t.Fatalf("cycle 2: expected fallback to pick %d, got %d", len(pool), len(out2))
+	}
 }
 
 // crossProjectMockStore tracks associations created and returns configured embedding results.


### PR DESCRIPTION
## Summary
- Dream replay was picking the same top-N memories by `created_at DESC` every cycle. Over a 1.5h log window: `pattern_links` yield was 0% in 14/14 cycles, rejection counters flatlined (`pattern_link_rejected_concept=102-105`, `cross_pollinate_rejected_concept=88-91`) — same substrate, same rejections, redundant LLM work.
- `replayMemories` now pulls a wider pool, excludes IDs replayed in the last `replayRingCycles=3` cycles via an in-memory ring buffer, and falls back to previously-replayed memories only when the active pool is smaller than the ring (so small DBs don't starve).
- In-memory ring resets on daemon restart — matches the existing cold-start-is-correct design for cooldown state.

## Test plan
- [x] `go test ./internal/agent/dreaming/ -count=1` (new `TestReplayMemoriesRotatesAcrossCycles` + `TestReplayMemoriesFallsBackWhenPoolSmallerThanRing`)
- [x] `go test ./... -count=1` full repo suite
- [x] `golangci-lint run ./internal/agent/dreaming/...`
- [ ] Post-deploy: grep `dream cycle completed` over first 3-5 cycles; rejection counters should drift cycle-to-cycle instead of flatlining, `memories_replayed` stays ~60, `pattern_links` yield rises above 0.
- [ ] Edge case: active pool (~125) is smaller than ring capacity (180), so fallback will engage from cycle 2. Confirm `memories_replayed` doesn't drop below target.