### PR TITLE
feat(abstraction): gate synthesis on substrate-change fingerprint

### DIFF
--- a/internal/agent/abstraction/agent.go
+++ b/internal/agent/abstraction/agent.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"hash/fnv"
 	"log/slog"
+	"sort"
 	"strings"
 	"sync"
 	"time"
@@ -55,15 +57,25 @@ type AbstractionAgent struct {
 	wg          sync.WaitGroup
 	stopOnce    sync.Once
 	triggerCh   chan struct{} // allows on-demand abstraction when patterns are discovered
+
+	// Substrate-change fingerprints — skip the cluster+LLM loop when the input
+	// set is identical to the last cycle's. Resets on process restart so the
+	// first post-restart cycle always runs (cold-start-is-correct, matches the
+	// dream replay rotation design). See RC#2 in feat/abstraction-fingerprint-gating.
+	fingerprintMu            sync.Mutex
+	lastPrincipleFingerprint uint64
+	lastAxiomFingerprint     uint64
 }
 
 type CycleReport struct {
-	Duration             time.Duration
-	PatternsEvaluated    int
-	PrinciplesCreated    int
-	AxiomsCreated        int
-	AbstractionsDemoted  int
-	AbstractionsArchived int
+	Duration                  time.Duration
+	PatternsEvaluated         int
+	PrinciplesCreated         int
+	AxiomsCreated             int
+	AbstractionsDemoted       int
+	AbstractionsArchived      int
+	PrinciplesSkippedNoChange bool
+	AxiomsSkippedNoChange     bool
 }
 
 func NewAbstractionAgent(s store.Store, llmProv llm.Provider, cfg AbstractionConfig, log *slog.Logger) *AbstractionAgent {
@@ -140,6 +152,8 @@ func (aa *AbstractionAgent) loop() {
 				"axioms_created", report.AxiomsCreated,
 				"abstractions_demoted", report.AbstractionsDemoted,
 				"abstractions_archived", report.AbstractionsArchived,
+				"principles_skipped_no_change", report.PrinciplesSkippedNoChange,
+				"axioms_skipped_no_change", report.AxiomsSkippedNoChange,
 			)
 		}
 	}
@@ -213,6 +227,22 @@ func (aa *AbstractionAgent) synthesizePrinciples(ctx context.Context, report *Cy
 	if len(strong) < 2 {
 		return nil
 	}
+
+	// Substrate-change gate: if the strong-pattern set is identical to the last
+	// cycle's (same IDs at same quantized strengths), skip the cluster+LLM loop.
+	// Same-input cycles repeat the same dedup hits and waste LLM budget.
+	fingerprint := fingerprintPatterns(strong)
+	aa.fingerprintMu.Lock()
+	if aa.lastPrincipleFingerprint == fingerprint {
+		aa.fingerprintMu.Unlock()
+		report.PrinciplesSkippedNoChange = true
+		aa.log.Info("abstraction.principles skipped — strong-pattern substrate unchanged",
+			"fingerprint", fmt.Sprintf("%016x", fingerprint),
+			"strong_patterns", len(strong))
+		return nil
+	}
+	aa.lastPrincipleFingerprint = fingerprint
+	aa.fingerprintMu.Unlock()
 
 	// Cluster patterns by embedding similarity
 	clusters := clusterPatterns(strong, 0.8)
@@ -311,6 +341,20 @@ func (aa *AbstractionAgent) synthesizeAxioms(ctx context.Context, report *CycleR
 	if len(active) < 2 {
 		return nil
 	}
+
+	// Substrate-change gate on level-2 principles. See synthesizePrinciples for rationale.
+	fingerprint := fingerprintAbstractions(active)
+	aa.fingerprintMu.Lock()
+	if aa.lastAxiomFingerprint == fingerprint {
+		aa.fingerprintMu.Unlock()
+		report.AxiomsSkippedNoChange = true
+		aa.log.Info("abstraction.axioms skipped — principle substrate unchanged",
+			"fingerprint", fmt.Sprintf("%016x", fingerprint),
+			"active_principles", len(active))
+		return nil
+	}
+	aa.lastAxiomFingerprint = fingerprint
+	aa.fingerprintMu.Unlock()
 
 	clusters := clusterAbstractions(active, 0.85)
 
@@ -769,6 +813,41 @@ Set has_axiom to false if:
 // --- Helper functions ---
 
 // clusterPatterns groups patterns by embedding similarity (greedy clustering).
+// fingerprintPatterns returns an fnv64 hash of the sorted (id|quantizedStrength)
+// tuples of the input patterns. Strength is quantized to 2 decimals so minor
+// float wobble (AccessCount-driven updates, for example) does not churn the
+// fingerprint. A stable fingerprint means the cluster+LLM loop would produce
+// the same output as last cycle and can be skipped.
+func fingerprintPatterns(patterns []store.Pattern) uint64 {
+	parts := make([]string, len(patterns))
+	for i, p := range patterns {
+		parts[i] = fmt.Sprintf("%s|%.2f", p.ID, p.Strength)
+	}
+	sort.Strings(parts)
+	h := fnv.New64a()
+	for _, s := range parts {
+		_, _ = h.Write([]byte(s))
+		_, _ = h.Write([]byte{0})
+	}
+	return h.Sum64()
+}
+
+// fingerprintAbstractions is the axiom-synthesis analogue of fingerprintPatterns.
+// Uses Confidence as the salience field.
+func fingerprintAbstractions(abs []store.Abstraction) uint64 {
+	parts := make([]string, len(abs))
+	for i, a := range abs {
+		parts[i] = fmt.Sprintf("%s|%.2f", a.ID, a.Confidence)
+	}
+	sort.Strings(parts)
+	h := fnv.New64a()
+	for _, s := range parts {
+		_, _ = h.Write([]byte(s))
+		_, _ = h.Write([]byte{0})
+	}
+	return h.Sum64()
+}
+
 func clusterPatterns(patterns []store.Pattern, threshold float32) [][]store.Pattern {
 	if len(patterns) == 0 {
 		return nil

--- a/internal/agent/abstraction/agent_test.go
+++ b/internal/agent/abstraction/agent_test.go
@@ -431,3 +431,150 @@ func TestFindSimilarAbstraction_StrongTitleMatchBypassesConceptGate(t *testing.T
 		t.Errorf("expected strong title+embedding match to bypass concept gate, got %+v", match)
 	}
 }
+
+// patternMockStore is a minimal ListPatterns/ListAbstractions stub. The
+// fingerprint-gating tests only need to control what the two list calls
+// return; everything else falls through to MockStore's zero-value methods.
+type patternMockStore struct {
+	storetest.MockStore
+	patterns     []store.Pattern
+	abstractions []store.Abstraction
+}
+
+func (m *patternMockStore) ListPatterns(context.Context, string, int) ([]store.Pattern, error) {
+	return m.patterns, nil
+}
+
+func (m *patternMockStore) ListAbstractions(_ context.Context, level, _ int) ([]store.Abstraction, error) {
+	var out []store.Abstraction
+	for _, a := range m.abstractions {
+		if a.Level == level {
+			out = append(out, a)
+		}
+	}
+	return out, nil
+}
+
+// TestFingerprintPatterns_StableAndSensitive verifies fingerprintPatterns is
+// deterministic under reordering and float-wobble-below-quantum, and changes
+// when a pattern's strength crosses the 0.01 quantum or an ID shifts.
+func TestFingerprintPatterns_StableAndSensitive(t *testing.T) {
+	base := []store.Pattern{
+		{ID: "p1", Strength: 0.80},
+		{ID: "p2", Strength: 0.72},
+		{ID: "p3", Strength: 0.65},
+	}
+	fpBase := fingerprintPatterns(base)
+
+	reordered := []store.Pattern{base[2], base[0], base[1]}
+	if got := fingerprintPatterns(reordered); got != fpBase {
+		t.Errorf("fingerprint should be order-independent, got %x want %x", got, fpBase)
+	}
+
+	wobble := []store.Pattern{
+		{ID: "p1", Strength: 0.803}, // still 0.80 at 2dp
+		{ID: "p2", Strength: 0.724},
+		{ID: "p3", Strength: 0.651},
+	}
+	if got := fingerprintPatterns(wobble); got != fpBase {
+		t.Errorf("sub-quantum wobble must not change fingerprint, got %x want %x", got, fpBase)
+	}
+
+	strengthened := []store.Pattern{
+		{ID: "p1", Strength: 0.82}, // crosses 0.01 quantum
+		{ID: "p2", Strength: 0.72},
+		{ID: "p3", Strength: 0.65},
+	}
+	if got := fingerprintPatterns(strengthened); got == fpBase {
+		t.Errorf("strength change of 0.02 must change fingerprint, got %x == baseline", got)
+	}
+
+	added := append([]store.Pattern{}, base...)
+	added = append(added, store.Pattern{ID: "p4", Strength: 0.70})
+	if got := fingerprintPatterns(added); got == fpBase {
+		t.Errorf("adding a pattern must change fingerprint, got %x == baseline", got)
+	}
+}
+
+// TestSynthesizePrinciples_SkipsWhenSubstrateUnchanged verifies that a second
+// call on an identical strong-pattern set short-circuits before clustering.
+// Proxy for skipping: report.PrinciplesSkippedNoChange must be true on the
+// second call and false on the first.
+func TestSynthesizePrinciples_SkipsWhenSubstrateUnchanged(t *testing.T) {
+	// Orthogonal embeddings across patterns → no cluster of 2+ forms →
+	// cluster loop skips all entries → no LLM call needed (nil provider is fine).
+	patterns := []store.Pattern{
+		{ID: "p1", Strength: 0.9, State: "active", Embedding: []float32{1, 0, 0}},
+		{ID: "p2", Strength: 0.9, State: "active", Embedding: []float32{0, 1, 0}},
+		{ID: "p3", Strength: 0.9, State: "active", Embedding: []float32{0, 0, 1}},
+	}
+	ms := &patternMockStore{patterns: patterns}
+	cfg := AbstractionConfig{MinStrength: 0.5, MaxLLMCalls: 0} // LLM budget 0 so no LLM call is attempted
+	agent := NewAbstractionAgent(ms, nil, cfg, silentLogger())
+
+	r1 := &CycleReport{}
+	if err := agent.synthesizePrinciples(context.Background(), r1); err != nil {
+		t.Fatalf("first cycle: %v", err)
+	}
+	if r1.PrinciplesSkippedNoChange {
+		t.Errorf("first cycle should NOT be skipped (empty baseline fingerprint)")
+	}
+	if r1.PatternsEvaluated != 3 {
+		t.Errorf("first cycle should evaluate 3 patterns, got %d", r1.PatternsEvaluated)
+	}
+
+	r2 := &CycleReport{}
+	if err := agent.synthesizePrinciples(context.Background(), r2); err != nil {
+		t.Fatalf("second cycle: %v", err)
+	}
+	if !r2.PrinciplesSkippedNoChange {
+		t.Errorf("second cycle should be skipped (substrate unchanged)")
+	}
+}
+
+// TestSynthesizePrinciples_GateOpensOnStrengthChange verifies that mutating a
+// pattern's strength between calls invalidates the fingerprint and re-runs.
+func TestSynthesizePrinciples_GateOpensOnStrengthChange(t *testing.T) {
+	ms := &patternMockStore{patterns: []store.Pattern{
+		{ID: "p1", Strength: 0.9, State: "active", Embedding: []float32{1, 0, 0}},
+		{ID: "p2", Strength: 0.9, State: "active", Embedding: []float32{0, 1, 0}},
+	}}
+	cfg := AbstractionConfig{MinStrength: 0.5, MaxLLMCalls: 0}
+	agent := NewAbstractionAgent(ms, nil, cfg, silentLogger())
+
+	r1 := &CycleReport{}
+	_ = agent.synthesizePrinciples(context.Background(), r1)
+
+	ms.patterns[0].Strength = 0.75 // mutate — fingerprint must change
+
+	r2 := &CycleReport{}
+	if err := agent.synthesizePrinciples(context.Background(), r2); err != nil {
+		t.Fatalf("second cycle: %v", err)
+	}
+	if r2.PrinciplesSkippedNoChange {
+		t.Errorf("second cycle should NOT be skipped after strength change")
+	}
+}
+
+// TestSynthesizeAxioms_SkipsWhenSubstrateUnchanged is the level-2 analogue.
+func TestSynthesizeAxioms_SkipsWhenSubstrateUnchanged(t *testing.T) {
+	principles := []store.Abstraction{
+		{ID: "a1", Level: 2, State: "active", Confidence: 0.8, Embedding: []float32{1, 0, 0}},
+		{ID: "a2", Level: 2, State: "active", Confidence: 0.8, Embedding: []float32{0, 1, 0}},
+	}
+	ms := &patternMockStore{abstractions: principles}
+	cfg := AbstractionConfig{MaxLLMCalls: 0}
+	agent := NewAbstractionAgent(ms, nil, cfg, silentLogger())
+
+	r1 := &CycleReport{}
+	_ = agent.synthesizeAxioms(context.Background(), r1)
+	if r1.AxiomsSkippedNoChange {
+		t.Errorf("first cycle should NOT be skipped")
+	}
+
+	r2 := &CycleReport{}
+	_ = agent.synthesizeAxioms(context.Background(), r2)
+	if !r2.AxiomsSkippedNoChange {
+		t.Errorf("second cycle should be skipped (principle substrate unchanged)")
+	}
+}


### PR DESCRIPTION
## Summary
- Root cause #2 of 3 from the 2026-04-18 agent-scheduling audit. Companion to the dream-replay-rotation fix merged as #427.
- Before: `synthesizePrinciples` / `synthesizeAxioms` re-clustered and re-LLM'd the same static pattern/principle substrate every cycle — 61% zero-principle cycles, 78% zero-axiom cycles across the audit window, pure LLM-budget waste.
- After: fnv64 fingerprint over the sorted `(id|quantizedStrength)` tuples of the strong-pattern set (and `(id|quantizedConfidence)` for level-2 principles feeding axioms) gates the cluster+LLM loop. When the substrate hasn't changed since the last cycle, skip — log a dedicated INFO line and set a bool on `CycleReport` for observability.
- Same in-memory / cold-start-is-correct design as the dream ring buffer: fingerprints reset on process restart, so the first post-restart cycle always runs.
- `verifyGrounding` is intentionally NOT gated — decay, demotion-streak, and archival must run every cycle to drive the existing state-transition machinery forward.

## Design notes
- Strength / confidence are quantized to 2 decimals so tiny `AccessCount`-driven float wobble (e.g. `0.803 → 0.804` on a touch) does not churn the fingerprint.
- Two independent fingerprints (`lastPrincipleFingerprint`, `lastAxiomFingerprint`) behind a single `sync.Mutex` — the two synthesis steps run sequentially in one cycle, so they can't race, but the mutex guards against reactor-driven on-demand cycles stepping on scheduled ones.
- New `PrinciplesSkippedNoChange` / `AxiomsSkippedNoChange` bool fields on `CycleReport`, surfaced in the `abstraction cycle completed` summary log.

## Test plan
- [x] `go test ./internal/agent/abstraction/` — full package passes including 4 new cases:
  - `TestFingerprintPatterns_StableAndSensitive` — order-independence, sub-quantum wobble invariance, strength-change and set-growth sensitivity.
  - `TestSynthesizePrinciples_SkipsWhenSubstrateUnchanged` — first call not skipped, second call skipped.
  - `TestSynthesizePrinciples_GateOpensOnStrengthChange` — mutating a pattern's `Strength` re-opens the gate.
  - `TestSynthesizeAxioms_SkipsWhenSubstrateUnchanged` — level-2 substrate analogue.
- [x] `go test ./...` — no regressions.
- [x] `golangci-lint run ./internal/agent/abstraction/` — 0 issues.
- [ ] Post-merge verification: after authorized daemon restart, grep `mnemonic.log` for `abstraction cycle completed` and confirm `principles_skipped_no_change=true` starts appearing once the pattern pool stabilizes. First few cycles should still run (cold-start); steady-state should skip until a pattern's strength crosses the 0.01 quantum or a new strong pattern is discovered.

## Follow-ups (not in this PR)
- Root cause #3: consolidation `merges=0` in 10/10 cycles, 95 memories re-decay every 4h without state transitions — investigate decay multiplier vs fading threshold and the merge_similar heuristic.
- Design doc for the substrate-fingerprint gating framework as a shared pattern across dream / abstraction / consolidation — this is what `adaptive_intervals` should mean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)