### PR TITLE
fix(consolidation): bound salience with a 1.0 ceiling in decay

### DIFF
--- a/cmd/mnemonic/runtime.go
+++ b/cmd/mnemonic/runtime.go
@@ -190,6 +190,7 @@ func toConsolidationConfig(cfg *config.Config) consolidation.ConsolidationConfig
 		RecencyProtection168h:         cfg.Consolidation.RecencyProtection168h,
 		AccessResistanceCap:           cfg.Consolidation.AccessResistanceCap,
 		AccessResistanceScale:         cfg.Consolidation.AccessResistanceScale,
+		SalienceCeiling:               float32(cfg.Consolidation.SalienceCeiling),
 		MergeSimilarityThreshold:      cfg.Consolidation.MergeSimilarityThreshold,
 		PatternMatchThreshold:         cfg.Consolidation.PatternMatchThreshold,
 		PatternMatchMinConceptOverlap: cfg.Consolidation.PatternMatchMinConceptOverlap,

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -321,6 +321,12 @@ consolidation:
   # Threshold below which memories are archived (0.0-1.0)
   archive_threshold: 0.1
 
+  # Upper bound applied in salience decay. Encoding clamps new memories to
+  # [0, 1.0]; without a matching ceiling here, post-decay attribute boosts
+  # (satisfying+success, frustrating) compound above 1.0 and strand memories
+  # above the fade threshold forever. Set <= 0 to disable. Default: 1.0.
+  salience_ceiling: 1.0
+
   # Retention window before permanent deletion (e.g., "90d", "6w")
   retention_window: "90d"
 

--- a/internal/agent/consolidation/agent.go
+++ b/internal/agent/consolidation/agent.go
@@ -37,6 +37,15 @@ type ConsolidationConfig struct {
 	AccessResistanceCap   float64 // max resistance from access count (default 0.3)
 	AccessResistanceScale float64 // per-access resistance factor (default 0.02)
 
+	// SalienceCeiling is the upper bound for salience applied in decaySalience.
+	// The post-decay attribute boosts (satisfying+success, frustrating) combined
+	// with recency protection and access resistance can produce an effective
+	// per-cycle multiplier above 1.0 for popular memories, causing unbounded
+	// salience growth that strands memories above the fade threshold forever.
+	// Encoding already clamps new salience to [0, 1.0], so a 1.0 ceiling matches
+	// the rest of the system. Set <= 0 to disable clamping. Default: 1.0.
+	SalienceCeiling float32
+
 	// Pattern strength tunables
 	MergeSimilarityThreshold      float64 // cosine threshold for memory merge clustering (default 0.85)
 	PatternMatchThreshold         float64 // cosine threshold for cluster→pattern matching (default 0.70)
@@ -85,6 +94,7 @@ func DefaultConfig() ConsolidationConfig {
 		RecencyProtection168h:         0.9,
 		AccessResistanceCap:           0.3,
 		AccessResistanceScale:         0.02,
+		SalienceCeiling:               1.0,
 		MergeSimilarityThreshold:      0.85,
 		PatternMatchThreshold:         0.70,
 		PatternMatchMinConceptOverlap: 2,
@@ -459,6 +469,18 @@ func (ca *ConsolidationAgent) decaySalience(ctx context.Context) (decayed, proce
 		// Floor at 0.01 (don't let it hit exactly 0)
 		if newSalience < 0.01 {
 			newSalience = 0.01
+		}
+
+		// Ceiling symmetric to the 0.01 floor. The attribute-boost path above
+		// multiplies salience by up to 1.05 per cycle after decay, which over
+		// hundreds of cycles can flip the net multiplier above 1.0 for popular
+		// memories. Without a ceiling, salience grows unbounded — audit on
+		// 2026-04-18 found a memory at 21,539 and 71/117 active memories above
+		// 1.0, none reachable by the 0.3 fade threshold. Encoding already
+		// clamps new salience to <= 1.0, so this keeps the whole system inside
+		// [0.01, SalienceCeiling]. Set SalienceCeiling <= 0 to disable.
+		if ca.config.SalienceCeiling > 0 && newSalience > ca.config.SalienceCeiling {
+			newSalience = ca.config.SalienceCeiling
 		}
 
 		if newSalience != mem.Salience {

--- a/internal/agent/consolidation/agent_test.go
+++ b/internal/agent/consolidation/agent_test.go
@@ -746,6 +746,136 @@ func TestDecaySalience(t *testing.T) {
 	})
 }
 
+// TestSalienceCeiling_ClampsBloatedMemory verifies the ceiling introduced in
+// RC#3. Before the fix, attribute-boost multipliers (satisfying+success = 1.05,
+// frustrating = 1.03) applied after decay could flip the net per-cycle
+// multiplier above 1.0 for recently-accessed popular memories, producing
+// unbounded growth. Audit on 2026-04-18 found salience at 21,539 on a
+// production memory. The ceiling guarantees salience stays <= SalienceCeiling
+// (default 1.0) regardless of attribute effects.
+func TestSalienceCeiling_ClampsBloatedMemory(t *testing.T) {
+	ms := newMockStore()
+	mlp := newMockLLMProvider()
+	cfg := testConfig()
+	cfg.DecayRate = 0.95
+	cfg.SalienceCeiling = 1.0
+	agent := NewConsolidationAgent(ms, mlp, cfg, testLogger())
+
+	bloated := store.Memory{
+		ID:           "bloated",
+		Salience:     21539.0, // reproduces the production anomaly
+		AccessCount:  200,
+		LastAccessed: time.Now().Add(-1 * time.Hour),
+		CreatedAt:    time.Now().Add(-30 * 24 * time.Hour),
+		State:        "active",
+	}
+	ms.listMemoriesFn = func(_ context.Context, state string, _, _ int) ([]store.Memory, error) {
+		if state == "active" {
+			return []store.Memory{bloated}, nil
+		}
+		return nil, nil
+	}
+	// Satisfying+success attributes — the exact combination that drove the
+	// unbounded growth. Ceiling must dominate the +5% post-multiplier.
+	ms.getMemoryAttributesFn = func(_ context.Context, _ string) (store.MemoryAttributes, error) {
+		return store.MemoryAttributes{EmotionalTone: "satisfying", Outcome: "success"}, nil
+	}
+
+	if _, _, err := agent.decaySalience(context.Background()); err != nil {
+		t.Fatalf("decaySalience: %v", err)
+	}
+
+	if len(ms.batchUpdateSalienceCalls) != 1 {
+		t.Fatalf("expected 1 BatchUpdateSalience call, got %d", len(ms.batchUpdateSalienceCalls))
+	}
+	got := ms.batchUpdateSalienceCalls[0]["bloated"]
+	if got > cfg.SalienceCeiling {
+		t.Errorf("salience must be clamped to ceiling %f, got %f", cfg.SalienceCeiling, got)
+	}
+	if got != cfg.SalienceCeiling {
+		t.Errorf("bloated memory should clamp exactly to ceiling %f, got %f", cfg.SalienceCeiling, got)
+	}
+}
+
+// TestSalienceCeiling_DisabledWhenZero verifies the ceiling is a no-op when
+// SalienceCeiling is <= 0, so callers can opt out explicitly.
+func TestSalienceCeiling_DisabledWhenZero(t *testing.T) {
+	ms := newMockStore()
+	mlp := newMockLLMProvider()
+	cfg := testConfig()
+	cfg.DecayRate = 0.95
+	cfg.SalienceCeiling = 0
+	agent := NewConsolidationAgent(ms, mlp, cfg, testLogger())
+
+	bloated := store.Memory{
+		ID:           "bloated",
+		Salience:     500.0,
+		AccessCount:  0,
+		LastAccessed: time.Now().Add(-200 * time.Hour),
+		CreatedAt:    time.Now().Add(-200 * time.Hour),
+		State:        "active",
+	}
+	ms.listMemoriesFn = func(_ context.Context, state string, _, _ int) ([]store.Memory, error) {
+		if state == "active" {
+			return []store.Memory{bloated}, nil
+		}
+		return nil, nil
+	}
+	ms.getMemoryAttributesFn = func(_ context.Context, _ string) (store.MemoryAttributes, error) {
+		return store.MemoryAttributes{}, fmt.Errorf("not found")
+	}
+
+	if _, _, err := agent.decaySalience(context.Background()); err != nil {
+		t.Fatalf("decaySalience: %v", err)
+	}
+
+	got := ms.batchUpdateSalienceCalls[0]["bloated"]
+	// With ceiling disabled, should just apply 0.95 decay: 500 * 0.95 = 475.
+	expected := float32(500.0 * 0.95)
+	if !almostEqual(got, expected, 0.5) {
+		t.Errorf("ceiling-disabled path should apply raw decay, expected ~%f got %f", expected, got)
+	}
+}
+
+// TestSalienceCeiling_DoesNotBoostBelowCeiling verifies the ceiling only
+// clamps downward — it does not artificially lift low-salience memories.
+func TestSalienceCeiling_DoesNotBoostBelowCeiling(t *testing.T) {
+	ms := newMockStore()
+	mlp := newMockLLMProvider()
+	cfg := testConfig()
+	cfg.DecayRate = 0.95
+	cfg.SalienceCeiling = 1.0
+	agent := NewConsolidationAgent(ms, mlp, cfg, testLogger())
+
+	low := store.Memory{
+		ID:           "low",
+		Salience:     0.4,
+		AccessCount:  0,
+		LastAccessed: time.Now().Add(-200 * time.Hour),
+		CreatedAt:    time.Now().Add(-200 * time.Hour),
+		State:        "active",
+	}
+	ms.listMemoriesFn = func(_ context.Context, state string, _, _ int) ([]store.Memory, error) {
+		if state == "active" {
+			return []store.Memory{low}, nil
+		}
+		return nil, nil
+	}
+	ms.getMemoryAttributesFn = func(_ context.Context, _ string) (store.MemoryAttributes, error) {
+		return store.MemoryAttributes{}, fmt.Errorf("not found")
+	}
+
+	if _, _, err := agent.decaySalience(context.Background()); err != nil {
+		t.Fatalf("decaySalience: %v", err)
+	}
+
+	got := ms.batchUpdateSalienceCalls[0]["low"]
+	expected := float32(0.4 * 0.95)
+	if !almostEqual(got, expected, 0.01) {
+		t.Errorf("low-salience memory should decay normally, expected ~%f got %f", expected, got)
+	}
+}
+
 func TestTransitionStates(t *testing.T) {
 	t.Run("active memory below fade threshold transitions to fading", func(t *testing.T) {
 		ms := newMockStore()

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -240,6 +240,7 @@ type ConsolidationConfig struct {
 	RecencyProtection168h float64 `yaml:"recency_protection_168h"`
 	AccessResistanceCap   float64 `yaml:"access_resistance_cap"`
 	AccessResistanceScale float64 `yaml:"access_resistance_scale"`
+	SalienceCeiling       float64 `yaml:"salience_ceiling"` // upper bound applied in decaySalience (default 1.0)
 
 	// Pattern strength tunables
 	MergeSimilarityThreshold      float64 `yaml:"merge_similarity_threshold"`
@@ -738,6 +739,7 @@ func Default() *Config {
 			RecencyProtection168h:         0.9,
 			AccessResistanceCap:           0.3,
 			AccessResistanceScale:         0.02,
+			SalienceCeiling:               1.0,
 			MergeSimilarityThreshold:      0.85,
 			PatternMatchThreshold:         0.70,
 			PatternMatchMinConceptOverlap: 2,


### PR DESCRIPTION
## Summary

Root cause #3 of 3 from the 2026-04-18 agent-scheduling audit. Companion to [#427](https://github.com/AppSprout-dev/mnemonic/pull/427) (dream replay rotation) and [#428](https://github.com/AppSprout-dev/mnemonic/pull/428) (abstraction fingerprint gating).

The attribute-boost path in `decaySalience` applies `× 1.05` (satisfying+success) or `× 1.03` (frustrating) as a **raw post-multiplier after** the decay step. Combined with `RecencyProtection` (`<24h` reduces decay exponent to 0.8) and `AccessResistance` (up to 30% less decay for popular memories), the effective per-cycle multiplier flips above 1.0 for frequently-touched positively-attributed memories. Without a ceiling, salience grows unbounded.

## Measured evidence (live daemon, 2026-04-18T13:29 EDT)

117 active memories:
```
min=0.313  max=21,539.723  median=1.256  mean=838.659
buckets:  <0.1: 0    0.1–0.3: 0    0.3–0.5: 6    0.5–0.7: 5
          0.7–0.9: 4    0.9–1.0: 31   >=1.0: 71
```

71/117 memories sit above 1.0. Zero are below the `fade_threshold=0.3`. The fade/archive state machine is silently broken — nothing ever transitions because nothing is ever in range. This is the mechanism behind the audit's finding that consolidation produced `merges=0` in 10/10 cycles and `transitioned_fading=0` across every cycle of the audit window.

Top 10 salience offenders, for posterity:
```
sal=21,539.723  access=153  type=learning   (TurboQuant implementation note)
sal=21,199.074  access=164  type=decision   (retrieval feedback-loop fix)
sal= 5,287.161  access=175  type=decision   (Phase A continuous learning plan)
sal= 4,984.564  access=174  type=decision   (compressionPrompt rewrite)
sal= 4,539.488  access=173  type=learning   (PostgreSQL switch)
sal= 3,786.935  access=239  type=decision   (chat_template field)
sal= 3,293.182  access=164  type=insight    (first lifecycle test passing)
sal= 3,263.124  access=175  type=learning   (carbonara recipe — yes, really)
sal= 3,020.056  access=157  type=insight    (W&B logging integration)
sal= 2,856.275  access=181  type=general    (WAL mode activation)
```

All top offenders have high `access_count` (153–239), which triggers both `RecencyProtection` (constant re-access within 24h) and `AccessResistance` (cap-saturated 30% decay reduction), keeping effective decay near 1.0. Any memory that then hits the satisfying+success or frustrating attribute paths crosses 1.0 and compounds.

## The fix

- New `SalienceCeiling` config field on `ConsolidationConfig`, default `1.0` — matches the `[0, 1.0]` clamp that `encoding/agent.go:1258` already enforces on freshly-stored memories.
- Applied in the same pass as the existing `0.01` floor, so the whole decay step produces values in `[0.01, SalienceCeiling]`.
- `SalienceCeiling <= 0` disables the clamp (opt-out for callers who genuinely want unbounded salience).
- Wired through `internal/config/config.go` defaults and `cmd/mnemonic/runtime.go` agent construction. `config.example.yaml` and `config.yaml` get a documented `salience_ceiling` key.

**No separate backfill migration needed.** The first post-fix consolidation cycle will clamp all 71 over-ceiling memories to 1.0 via the same `BatchUpdateSalience` path — a reactor-fired cycle or the next scheduled one (4h cadence). After that, normal decay can drive unused memories toward the 0.3 fade threshold; frequently-used memories stick at 1.0 but can still transition if access patterns change.

## What this does NOT fix

- Memory merge (`merges=0` in 10/10 cycles) — merge clustering runs on cosine similarity at `0.85`, independent of salience. That's a separate investigation (may need threshold calibration or a seed-order fix in the greedy clusterer). Not in this PR.
- Attribute-boost semantics — the +5%/+3% multipliers are preserved, just bounded. If review decides the "learning signal" should be recast as a decay-exponent modifier instead (the same shape as critical/important), that's a follow-up design choice, not a bug fix.

## Test plan

- [x] `go test ./internal/agent/consolidation/` — all existing tests still pass; three new cases cover:
  - `TestSalienceCeiling_ClampsBloatedMemory` — reproduces the production 21,539 anomaly with satisfying+success attributes, verifies clamp to exactly 1.0.
  - `TestSalienceCeiling_DisabledWhenZero` — `SalienceCeiling=0` passes through raw decay output.
  - `TestSalienceCeiling_DoesNotBoostBelowCeiling` — ceiling only clamps downward; low-salience memories decay normally.
- [x] `go test ./...` — no regressions.
- [x] `golangci-lint run ./internal/agent/consolidation/ ./cmd/mnemonic/ ./internal/config/` — 0 issues.
- [ ] Post-merge production verification: authorized daemon restart, then within one consolidation cycle, re-run the salience distribution query and confirm max <= 1.0, none > 1.0, and >0 memories below 0.3 (fade path now reachable).

## Follow-ups

- Monitor whether the now-unblocked fade transitions cause an aggressive purge of memories that have been riding on the boost-inflated salience but are semantically stale. If so, consider a one-shot "healthy memory" preservation pass before enabling the ceiling.
- Design doc for substrate-fingerprint gating (promised alongside #428) — unifies dream rotation, abstraction gating, and the now-working consolidation state machine under a single "sleep when there's nothing to do" framework.

🤖 Generated with [Claude Code](https://claude.com/claude-code)