### PR TITLE
fix(consolidation): catch pattern duplicates via evidence-set Jaccard

### DIFF
--- a/internal/agent/consolidation/agent.go
+++ b/internal/agent/consolidation/agent.go
@@ -50,14 +50,33 @@ type ConsolidationConfig struct {
 	MergeSimilarityThreshold      float64 // cosine threshold for memory merge clustering (default 0.85)
 	PatternMatchThreshold         float64 // cosine threshold for cluster→pattern matching (default 0.70)
 	PatternMatchMinConceptOverlap int     // min shared concepts required for cluster→pattern match (default 2) — prevents super-attractor behavior
-	MaxClusterSampleForLLM        int     // max cluster memories shown to the LLM for identifyPattern (default 10) — prevents JSON truncation on huge clusters
-	PatternStrengthIncrement      float32 // strength gain per new evidence (default 0.03)
-	PatternIncrementCap           float32 // max single-cycle strength gain (default 0.15)
-	LargeClusterBonus             float32 // multiplier for clusters >= LargeClusterMinSize (default 1.3)
-	LargeClusterMinSize           int     // cluster size to trigger bonus (default 5)
-	PatternStrengthCeiling        float32 // max strength unless strong evidence (default 0.95)
-	StrongEvidenceCeiling         float32 // max strength with strong evidence (default 1.0)
-	StrongEvidenceMinCount        int     // evidence count to unlock strong ceiling (default 10)
+	// PatternEvidenceJaccardMin is the evidence-set Jaccard above which two
+	// existing patterns are treated as duplicates regardless of title or
+	// embedding wording. Catches "Repeated Session Handoffs" / "Consistent
+	// Session Handoff" type variants that share most of their evidence but
+	// fail the title/embedding gates. Default: 0.5.
+	PatternEvidenceJaccardMin float32
+	// PatternEvidenceJaccardMinCount is the minimum evidence count BOTH patterns
+	// must have for evidence-Jaccard to apply as a duplicate signal. Below this,
+	// two small-cluster patterns sharing the same N memories are likely
+	// legitimately distinct extractions (e.g. one cluster of 4 memories yielding
+	// both a "Session Handoff Workflow" pattern and a "Tokenizer boundary"
+	// pattern). Real recurring patterns easily exceed this floor. Default: 10.
+	PatternEvidenceJaccardMinCount int
+	// PatternMatchEvidenceCoverageMin is the directional ratio
+	// |cluster ∩ pattern.evidence| / |cluster| above which findMatchingPattern
+	// treats a cluster as a re-extraction of an existing pattern (skipping the
+	// LLM call). Prevents new duplicate patterns from being generated when the
+	// memories are mostly already evidence in some pattern X. Default: 0.7.
+	PatternMatchEvidenceCoverageMin float32
+	MaxClusterSampleForLLM          int     // max cluster memories shown to the LLM for identifyPattern (default 10) — prevents JSON truncation on huge clusters
+	PatternStrengthIncrement        float32 // strength gain per new evidence (default 0.03)
+	PatternIncrementCap             float32 // max single-cycle strength gain (default 0.15)
+	LargeClusterBonus               float32 // multiplier for clusters >= LargeClusterMinSize (default 1.3)
+	LargeClusterMinSize             int     // cluster size to trigger bonus (default 5)
+	PatternStrengthCeiling          float32 // max strength unless strong evidence (default 0.95)
+	StrongEvidenceCeiling           float32 // max strength with strong evidence (default 1.0)
+	StrongEvidenceMinCount          int     // evidence count to unlock strong ceiling (default 10)
 
 	// Pattern decay tunables
 	PatternBaselineDecay float32 // per-cycle baseline decay (default 0.995)
@@ -80,40 +99,43 @@ type ConsolidationConfig struct {
 // DefaultConfig returns sensible defaults for consolidation.
 func DefaultConfig() ConsolidationConfig {
 	return ConsolidationConfig{
-		Interval:                      6 * time.Hour,
-		DecayRate:                     0.95,
-		FadeThreshold:                 0.3,
-		ArchiveThreshold:              0.1,
-		RetentionWindow:               90 * 24 * time.Hour,
-		MaxMemoriesPerCycle:           100,
-		MaxMergesPerCycle:             5,
-		MinClusterSize:                3,
-		MinEvidenceSalience:           0.5,
-		AssocPruneThreshold:           0.05,
-		RecencyProtection24h:          0.8,
-		RecencyProtection168h:         0.9,
-		AccessResistanceCap:           0.3,
-		AccessResistanceScale:         0.02,
-		SalienceCeiling:               1.0,
-		MergeSimilarityThreshold:      0.85,
-		PatternMatchThreshold:         0.70,
-		PatternMatchMinConceptOverlap: 2,
-		MaxClusterSampleForLLM:        10,
-		PatternStrengthIncrement:      0.03,
-		PatternIncrementCap:           0.15,
-		LargeClusterBonus:             1.3,
-		LargeClusterMinSize:           5,
-		PatternStrengthCeiling:        0.95,
-		StrongEvidenceCeiling:         1.0,
-		StrongEvidenceMinCount:        10,
-		PatternBaselineDecay:          0.995,
-		StaleDecayHealthy:             0.97,
-		StaleDecayModerate:            0.93,
-		StaleDecayAggressive:          0.85,
-		SelfSustainingMinEvidence:     10,
-		SelfSustainingMinStrength:     0.9,
-		SelfSustainingDecay:           0.995,
-		NeverRecalledArchiveDays:      30,
+		Interval:                        6 * time.Hour,
+		DecayRate:                       0.95,
+		FadeThreshold:                   0.3,
+		ArchiveThreshold:                0.1,
+		RetentionWindow:                 90 * 24 * time.Hour,
+		MaxMemoriesPerCycle:             100,
+		MaxMergesPerCycle:               5,
+		MinClusterSize:                  3,
+		MinEvidenceSalience:             0.5,
+		AssocPruneThreshold:             0.05,
+		RecencyProtection24h:            0.8,
+		RecencyProtection168h:           0.9,
+		AccessResistanceCap:             0.3,
+		AccessResistanceScale:           0.02,
+		SalienceCeiling:                 1.0,
+		MergeSimilarityThreshold:        0.85,
+		PatternMatchThreshold:           0.70,
+		PatternMatchMinConceptOverlap:   2,
+		PatternEvidenceJaccardMin:       0.5,
+		PatternEvidenceJaccardMinCount:  10,
+		PatternMatchEvidenceCoverageMin: 0.7,
+		MaxClusterSampleForLLM:          10,
+		PatternStrengthIncrement:        0.03,
+		PatternIncrementCap:             0.15,
+		LargeClusterBonus:               1.3,
+		LargeClusterMinSize:             5,
+		PatternStrengthCeiling:          0.95,
+		StrongEvidenceCeiling:           1.0,
+		StrongEvidenceMinCount:          10,
+		PatternBaselineDecay:            0.995,
+		StaleDecayHealthy:               0.97,
+		StaleDecayModerate:              0.93,
+		StaleDecayAggressive:            0.85,
+		SelfSustainingMinEvidence:       10,
+		SelfSustainingMinStrength:       0.9,
+		SelfSustainingDecay:             0.995,
+		NeverRecalledArchiveDays:        30,
 	}
 }
 
@@ -1183,8 +1205,13 @@ func (ca *ConsolidationAgent) findMatchingPattern(ctx context.Context, cluster [
 
 	threshold := float32(agentutil.Float64Or(ca.config.PatternMatchThreshold, 0.70))
 	minConceptOverlap := agentutil.IntOr(ca.config.PatternMatchMinConceptOverlap, 2)
+	evidenceCoverageMin := agentutil.Float32Or(ca.config.PatternMatchEvidenceCoverageMin, 0.7)
 
 	clusterConcepts := collectClusterConcepts(cluster)
+	clusterIDs := make([]string, 0, len(cluster))
+	for _, m := range cluster {
+		clusterIDs = append(clusterIDs, m.ID)
+	}
 
 	for i := range patterns {
 		p := &patterns[i]
@@ -1196,12 +1223,26 @@ func (ca *ConsolidationAgent) findMatchingPattern(ctx context.Context, cluster [
 			continue
 		}
 		overlap := countConceptOverlap(clusterConcepts, p.Concepts)
-		if overlap < minConceptOverlap {
-			ca.log.Info("pattern extraction: rejected embedding match on concept gate",
+		coverage := evidenceCoverage(clusterIDs, p.EvidenceIDs)
+		// Evidence-coverage override: when most of the cluster is already
+		// evidence in this candidate pattern, the cluster IS this pattern —
+		// bypass the concept gate. Concept gate alone caused
+		// "Repeated Session Handoffs"-class duplicates because the LLM
+		// re-extracted slightly-different concepts each cycle.
+		if overlap < minConceptOverlap && coverage < evidenceCoverageMin {
+			ca.log.Info("pattern extraction: rejected embedding match on concept+evidence gate",
 				"pattern_id", p.ID, "title", p.Title,
 				"cosine_sim", sim, "concept_overlap", overlap,
-				"min_required", minConceptOverlap)
+				"min_concept_required", minConceptOverlap,
+				"evidence_coverage", coverage,
+				"min_coverage_required", evidenceCoverageMin)
 			continue
+		}
+		if overlap < minConceptOverlap {
+			ca.log.Info("pattern extraction: matched via evidence-coverage override",
+				"pattern_id", p.ID, "title", p.Title,
+				"cosine_sim", sim, "concept_overlap", overlap,
+				"evidence_coverage", coverage)
 		}
 		return p, sim, nil
 	}
@@ -1593,6 +1634,59 @@ func (ca *ConsolidationAgent) logReport(report *CycleReport) {
 	)
 }
 
+// evidenceJaccard returns |A ∩ B| / |A ∪ B| over evidence-ID slices. Returns 0
+// when either side is empty. Used as a primary duplicate signal for patterns:
+// two patterns sharing most of their evidence ARE duplicates regardless of how
+// the LLM happened to title them this run vs last run.
+func evidenceJaccard(a, b []string) float32 {
+	if len(a) == 0 || len(b) == 0 {
+		return 0
+	}
+	setA := make(map[string]struct{}, len(a))
+	for _, id := range a {
+		setA[id] = struct{}{}
+	}
+	intersection := 0
+	setB := make(map[string]struct{}, len(b))
+	for _, id := range b {
+		setB[id] = struct{}{}
+		if _, ok := setA[id]; ok {
+			intersection++
+		}
+	}
+	union := len(setA)
+	for id := range setB {
+		if _, ok := setA[id]; !ok {
+			union++
+		}
+	}
+	if union == 0 {
+		return 0
+	}
+	return float32(intersection) / float32(union)
+}
+
+// evidenceCoverage returns |cluster ∩ pattern.evidence| / |cluster| — the
+// directional ratio of cluster memories already represented in a pattern.
+// High coverage means the cluster is a re-extraction of an existing pattern,
+// not a new one. Returns 0 when cluster is empty.
+func evidenceCoverage(clusterIDs, patternEvidence []string) float32 {
+	if len(clusterIDs) == 0 {
+		return 0
+	}
+	patSet := make(map[string]struct{}, len(patternEvidence))
+	for _, id := range patternEvidence {
+		patSet[id] = struct{}{}
+	}
+	hit := 0
+	for _, id := range clusterIDs {
+		if _, ok := patSet[id]; ok {
+			hit++
+		}
+	}
+	return float32(hit) / float32(len(clusterIDs))
+}
+
 // isDuplicate returns true if two items are near-duplicates based on title Jaccard and embedding cosine.
 // For short titles (<=4 words in either), requires BOTH signals to exceed thresholds to avoid false positives.
 func isDuplicate(titleA, titleB string, embA, embB []float32, titleThresh, embThresh float32) bool {
@@ -1857,6 +1951,8 @@ func (ca *ConsolidationAgent) dedupPatterns(ctx context.Context) (int, error) {
 
 	archived := 0
 	archivedIDs := make(map[string]bool)
+	evidenceJaccardMin := agentutil.Float32Or(ca.config.PatternEvidenceJaccardMin, 0.5)
+	evidenceMinCount := agentutil.IntOr(ca.config.PatternEvidenceJaccardMinCount, 10)
 
 	for i := 0; i < len(active); i++ {
 		if archivedIDs[active[i].ID] {
@@ -1866,7 +1962,33 @@ func (ca *ConsolidationAgent) dedupPatterns(ctx context.Context) (int, error) {
 			if archivedIDs[active[j].ID] {
 				continue
 			}
-			if isDuplicate(active[i].Title, active[j].Title, active[i].Embedding, active[j].Embedding, 0.5, 0.75) {
+			// Two duplicate paths:
+			//   1. Title-or-embedding similarity (existing isDuplicate behavior).
+			//   2. Evidence-set Jaccard >= threshold — patterns sharing most
+			//      of their evidence ARE duplicates regardless of title/embedding
+			//      wording. Catches LLM-induced title variants like "Repeated
+			//      Session Handoffs" vs "Consistent Session Handoff" that share
+			//      the same underlying memories.
+			titleEmbDup := isDuplicate(active[i].Title, active[j].Title, active[i].Embedding, active[j].Embedding, 0.5, 0.75)
+			evJaccard := evidenceJaccard(active[i].EvidenceIDs, active[j].EvidenceIDs)
+			// Evidence-jaccard duplicates must clear a minimum-count floor on
+			// BOTH sides. Otherwise small clusters (e.g. 4 memories yielding
+			// "Session Handoff Workflow" + "Tokenizer boundary") get falsely
+			// merged because they trivially share 4/4 evidence — different
+			// patterns extracted from the same small substrate are usually
+			// legitimately distinct, not duplicates.
+			evidenceDup := evJaccard >= evidenceJaccardMin &&
+				len(active[i].EvidenceIDs) >= evidenceMinCount &&
+				len(active[j].EvidenceIDs) >= evidenceMinCount
+			if titleEmbDup || evidenceDup {
+				if evidenceDup && !titleEmbDup {
+					ca.log.Info("pattern dedup: matched via evidence-jaccard",
+						"keep_id", active[i].ID, "keep_title", active[i].Title,
+						"archive_id", active[j].ID, "archive_title", active[j].Title,
+						"evidence_jaccard", evJaccard,
+						"keep_evidence_n", len(active[i].EvidenceIDs),
+						"archive_evidence_n", len(active[j].EvidenceIDs))
+				}
 				// Keep older (i), archive newer (j)
 				canonical := &active[i]
 				dup := &active[j]

--- a/internal/agent/consolidation/agent_test.go
+++ b/internal/agent/consolidation/agent_test.go
@@ -35,6 +35,7 @@ type mockStore struct {
 	batchMergeMemoriesFn    func(ctx context.Context, sourceIDs []string, gist store.Memory) error
 	writeConsolidationFn    func(ctx context.Context, record store.ConsolidationRecord) error
 	getMemoryAttributesFn   func(ctx context.Context, memoryID string) (store.MemoryAttributes, error)
+	listPatternsFn          func(ctx context.Context, project string, limit int) ([]store.Pattern, error)
 	searchPatternsByEmbFn   func(ctx context.Context, emb []float32, limit int) ([]store.Pattern, error)
 	searchArchivedByEmbFn   func(ctx context.Context, emb []float32, limit int) ([]store.Pattern, error)
 	updatePatternFn         func(ctx context.Context, p store.Pattern) error
@@ -72,6 +73,12 @@ func (m *mockStore) UpdateState(ctx context.Context, id string, state string) er
 func (m *mockStore) ListMemories(ctx context.Context, state string, limit, offset int) ([]store.Memory, error) {
 	if m.listMemoriesFn != nil {
 		return m.listMemoriesFn(ctx, state, limit, offset)
+	}
+	return nil, nil
+}
+func (m *mockStore) ListPatterns(ctx context.Context, project string, limit int) ([]store.Pattern, error) {
+	if m.listPatternsFn != nil {
+		return m.listPatternsFn(ctx, project, limit)
 	}
 	return nil, nil
 }

--- a/internal/agent/consolidation/dedup_evidence_test.go
+++ b/internal/agent/consolidation/dedup_evidence_test.go
@@ -1,0 +1,237 @@
+package consolidation
+
+import (
+	"context"
+	"log/slog"
+	"os"
+	"testing"
+
+	"github.com/appsprout-dev/mnemonic/internal/store"
+)
+
+// TestEvidenceJaccard covers the helper that drives the evidence-set duplicate
+// path in dedupPatterns. The motivating real-world failure: handoff-pattern
+// variants where two patterns shared 54 of 64 evidence IDs but had different
+// titles ("Repeated Session Handoffs" vs "Consistent Session Handoff") and so
+// fell through the title-Jaccard / embedding-cosine gates.
+func TestEvidenceJaccard(t *testing.T) {
+	cases := []struct {
+		name     string
+		a, b     []string
+		expected float32
+	}{
+		{"identical sets", []string{"x", "y", "z"}, []string{"x", "y", "z"}, 1.0},
+		{"disjoint sets", []string{"a", "b"}, []string{"c", "d"}, 0.0},
+		{"empty a", []string{}, []string{"x"}, 0.0},
+		{"empty b", []string{"x"}, []string{}, 0.0},
+		{"strict subset 0.84", listN("x", 54), listN("x", 64), 54.0 / 64.0},
+		{"half overlap", []string{"a", "b"}, []string{"b", "c"}, 1.0 / 3.0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := evidenceJaccard(tc.a, tc.b)
+			if abs(got-tc.expected) > 0.001 {
+				t.Errorf("expected %v, got %v", tc.expected, got)
+			}
+		})
+	}
+}
+
+// TestEvidenceCoverage covers the directional ratio used by findMatchingPattern
+// to recognize "this cluster is mostly already evidence in pattern X" — the
+// signal that lets us strengthen X instead of generating a new duplicate via
+// the LLM.
+func TestEvidenceCoverage(t *testing.T) {
+	cases := []struct {
+		name     string
+		cluster  []string
+		evidence []string
+		expected float32
+	}{
+		{"full coverage", []string{"a", "b", "c"}, []string{"a", "b", "c", "d"}, 1.0},
+		{"partial 0.66", []string{"a", "b", "c"}, []string{"a", "b", "z"}, 2.0 / 3.0},
+		{"zero coverage", []string{"a", "b"}, []string{"x", "y"}, 0.0},
+		{"empty cluster", []string{}, []string{"x"}, 0.0},
+		{"empty evidence", []string{"a", "b"}, []string{}, 0.0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := evidenceCoverage(tc.cluster, tc.evidence)
+			if abs(got-tc.expected) > 0.001 {
+				t.Errorf("expected %v, got %v", tc.expected, got)
+			}
+		})
+	}
+}
+
+func listN(prefix string, n int) []string {
+	out := make([]string, n)
+	for i := 0; i < n; i++ {
+		out[i] = prefix + "-" + itoa(i)
+	}
+	return out
+}
+
+func itoa(n int) string {
+	if n == 0 {
+		return "0"
+	}
+	var b []byte
+	for n > 0 {
+		b = append([]byte{byte('0' + n%10)}, b...)
+		n /= 10
+	}
+	return string(b)
+}
+
+func abs(f float32) float32 {
+	if f < 0 {
+		return -f
+	}
+	return f
+}
+
+// TestDedupPatterns_EvidenceJaccardCatchesTitleVariants is the integration test
+// for the handoff-variant problem: two patterns with totally different titles
+// ("Repeated Session Handoffs" vs "Consistent Session Handoff") whose evidence
+// IDs overlap heavily must be collapsed by dedupPatterns even when their
+// titles fail Jaccard and embeddings disagree. Real-world data showed pairs
+// with up to 84% evidence-Jaccard going undetected by the pre-fix gates.
+func TestDedupPatterns_EvidenceJaccardCatchesTitleVariants(t *testing.T) {
+	canonicalEvidence := listN("mem", 64)
+	dupEvidence := append([]string{}, canonicalEvidence[:54]...) // strict subset → 54/64 ≈ 0.84 Jaccard
+	canonical := store.Pattern{
+		ID:          "canonical-id",
+		Title:       "Repeated Session Handoffs",
+		EvidenceIDs: canonicalEvidence,
+		Strength:    0.9,
+		State:       "active",
+		Embedding:   []float32{1, 0, 0}, // deliberately orthogonal to the dup's embedding
+		Concepts:    []string{"session", "handoff", "repeated"},
+	}
+	dup := store.Pattern{
+		ID:          "dup-id",
+		Title:       "Consistent Session Handoff", // short title, fails Jaccard short-title AND gate
+		EvidenceIDs: dupEvidence,
+		Strength:    0.7,
+		State:       "active",
+		Embedding:   []float32{0, 1, 0}, // cosine 0 → fails embedding gate
+		Concepts:    []string{"consistent", "session", "handoff"},
+	}
+
+	ms := &mockStore{}
+	ms.listPatternsFn = func(_ context.Context, _ string, _ int) ([]store.Pattern, error) {
+		return []store.Pattern{canonical, dup}, nil
+	}
+	updates := make(map[string]store.Pattern)
+	ms.updatePatternFn = func(_ context.Context, p store.Pattern) error {
+		updates[p.ID] = p
+		return nil
+	}
+
+	cfg := DefaultConfig()
+	ca := NewConsolidationAgent(ms, nil, cfg, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+
+	archived, err := ca.dedupPatterns(context.Background())
+	if err != nil {
+		t.Fatalf("dedupPatterns failed: %v", err)
+	}
+	if archived != 1 {
+		t.Fatalf("expected 1 archived, got %d (title+embedding gates would have produced 0)", archived)
+	}
+	if got, ok := updates[dup.ID]; !ok || got.State != "archived" {
+		t.Errorf("expected dup to be archived, got state=%q exists=%v", got.State, ok)
+	}
+	if got, ok := updates[canonical.ID]; !ok || len(got.EvidenceIDs) != 64 {
+		t.Errorf("expected canonical to retain 64 evidence ids (no new ones from subset dup), got %d", len(got.EvidenceIDs))
+	}
+}
+
+// TestDedupPatterns_SmallClusterEvidenceDoesNotMerge guards against the false
+// positive caught during production-impact prediction: two patterns extracted
+// from the same 4-memory cluster but with disjoint topics ("CRISPR-LM Session
+// Handoff Workflow" vs "CRISPR-LM tokenizer boundary"). They share 4/4
+// evidence (jaccard=1.0) but they ARE legitimately different patterns.
+// Evidence-jaccard duplicate requires both sides to have at least
+// PatternEvidenceJaccardMinCount evidence to apply.
+func TestDedupPatterns_SmallClusterEvidenceDoesNotMerge(t *testing.T) {
+	shared := []string{"m1", "m2", "m3", "m4"}
+	a := store.Pattern{
+		ID: "small-a", Title: "CRISPR-LM Session Handoff Workflow",
+		EvidenceIDs: shared, Strength: 0.5, State: "active",
+		Embedding: []float32{1, 0, 0}, Concepts: []string{"session", "handoff"},
+	}
+	b := store.Pattern{
+		ID: "small-b", Title: "CRISPR-LM tokenizer boundary",
+		EvidenceIDs: shared, Strength: 0.5, State: "active",
+		Embedding: []float32{0, 1, 0}, Concepts: []string{"tokenizer", "boundary"},
+	}
+	ms := &mockStore{}
+	ms.listPatternsFn = func(_ context.Context, _ string, _ int) ([]store.Pattern, error) {
+		return []store.Pattern{a, b}, nil
+	}
+	updateCalls := 0
+	ms.updatePatternFn = func(_ context.Context, _ store.Pattern) error {
+		updateCalls++
+		return nil
+	}
+
+	cfg := DefaultConfig()
+	ca := NewConsolidationAgent(ms, nil, cfg, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	archived, err := ca.dedupPatterns(context.Background())
+	if err != nil {
+		t.Fatalf("dedupPatterns failed: %v", err)
+	}
+	if archived != 0 {
+		t.Errorf("expected 0 archived for small-cluster patterns despite jaccard=1.0, got %d (false positive — would have lost the 'tokenizer boundary' pattern)", archived)
+	}
+	if updateCalls != 0 {
+		t.Errorf("expected no UpdatePattern calls, got %d", updateCalls)
+	}
+}
+
+// TestDedupPatterns_LowEvidenceJaccardLeavesDistinctPatternsAlone is the negative
+// control: two patterns with disjoint evidence and dissimilar titles must NOT
+// be collapsed even if both come back from ListPatterns in the same call.
+func TestDedupPatterns_LowEvidenceJaccardLeavesDistinctPatternsAlone(t *testing.T) {
+	a := store.Pattern{
+		ID:          "a",
+		Title:       "Database migration safety",
+		EvidenceIDs: []string{"m1", "m2", "m3"},
+		Strength:    0.8,
+		State:       "active",
+		Embedding:   []float32{1, 0, 0},
+		Concepts:    []string{"database", "migration"},
+	}
+	b := store.Pattern{
+		ID:          "b",
+		Title:       "Frontend build performance",
+		EvidenceIDs: []string{"m4", "m5", "m6"},
+		Strength:    0.8,
+		State:       "active",
+		Embedding:   []float32{0, 1, 0},
+		Concepts:    []string{"frontend", "build"},
+	}
+	ms := &mockStore{}
+	ms.listPatternsFn = func(_ context.Context, _ string, _ int) ([]store.Pattern, error) {
+		return []store.Pattern{a, b}, nil
+	}
+	updateCalls := 0
+	ms.updatePatternFn = func(_ context.Context, _ store.Pattern) error {
+		updateCalls++
+		return nil
+	}
+
+	cfg := DefaultConfig()
+	ca := NewConsolidationAgent(ms, nil, cfg, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	archived, err := ca.dedupPatterns(context.Background())
+	if err != nil {
+		t.Fatalf("dedupPatterns failed: %v", err)
+	}
+	if archived != 0 {
+		t.Errorf("expected 0 archived for disjoint patterns, got %d (false positive)", archived)
+	}
+	if updateCalls != 0 {
+		t.Errorf("expected no UpdatePattern calls, got %d", updateCalls)
+	}
+}


### PR DESCRIPTION
## Summary

Schema-health telemetry from PR #433 surfaced an abstraction cycle producing 0 principles from 14 evaluated clusters. Investigation showed 13 active "session handoff" patterns sitting in the DB, many sharing 50-100% of their evidence IDs but with LLM-generated title variants. The existing dedup gates (title Jaccard OR embedding cosine) miss them because the discriminating words ("Repeated" / "Consistent" / "staggered" / etc.) break title Jaccard, and short titles trip an AND-gate.

Two new dedup signals:

1. **`dedupPatterns`** gains an evidence-set Jaccard path. Two patterns whose evidence-ID sets overlap ≥0.5 ARE duplicates regardless of title/embedding wording.
2. **`findMatchingPattern`** gains an evidence-coverage match. When a new cluster's IDs are ≥70% already evidence in candidate pattern X, the cluster IS that pattern — bypass the concept gate and skip the LLM call. Prevents new duplicates at write time, not just after-the-fact.

**Safeguard**: evidence-Jaccard duplicate requires both patterns to have ≥10 evidence. This prevents a real false positive caught during production-impact prediction: "CRISPR-LM Session Handoff Workflow" and "CRISPR-LM tokenizer boundary" share 4/4 evidence but are legitimately different patterns extracted from the same small cluster.

## Production-impact result (verified post-merge)

| metric | predicted | actual |
|---|---|---|
| patterns archived in first dedup cycle | ~13 | **12** |
| active patterns after | ~18 | **19** |
| duplicate pairs collapsed | 47 | matched |

## Caveats — including a real regression caught post-deploy

- **Super-attractor false positives.** 3 of 12 dedups were semantically wrong: "Developing a Self-Contained LLM Architecture" (125 evidence) absorbed "Consistent Mnemonic Session Handoff", "Optimizing LLM/AI Workflows...", and "The Emergence of a Structured Handoff Workflow" because they all share heavy evidence overlap with the canonical (jaccard 0.50–0.72). These are different aspects of the same memories, not duplicates. The evidence-Jaccard path lacks a semantic floor analogous to the concept-overlap gate on the LLM-write path. **Worth a follow-up**: require a weak semantic gate (shared title word OR embedding cosine ≥ 0.4) on top of evidence-Jaccard.
- **Dedup did NOT unblock principle synthesis.** The original motivation was `principles_created: 0` from a junk-saturated substrate. After dedup, substrate dropped from 14 evaluated patterns to 7 — but `principles_created` is still 0. The LLM keeps soft-rejecting every cluster. The cleaner substrate doesn't fix the OOD coverage gap on the principle schema. Next move is training-data (EXP-32) or routing principle synthesis to the cloud teacher, not more code.
- One-directional dedup (older keeps, newer archives) — if older pattern is the inferior one, evidence merges into it but title remains the older title. Acceptable for now.

## Test plan — verified post-merge

- [x] `go fmt`, `go vet`, `go test ./internal/agent/consolidation/...`, `golangci-lint run` clean — all green, lint 0 issues.
- [x] After deploy, run `curl -X POST localhost:9999/api/v1/consolidation/run`, check daemon log for `pattern dedup: matched via evidence-jaccard` lines — **12 lines fired in the post-deploy consolidation**, all with valid jaccard scores.
- [x] Query active pattern count before vs after first dedup cycle — **31 → 19 active, 12 archived. Predicted 13, actual 12.**
- [x] Spot-check a few archived patterns — confirmed 9 obvious duplicates (handoff variants, Mnemonic-LM Development variants), **3 false positives** (super-attractor merges, flagged in Caveats).
- [ ] Re-run abstraction agent: principles_created should improve — **NOT verified.** First post-deploy abstraction cycle: `patterns_evaluated=7, principles_created=0`. Substrate is cleaner but the LLM still soft-rejects. The dedup did its mechanical job; the principle-synthesis blocker is the OOD spoke, not the substrate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
