### PR TITLE
feat(abstraction): capture raw rejected output for principle/axiom soft-rejects

### DIFF
--- a/internal/agent/abstraction/agent.go
+++ b/internal/agent/abstraction/agent.go
@@ -668,6 +668,7 @@ Set has_principle to false if:
 
 	if !result.HasPrinciple || result.Title == "" || result.Principle == "" {
 		report.Outcome = events.SchemaCallSoftRejected
+		aa.captureRejectionSample(ctx, "principle_synthesize", patternIDs, patternTitles(patterns), resp.Content, principleRejectReason(result))
 		return nil, nil
 	}
 	report.Outcome = events.SchemaCallOK
@@ -789,6 +790,7 @@ Set has_axiom to false if:
 
 	if !result.HasAxiom || result.Title == "" || result.Axiom == "" {
 		report.Outcome = events.SchemaCallSoftRejected
+		aa.captureRejectionSample(ctx, "axiom_synthesize", sourceIDs, abstractionTitles(principles), resp.Content, axiomRejectReason(result))
 		return nil, nil
 	}
 	report.Outcome = events.SchemaCallOK

--- a/internal/agent/abstraction/rejection_sample.go
+++ b/internal/agent/abstraction/rejection_sample.go
@@ -1,0 +1,118 @@
+package abstraction
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/uuid"
+
+	"github.com/appsprout-dev/mnemonic/internal/agent/agentutil"
+	"github.com/appsprout-dev/mnemonic/internal/store"
+)
+
+// rejectionSampleMaxRawChars caps the captured raw response so a single
+// runaway LLM output doesn't bloat meta_observations. 1500 is enough for the
+// full principle/axiom JSON plus reasoning prose, while keeping the row
+// SQLite-friendly. The diagnostic value is the JSON shape, not pages of text.
+const rejectionSampleMaxRawChars = 1500
+
+// rejectionSampleMaxSourceTitles caps how many cluster titles we copy into the
+// observation details. Above this, we trust the IDs and let the reader join
+// against the patterns table.
+const rejectionSampleMaxSourceTitles = 12
+
+// captureRejectionSample writes a meta_observations row capturing one
+// soft-rejected LLM call's full input/output. The point of this row is to
+// answer "given THIS cluster, what did the spoke actually say?" — Feynman's
+// three-mechanism question (correct skepticism / parsing artifact /
+// OOD-default-token) requires the raw response, not just the verdict.
+//
+// Failure to write is logged but never propagated: this is diagnostic
+// instrumentation, not control flow.
+func (aa *AbstractionAgent) captureRejectionSample(
+	ctx context.Context,
+	schema string,
+	sourceIDs []string,
+	sourceTitles []string,
+	rawResponse string,
+	parsedReason string,
+) {
+	if aa.store == nil {
+		return
+	}
+	titles := sourceTitles
+	if len(titles) > rejectionSampleMaxSourceTitles {
+		titles = titles[:rejectionSampleMaxSourceTitles]
+	}
+	obs := store.MetaObservation{
+		ID:              uuid.New().String(),
+		ObservationType: "schema_rejection_sample",
+		Severity:        "info",
+		Details: map[string]any{
+			"schema":        schema,
+			"agent":         aa.Name(),
+			"source_ids":    sourceIDs,
+			"source_titles": titles,
+			"raw_response":  agentutil.Truncate(rawResponse, rejectionSampleMaxRawChars),
+			"parsed_reason": parsedReason,
+		},
+		CreatedAt: time.Now(),
+	}
+	if err := aa.store.WriteMetaObservation(ctx, obs); err != nil {
+		aa.log.Warn("failed to capture rejection sample",
+			"schema", schema, "source_count", len(sourceIDs), "error", err)
+	}
+}
+
+// patternTitles extracts titles from a slice of patterns for rejection-sample
+// recording. Kept as a free function so tests can verify the projection
+// independently of the agent.
+func patternTitles(patterns []store.Pattern) []string {
+	out := make([]string, 0, len(patterns))
+	for _, p := range patterns {
+		out = append(out, p.Title)
+	}
+	return out
+}
+
+// abstractionTitles is patternTitles' analogue for axiom synthesis, which
+// clusters principles (level-2 abstractions), not patterns.
+func abstractionTitles(items []store.Abstraction) []string {
+	out := make([]string, 0, len(items))
+	for _, a := range items {
+		out = append(out, a.Title)
+	}
+	return out
+}
+
+// principleRejectReason explains why a principleResponse was classified as
+// soft_rejected. The three branches in synthesizePrinciple are equivalent at
+// the verdict level (all → SchemaCallSoftRejected) but mean different things
+// when reading the captured sample: did the model say "no" outright, or did
+// it return malformed JSON that just parsed cleanly with empty fields?
+func principleRejectReason(r principleResponse) string {
+	switch {
+	case !r.HasPrinciple:
+		return "has_principle_false"
+	case r.Title == "":
+		return "missing_title"
+	case r.Principle == "":
+		return "missing_principle_text"
+	default:
+		return "unknown"
+	}
+}
+
+// axiomRejectReason mirrors principleRejectReason for the axiom schema.
+func axiomRejectReason(r axiomResponse) string {
+	switch {
+	case !r.HasAxiom:
+		return "has_axiom_false"
+	case r.Title == "":
+		return "missing_title"
+	case r.Axiom == "":
+		return "missing_axiom_text"
+	default:
+		return "unknown"
+	}
+}

--- a/internal/agent/abstraction/rejection_sample_test.go
+++ b/internal/agent/abstraction/rejection_sample_test.go
@@ -1,0 +1,161 @@
+package abstraction
+
+import (
+	"context"
+	"testing"
+
+	"github.com/appsprout-dev/mnemonic/internal/store"
+	"github.com/appsprout-dev/mnemonic/internal/store/storetest"
+)
+
+// captureMockStore records every WriteMetaObservation call so tests can
+// assert against the captured rejection sample.
+type captureMockStore struct {
+	storetest.MockStore
+	captured []store.MetaObservation
+}
+
+func (m *captureMockStore) WriteMetaObservation(_ context.Context, obs store.MetaObservation) error {
+	m.captured = append(m.captured, obs)
+	return nil
+}
+
+// TestCaptureRejectionSample_WritesAllDiagnosticFields proves that the
+// instrumentation captures everything the operator needs to read a rejection
+// by hand: the schema, the cluster IDs and titles, the LLM's raw response,
+// and the parsed reason. Without these fields, a captured row is just noise.
+func TestCaptureRejectionSample_WritesAllDiagnosticFields(t *testing.T) {
+	ms := &captureMockStore{}
+	cfg := AbstractionConfig{}
+	aa := NewAbstractionAgent(ms, nil, cfg, silentLogger())
+
+	aa.captureRejectionSample(
+		context.Background(),
+		"principle_synthesize",
+		[]string{"pat-1", "pat-2", "pat-3"},
+		[]string{"Repeated Session Handoffs", "CRISPR-LM Workflow", "Mnemonic Development"},
+		`{"has_principle":false,"title":"","principle":"","concepts":[],"confidence":0.0}`,
+		"has_principle_false",
+	)
+
+	if len(ms.captured) != 1 {
+		t.Fatalf("expected 1 observation written, got %d", len(ms.captured))
+	}
+	got := ms.captured[0]
+	if got.ObservationType != "schema_rejection_sample" {
+		t.Errorf("observation_type = %q, want schema_rejection_sample", got.ObservationType)
+	}
+	if got.Severity != "info" {
+		t.Errorf("severity = %q, want info (rejection samples are diagnostic, not alarms)", got.Severity)
+	}
+	if got.Details["schema"] != "principle_synthesize" {
+		t.Errorf("schema = %v, want principle_synthesize", got.Details["schema"])
+	}
+	if ids, ok := got.Details["source_ids"].([]string); !ok || len(ids) != 3 {
+		t.Errorf("source_ids missing or wrong length: %v", got.Details["source_ids"])
+	}
+	if titles, ok := got.Details["source_titles"].([]string); !ok || len(titles) != 3 {
+		t.Errorf("source_titles missing or wrong length: %v", got.Details["source_titles"])
+	}
+	if raw, ok := got.Details["raw_response"].(string); !ok || raw == "" {
+		t.Errorf("raw_response missing — diagnostic value depends on this field")
+	}
+	if got.Details["parsed_reason"] != "has_principle_false" {
+		t.Errorf("parsed_reason = %v, want has_principle_false", got.Details["parsed_reason"])
+	}
+}
+
+// TestCaptureRejectionSample_TruncatesRunawayResponses prevents a single
+// 100-page LLM response from bloating meta_observations. Caps at
+// rejectionSampleMaxRawChars; readers can always re-run with a longer cap if
+// truncation hides something interesting.
+func TestCaptureRejectionSample_TruncatesRunawayResponses(t *testing.T) {
+	ms := &captureMockStore{}
+	cfg := AbstractionConfig{}
+	aa := NewAbstractionAgent(ms, nil, cfg, silentLogger())
+
+	huge := make([]byte, rejectionSampleMaxRawChars*5)
+	for i := range huge {
+		huge[i] = 'x'
+	}
+	aa.captureRejectionSample(context.Background(), "axiom_synthesize", nil, nil, string(huge), "has_axiom_false")
+
+	if len(ms.captured) != 1 {
+		t.Fatalf("expected 1 observation, got %d", len(ms.captured))
+	}
+	raw, _ := ms.captured[0].Details["raw_response"].(string)
+	// agentutil.Truncate caps content to N runes and appends "..." — so the
+	// captured length is rejectionSampleMaxRawChars + 3. The contract is "no
+	// runaway storage," not "exactly N chars," so accept the documented suffix.
+	const truncSuffixLen = 3
+	if len(raw) != rejectionSampleMaxRawChars+truncSuffixLen {
+		t.Errorf("raw_response length = %d, want %d (Truncate cap + suffix)", len(raw), rejectionSampleMaxRawChars+truncSuffixLen)
+	}
+	if len(raw) >= len(string(make([]byte, rejectionSampleMaxRawChars*5))) {
+		t.Errorf("raw_response was not truncated — would have stored full payload")
+	}
+}
+
+// TestPrincipleRejectReason covers the three branches that map to
+// SchemaCallSoftRejected at the verdict level but mean different things to a
+// reader: did the model say "no", or did it return a malformed-but-parseable
+// JSON with empty fields?
+func TestPrincipleRejectReason(t *testing.T) {
+	cases := []struct {
+		name     string
+		resp     principleResponse
+		expected string
+	}{
+		{"explicit no", principleResponse{HasPrinciple: false, Title: "anything", Principle: "anything"}, "has_principle_false"},
+		{"missing title", principleResponse{HasPrinciple: true, Title: "", Principle: "ok"}, "missing_title"},
+		{"missing principle text", principleResponse{HasPrinciple: true, Title: "ok", Principle: ""}, "missing_principle_text"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := principleRejectReason(tc.resp); got != tc.expected {
+				t.Errorf("got %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+// TestAxiomRejectReason mirrors TestPrincipleRejectReason for the axiom schema.
+func TestAxiomRejectReason(t *testing.T) {
+	cases := []struct {
+		name     string
+		resp     axiomResponse
+		expected string
+	}{
+		{"explicit no", axiomResponse{HasAxiom: false, Title: "anything", Axiom: "anything"}, "has_axiom_false"},
+		{"missing title", axiomResponse{HasAxiom: true, Title: "", Axiom: "ok"}, "missing_title"},
+		{"missing axiom text", axiomResponse{HasAxiom: true, Title: "ok", Axiom: ""}, "missing_axiom_text"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := axiomRejectReason(tc.resp); got != tc.expected {
+				t.Errorf("got %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+// TestPatternTitles_AndAbstractionTitles confirms the title projections used
+// by the rejection-sample callers preserve order and copy all entries — these
+// are the labels operators see in the SQL output.
+func TestPatternTitles_AndAbstractionTitles(t *testing.T) {
+	pats := []store.Pattern{
+		{Title: "first"}, {Title: "second"}, {Title: "third"},
+	}
+	got := patternTitles(pats)
+	if len(got) != 3 || got[0] != "first" || got[2] != "third" {
+		t.Errorf("patternTitles produced %v, want [first second third]", got)
+	}
+
+	abs := []store.Abstraction{
+		{Title: "alpha"}, {Title: "beta"},
+	}
+	gotA := abstractionTitles(abs)
+	if len(gotA) != 2 || gotA[0] != "alpha" || gotA[1] != "beta" {
+		t.Errorf("abstractionTitles produced %v, want [alpha beta]", gotA)
+	}
+}


### PR DESCRIPTION
## Summary

The advisory board (Karpathy, Feynman, Hickey, Hopper) unanimously called for instrumentation before any further action on the persistent `principles_created=0` problem from PR #434's verification. The schema-health telemetry (PR #433) captures the verdict (`has_principle: false`) but not the raw response — and Feynman's framing makes the diagnostic question concrete:

> `has_principle: false` could be three completely different mechanisms wearing the same costume:
> (a) coherent skeptical refusal — substrate genuinely isn't principle-shaped
> (b) garbage JSON parsed-then-coerced to has_principle: false defaults
> (c) OOD prior favoring "false" as the safer token under unfamiliar prompts
>
> Aggregate counts are identical in all three worlds.

This PR captures the raw LLM response on every `soft_rejected` outcome in `synthesizePrinciple` and `synthesizeAxiom`, plus the cluster IDs / titles and the parsed reason, into `meta_observations` as `observation_type=schema_rejection_sample`. Reading 5-10 of these by hand answers (a)/(b)/(c).

## Design

- **Direct capture** (agent → store), not via the in-memory aggregator. Samples need to survive process restarts and be SQL-queryable.
- **Truncation** caps `raw_response` at 1500 chars — sized for the principle/axiom JSON plus short reasoning prose, not pages of LLM rambling.
- **Parsed reason** distinguishes the soft-reject branches: `has_principle_false`, `missing_title`, `missing_principle_text`. Same for axiom.
- **Diagnostic, not control flow.** Failure to write logs and continues; never affects the host call's outcome.

## What gets captured (per row)

| field | source |
|---|---|
| `schema` | `principle_synthesize` or `axiom_synthesize` |
| `agent` | abstraction-agent |
| `source_ids` | the cluster's pattern/principle IDs |
| `source_titles` | the cluster titles (capped at 12) |
| `raw_response` | LLM output (truncated to 1500 chars) |
| `parsed_reason` | which branch tripped: false / missing_title / missing_text |

## Verification flow after deploy

```
SELECT json_extract(details,'$.schema'),
       json_extract(details,'$.parsed_reason'),
       substr(json_extract(details,'$.raw_response'),1,300)
FROM meta_observations
WHERE observation_type='schema_rejection_sample'
ORDER BY created_at DESC LIMIT 10;
```

Read each row by hand. Look for:
- **Mechanism (a)**: coherent prose explaining why the cluster isn't principle-shaped → spoke is correct, accept `principles_created=0`, redefine the schema (Hickey/Hopper path)
- **Mechanism (b)**: malformed/empty fields with garbage in `raw_response` → fix the parser, no training needed
- **Mechanism (c)**: confidently wrong rejections of clusters that ARE principle-shaped → real OOD problem, justifies EXP-32 or cloud-routing

The data picks the path. We don't pick a path before reading the data.

## Test plan

- [ ] `go test ./internal/agent/abstraction/...` clean — 4 new tests
- [ ] After deploy + first abstraction cycle, query `meta_observations WHERE observation_type='schema_rejection_sample'` — expect rows for every soft-rejected cluster
- [ ] Read at least 5 captured `raw_response` values by hand
- [ ] Categorize each into mechanism (a), (b), or (c). Update the `principles_created` decision based on the distribution.

## Caveats / scope

- Narrow: only abstraction's two failing schemas. Consolidation/dreaming/encoding will get the same treatment in a follow-up if their soft_rejected rates rise (currently they don't — encoding is at 100% ok, association_classify at 100% ok).
- This is **diagnostic instrumentation, not a fix**. `principles_created=0` is unchanged after this PR. The follow-up decision (paths 3/4/5 from the advisory-board frame) waits on what the captured data shows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
